### PR TITLE
rhaschke's WIP

### DIFF
--- a/core/demo/plan_pick_pa10.cpp
+++ b/core/demo/plan_pick_pa10.cpp
@@ -141,6 +141,21 @@ int main(int argc, char** argv){
 		t.add(std::move(move));
 	}
 
+	{
+		auto move = std::make_unique<stages::MoveRelative>("shift object", cartesian);
+		move->properties().configureInitFrom(Stage::PARENT, {"group"});
+		move->setMinMaxDistance(0.1, 0.2);
+		move->properties().set("marker_ns", std::string("lift"));
+		move->properties().set("link", std::string("lh_tool_frame"));
+
+		geometry_msgs::TwistStamped twist;
+		twist.header.frame_id = "object";
+		twist.twist.linear.y = 1;
+		twist.twist.angular.y = 2;
+		move->along(twist);
+		t.add(std::move(move));
+	}
+
 	try {
 		auto scene = t.initScene(ros::Duration(0));
 		auto& state = scene->getCurrentStateNonConst();

--- a/core/include/moveit/task_constructor/cost_queue.h
+++ b/core/include/moveit/task_constructor/cost_queue.h
@@ -104,6 +104,9 @@ public:
 		c.splice(at, other, pos);
 		return pos;
 	}
+
+	template<typename Predicate>
+	void remove_if(Predicate p) { c.remove_if(p); }
 };
 
 namespace detail {

--- a/core/include/moveit/task_constructor/marker_tools.h
+++ b/core/include/moveit/task_constructor/marker_tools.h
@@ -10,6 +10,7 @@ MOVEIT_CLASS_FORWARD(PlanningScene)
 }
 namespace moveit { namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
+MOVEIT_CLASS_FORWARD(LinkModel)
 } }
 
 namespace moveit { namespace task_constructor {
@@ -28,12 +29,18 @@ void generateMarkersForObjects(const planning_scene::PlanningSceneConstPtr &scen
 void generateCollisionMarkers(const moveit::core::RobotState &robot_state,
                              const MarkerCallback& callback,
                              const std::vector<std::string> &link_names = {});
+void generateCollisionMarkers(const moveit::core::RobotState &robot_state,
+                             const MarkerCallback& callback,
+                             const std::vector<const moveit::core::LinkModel*> &link_models);
 
 /** generate marker msgs to visualize robot's visual geometry, calling the given callback for each of them
  *  link_names: set of links to include (or all if empty) */
 void generateVisualMarkers(const moveit::core::RobotState &robot_state,
                            const MarkerCallback& callback,
                            const std::vector<std::string> &link_names = {});
+void generateVisualMarkers(const moveit::core::RobotState &robot_state,
+                           const MarkerCallback& callback,
+                           const std::vector<const moveit::core::LinkModel*> &link_models);
 
 /** generate marker msgs to visualize the planning scene, calling the given callback for each of them
  *  calls generateMarkersForRobot() and generateMarkersForObjects() */

--- a/core/include/moveit/task_constructor/solvers/cartesian_path.h
+++ b/core/include/moveit/task_constructor/solvers/cartesian_path.h
@@ -32,66 +32,38 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    generate and validate a straight-line Cartesian path
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/solvers/planner_interface.h>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor { namespace solvers {
 
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+/** Use RobotState's computeCartesianPath() to generate a straigh-line path between to scenes */
+class CartesianPath : public PlannerInterface {
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	CartesianPath();
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	void setGroup(const std::string &group) { setProperty("group", group); }
+	void setTimeout(double timeout) { setProperty("timeout", timeout); }
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
+
+	bool plan(const planning_scene::PlanningSceneConstPtr from,
+	          const planning_scene::PlanningSceneConstPtr to,
+	          const moveit::core::JointModelGroup *jmg,
+             double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result) override;
+
+	bool plan(const planning_scene::PlanningSceneConstPtr from,
+	          const moveit::core::LinkModel &link,
+	          const Eigen::Affine3d& target,
+	          const moveit::core::JointModelGroup *jmg,
+             double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result) override;
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} } }

--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -32,66 +32,47 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Robert Haschke
+   Desc:    plan using MoveIt's PlanningPipeline
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/solvers/planner_interface.h>
+#include <moveit/macros/class_forward.h>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
-
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
-public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
-
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
-
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
-};
-
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
+namespace planning_pipeline {
+MOVEIT_CLASS_FORWARD(PlanningPipeline)
 }
+
+namespace moveit { namespace task_constructor { namespace solvers {
+
+/** Use MoveIt's PlanningPipeline to plan a trajectory between to scenes */
+class PipelinePlanner : public PlannerInterface {
+public:
+	PipelinePlanner();
+
+	void setGroup(const std::string &group) { setProperty("group", group); }
+	void setPlannerId(const std::string &planner) { setProperty("planner", planner); }
+	void setTimeout(double timeout) { setProperty("timeout", timeout); }
+
+	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
+
+	bool plan(const planning_scene::PlanningSceneConstPtr from,
+	          const planning_scene::PlanningSceneConstPtr to,
+	          const core::JointModelGroup *jmg,
+	          double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result) override;
+
+	bool plan(const planning_scene::PlanningSceneConstPtr from,
+	          const moveit::core::LinkModel &link,
+	          const Eigen::Affine3d& target,
+	          const core::JointModelGroup *jmg,
+	          double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result) override;
+
+protected:
+	planning_pipeline::PlanningPipelinePtr planner_;
+};
+
+} } }

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -80,6 +80,12 @@ public:
 	inline InterfaceConstPtr prevEnds() const { return prev_ends_.lock(); }
 	inline InterfaceConstPtr nextStarts() const { return next_starts_.lock(); }
 
+	/// templated access to pull/push interfaces
+	inline InterfacePtr& pullInterface(Interface::Direction dir) { return dir == Interface::FORWARD ? starts_ : ends_; }
+	inline InterfacePtr  pushInterface(Interface::Direction dir) { return dir == Interface::FORWARD ? next_starts_.lock() : prev_ends_.lock(); }
+	inline InterfaceConstPtr pullInterface(Interface::Direction dir) const { return dir == Interface::FORWARD ? starts_ : ends_; }
+	inline InterfaceConstPtr pushInterface(Interface::Direction dir) const { return dir == Interface::FORWARD ? next_starts_.lock() : prev_ends_.lock(); }
+
 	/// the following methods should be called only by a container
 	/// to setup the connection structure of their children
 	inline void setHierarchy(ContainerBase* parent, container_type::iterator it) {

--- a/core/include/moveit/task_constructor/stages/compute_ik.h
+++ b/core/include/moveit/task_constructor/stages/compute_ik.h
@@ -15,7 +15,7 @@ namespace core { MOVEIT_CLASS_FORWARD(RobotState) }
 
 namespace moveit { namespace task_constructor { namespace stages {
 
-class ComputeIK : public Wrapper {
+class ComputeIK : public WrapperBase {
 public:
 	ComputeIK(const std::string &name, pointer &&child = Stage::pointer());
 

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -32,66 +32,26 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    Connect arbitrary states by motion planning
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/solvers/planner_interface.h>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor { namespace stages {
 
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+class Connect : public Connecting {
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	Connect(std::string name, const solvers::PlannerInterfacePtr &planner);
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	void init(const planning_scene::PlanningSceneConstPtr &scene);
+	bool compute(const InterfaceState &from, const InterfaceState &to);
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+protected:
+	solvers::PlannerInterfacePtr planner_;
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} } }

--- a/core/include/moveit/task_constructor/stages/current_state.h
+++ b/core/include/moveit/task_constructor/stages/current_state.h
@@ -44,7 +44,7 @@ namespace moveit { namespace task_constructor { namespace stages {
 
 class CurrentState : public Generator {
 public:
-	CurrentState(std::string name);
+	CurrentState(const std::string& name = "current state");
 
 	void init(const planning_scene::PlanningSceneConstPtr& scene) override;
 	bool canCompute() const override;

--- a/core/include/moveit/task_constructor/stages/fix_collision_objects.h
+++ b/core/include/moveit/task_constructor/stages/fix_collision_objects.h
@@ -32,66 +32,31 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Elham Iravani, Robert Haschke
+   Desc:    Fix collisions in input scene
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/stage.h>
+#include <visualization_msgs/Marker.h>
+#include <geometry_msgs/Pose.h>
+#include <deque>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor { namespace stages {
 
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+class FixCollisionObjects : public PropagatingEitherWay {
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	FixCollisionObjects(const std::string& name = "fix collisions of objects");
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	bool computeForward(const InterfaceState& from) override;
+	bool computeBackward(const InterfaceState& to) override;
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+	void setMaxPenetration(double penetration);
+
+private:
+	bool fixCollisions(planning_scene::PlanningScene &scene, std::deque<visualization_msgs::Marker>& markers) const;
+	void fixCollision(planning_scene::PlanningScene &scene, geometry_msgs::Pose pose, const std::string& object) const;
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} } }

--- a/core/include/moveit/task_constructor/stages/modify_planning_scene.h
+++ b/core/include/moveit/task_constructor/stages/modify_planning_scene.h
@@ -1,0 +1,140 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke
+   Desc:    Modify planning scene
+*/
+
+#pragma once
+
+#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/properties.h>
+#include <moveit/task_constructor/type_traits.h>
+#include <map>
+
+namespace moveit { namespace core {
+MOVEIT_CLASS_FORWARD(JointModelGroup)
+} }
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+/** Allow modification of planning scene
+ *
+ * This stage takes the incoming planning scene and applies previously scheduled
+ * changes to it, for example:
+ * - Modify allowed collision matrix, enabling or disabling collision pairs.
+ * - Attach or detach objects to robot links.
+ * - Spawn or remove objects.
+ */
+class ModifyPlanningScene : public PropagatingEitherWay {
+public:
+	typedef std::vector<std::string> Names;
+	typedef std::function<void(planning_scene::PlanningScenePtr scene, PropertyMap& properties)> ApplyCallback;
+	ModifyPlanningScene(const std::string& name = "modify planning scene");
+
+	bool computeForward(const InterfaceState& from) override;
+	bool computeBackward(const InterfaceState& to) override;
+
+	/// call an arbitrary function
+	void setCallback(const ApplyCallback& cb) { callback_ = cb; }
+
+	/// attach or detach a list of objects to the given link
+	void attachObjects(const Names& objects, const std::string& attach_link, bool attach);
+
+	/// conviency methods accepting a single object name
+	inline void attachObject(const std::string& object, const std::string& link);
+	inline void detachObject(const std::string& object, const std::string& link);
+
+	/// conviency methods accepting any container of object names
+	template <typename T, typename E = typename std::enable_if_t<is_container<T>::value && std::is_base_of<std::string, typename T::value_type>::value>>
+	inline void attachObjects(const T& objects, const std::string& link) {
+		attachObjects(Names(objects.cbegin(), objects.cend()), link, true);
+	}
+	template <typename T, typename E = typename std::enable_if_t<is_container<T>::value && std::is_base_of<std::string, typename T::value_type>::value>>
+	inline void detachObjects(const T& objects, const std::string& link) {
+		attachObjects(Names(objects.cbegin(), objects.cend()), link, false);
+	}
+
+	/// enable / disable collisions for each combination of pairs in first and second lists
+	void enableCollisions(const Names& first, const Names& second, bool enable_collision);
+	/// enable / disable all collisions for given object
+	void enableCollisions(const std::string& object, bool enable_collision) {
+		enableCollisions(Names({object}), Names(), enable_collision);
+	}
+
+	/// conveniency method accepting arbitrary container types
+	template <typename T1, typename T2,
+	          typename E1 = typename std::enable_if_t<is_container<T1>::value && std::is_base_of<std::string, typename T1::value_type>::value>,
+	          typename E2 = typename std::enable_if_t<is_container<T2>::value && std::is_base_of<std::string, typename T2::value_type>::value>>
+	inline void enableCollisions(const T1& first, const T2& second, bool enable_collision) {
+		enableCollisions(Names(first.cbegin(), first.cend()), Names(second.cbegin(), second.cend()), enable_collision);
+	}
+	/// conveniency method accepting std::string and an arbitrary container of names
+	template <typename T, typename E = typename std::enable_if_t<is_container<T>::value && std::is_base_of<std::string, typename T::value_type>::value>>
+	inline void enableCollisions(const std::string& first, const T& second, bool enable_collision) {
+		enableCollisions(Names({first}), Names(second.cbegin(), second.cend()), enable_collision);
+	}
+	/// conveniency method accepting std::string and JointModelGroup
+	void enableCollisions(const std::string& first, const moveit::core::JointModelGroup& jmg, bool enable_collision);
+
+protected:
+	// list of objects to attach (true) / detach (false) to a given link
+	std::map<std::string, std::pair<Names, bool> > attach_objects_;
+
+	// list of objects to mutually
+	struct CollisionMatrixPairs {
+		Names first;
+		Names second;
+		bool enable;
+	};
+	std::list<CollisionMatrixPairs> collision_matrix_edits_;
+	ApplyCallback callback_;
+
+protected:
+	// apply stored modifications to scene
+	InterfaceState apply(const InterfaceState &from, bool invert);
+	void attachObjects(planning_scene::PlanningScene &scene, const std::pair<std::string, std::pair<Names, bool> >& pair, bool invert);
+	void enableCollisions(planning_scene::PlanningScene &scene, const CollisionMatrixPairs& pairs, bool invert);
+};
+
+
+inline void ModifyPlanningScene::attachObject(const std::string &object, const std::string &link) {
+	attachObjects(Names({object}), link, true);
+}
+
+inline void ModifyPlanningScene::detachObject(const std::string &object, const std::string &link) {
+	attachObjects(Names({object}), link, false);
+}
+
+} } }

--- a/core/include/moveit/task_constructor/stages/move_relative.h
+++ b/core/include/moveit/task_constructor/stages/move_relative.h
@@ -32,66 +32,47 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    Move to joint-state or Cartesian goal pose
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/solvers/planner_interface.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/Vector3Stamped.h>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor { namespace stages {
 
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+/** Perform a Cartesian motion relative to some link */
+class MoveRelative : public PropagatingEitherWay {
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	MoveRelative(std::string name, const solvers::PlannerInterfacePtr& planner);
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	void init(const planning_scene::PlanningSceneConstPtr &scene) override;
+	bool computeForward(const InterfaceState& from) override;
+	bool computeBackward(const InterfaceState& to) override;
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+	void setGroup(const std::string& group);
+	void setLink(const std::string& link);
+
+	/// set minimum / maximum distance to move
+	void setMinDistance(double distance);
+	void setMaxDistance(double distance);
+	void setMinMaxDistance(double min_distance, double max_distance);
+
+	/// perform twist motion on specified link
+	void along(const geometry_msgs::TwistStamped& twist);
+	/// translate link along given direction
+	void along(const geometry_msgs::Vector3Stamped& direction);
+
+protected:
+	bool compute(const InterfaceState& state, planning_scene::PlanningScenePtr &scene,
+	             SubTrajectory &trajectory, Direction dir);
+
+protected:
+	solvers::PlannerInterfacePtr planner_;
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} } }

--- a/core/include/moveit/task_constructor/stages/move_to.h
+++ b/core/include/moveit/task_constructor/stages/move_to.h
@@ -32,66 +32,43 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    Move to joint-state or Cartesian goal pose
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/solvers/planner_interface.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/PointStamped.h>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor { namespace stages {
 
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+class MoveTo : public PropagatingEitherWay {
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	MoveTo(std::string name, const solvers::PlannerInterfacePtr& planner);
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	void init(const planning_scene::PlanningSceneConstPtr &scene) override;
+	bool computeForward(const InterfaceState& from) override;
+	bool computeBackward(const InterfaceState& to) override;
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+	void setGroup(const std::string& group);
+	void setLink(const std::string& link);
+
+	/// move link to given pose
+	void setGoal(const geometry_msgs::PoseStamped& pose);
+	/// move link to given point, keeping current orientation
+	void setGoal(const geometry_msgs::PointStamped& point);
+	/// move joint model group to given named pose
+	void setGoal(const std::string& joint_pose);
+
+protected:
+	bool compute(const InterfaceState& state, planning_scene::PlanningScenePtr &scene,
+	             SubTrajectory &trajectory, Direction dir);
+
+protected:
+	solvers::PlannerInterfacePtr planner_;
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} } }

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -142,6 +142,7 @@ private:
 /** Interface provides a cost-sorted list of InterfaceStates available as input for a stage. */
 class Interface : public ordered<InterfaceState> {
 public:
+	enum Direction { FORWARD, BACKWARD, START=FORWARD, END=BACKWARD };
 	typedef std::function<void(iterator it, bool updated)> NotifyFunction;
 	Interface(const NotifyFunction &notify = NotifyFunction());
 
@@ -169,6 +170,9 @@ class SolutionBase {
 public:
 	inline const InterfaceState* start() const { return start_; }
 	inline const InterfaceState* end() const { return end_; }
+
+	template <Interface::Direction dir>
+	inline const InterfaceState::Solutions& trajectories() const;
 
 	inline void setStartState(const InterfaceState& state){
 		assert(start_ == NULL);  // only allow setting once (by Stage)
@@ -234,27 +238,34 @@ public:
 	{}
 
 	robot_trajectory::RobotTrajectoryConstPtr trajectory() const { return trajectory_; }
+	void setTrajectory(const robot_trajectory::RobotTrajectoryPtr& t) { trajectory_ = t; }
 
 	void fillMessage(moveit_task_constructor_msgs::Solution &msg,
 	                 Introspection* introspection = nullptr) const override;
 
 private:
 	// actual trajectory, might be empty
-	const robot_trajectory::RobotTrajectoryPtr trajectory_;
+	robot_trajectory::RobotTrajectoryPtr trajectory_;
 };
 
 
-enum TraverseDirection { FORWARD, BACKWARD };
-template <TraverseDirection dir>
-const InterfaceState::Solutions& trajectories(const SolutionBase &start);
-
 template <> inline
-const InterfaceState::Solutions& trajectories<FORWARD>(const SolutionBase &solution) {
-	return solution.end()->outgoingTrajectories();
+const InterfaceState::Solutions& SolutionBase::trajectories<Interface::FORWARD>() const {
+	return end_->outgoingTrajectories();
 }
 template <> inline
-const InterfaceState::Solutions& trajectories<BACKWARD>(const SolutionBase &solution) {
-	return solution.start()->incomingTrajectories();
+const InterfaceState::Solutions& SolutionBase::trajectories<Interface::BACKWARD>() const {
+	return start_->incomingTrajectories();
 }
 
 } }
+
+namespace std {
+// comparison for pointers to SolutionBase: compare based on value
+template<> struct less<moveit::task_constructor::SolutionBase*> {
+	bool operator()(const moveit::task_constructor::SolutionBase* x,
+	                const moveit::task_constructor::SolutionBase* y) {
+		return *x < *y;
+	}
+};
+}

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -91,11 +91,18 @@ public:
 	/// remove function callback
 	void erase(TaskCallbackList::const_iterator which);
 
+	/// initialize planning scene from get_planning_scene service (waiting given timeout for it)
+	/// if service is not available or timeout is zero, use an empty planning scene
+	planning_scene::PlanningScenePtr initScene(ros::Duration timeout = ros::Duration(-1));
+
+	/// reset all stages
 	void reset() override;
+	/// initialize all stages with given scene
 	void init(const planning_scene::PlanningSceneConstPtr &scene) override;
 
+	/// reset, init scene (if not yet done), and init all stages, then start planning
 	bool plan();
-	/// print current state std::cout
+	/// print current task state (number of found solutions and propagated states) to std::cout
 	static void printState(const Task &t);
 
 	size_t numSolutions() const override;
@@ -117,7 +124,6 @@ public:
 
 protected:
 	void initModel();
-	void initScene();
 	bool canCompute() const override;
 	bool compute() override;
 	void onNewSolution(const SolutionBase &s) override;
@@ -125,7 +131,7 @@ protected:
 private:
 	std::string id_;
 	robot_model_loader::RobotModelLoaderPtr rml_;
-	planning_scene::PlanningSceneConstPtr scene_; // initial scene
+	planning_scene::PlanningScenePtr scene_; // initial scene
 
 	// introspection and monitoring
 	std::unique_ptr<Introspection> introspection_;

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -104,7 +104,7 @@ public:
 	/// reset, init scene (if not yet done), and init all stages, then start planning
 	bool plan();
 	/// print current task state (number of found solutions and propagated states) to std::cout
-	static void printState(const Task &t);
+	void printState(std::ostream &os = std::cout) const;
 
 	size_t numSolutions() const override;
 	void processSolutions(const ContainerBase::SolutionProcessor &processor) const override;

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -62,9 +62,9 @@ MOVEIT_CLASS_FORWARD(Task)
 
 /** A Task is the root of a tree of stages.
  *
- * Actually a tasks wraps a single container, which serves as the root of all stages.
- * The wrapped container spawns its solutions into the prevEnds(), nextStarts() interfaces,
- * which are provided by the wrappers end_ and start_ and interfaces respectively. */
+ * Actually a tasks wraps a single container (by default a SerialContainer),
+ * which serves as the root of all stages.
+ */
 class Task : protected WrapperBase {
 public:
 	Task(const std::string& id = "",
@@ -76,6 +76,7 @@ public:
 	~Task();
 
 	std::string id() const;
+	const moveit::core::RobotModelPtr getRobotModel() const;
 
 	void add(Stage::pointer &&stage);
 	void clear() override;

--- a/core/include/moveit/task_constructor/type_traits.h
+++ b/core/include/moveit/task_constructor/type_traits.h
@@ -32,66 +32,35 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Robert Haschke
+   Desc:    type traits for SFINAE-based templating
 */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <type_traits>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace moveit { namespace task_constructor {
 
-namespace moveit_rviz_plugin {
+// detect STL-like containers by presence of cbegin(), cend() methods
+template<typename T, typename _ = void>
+struct is_container : std::false_type {};
 
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
+template<typename... Ts>
+struct is_container_helper {};
 
-class TaskPanelPrivate : public Ui_TaskPanel {
-public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+template<typename T>
+struct is_container<
+        T,
+        std::conditional_t<
+            false,
+            is_container_helper<
+                typename T::const_iterator,
+                decltype(std::declval<T>().cbegin()),
+                decltype(std::declval<T>().cend())
+                >,
+            void
+            >
+        > : public std::true_type {};
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
-
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
-};
-
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
-}
+} }

--- a/core/include/moveit/task_constructor/utils.h
+++ b/core/include/moveit/task_constructor/utils.h
@@ -94,12 +94,3 @@ private:
 };
 
 #define DECLARE_FLAGS(Flags, Enum) typedef QFlags<Enum> Flags;
-
-
-// compare two pointers by comparing their referenced values
-template <typename T>
-struct pointerLessThan : std::enable_if<std::is_pointer<T>::value> {
-	inline bool operator()(const T& x, const T& y) const {
-		return *x < *y;
-	}
-};

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -11,6 +11,10 @@ add_library(${PROJECT_NAME}
 	${PROJECT_INCLUDE}/task.h
 	${PROJECT_INCLUDE}/utils.h
 
+	${PROJECT_INCLUDE}/solvers/planner_interface.h
+	${PROJECT_INCLUDE}/solvers/cartesian_path.h
+	${PROJECT_INCLUDE}/solvers/pipeline_planner.h
+
 	container.cpp
 	introspection.cpp
 	marker_tools.cpp
@@ -18,6 +22,10 @@ add_library(${PROJECT_NAME}
 	stage.cpp
 	storage.cpp
 	task.cpp
+
+	solvers/planner_interface.cpp
+	solvers/cartesian_path.cpp
+	solvers/pipeline_planner.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 target_include_directories(${PROJECT_NAME}

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -393,10 +393,10 @@ bool SerialContainer::compute()
 	for(const auto& stage : pimpl()->children()) {
 		if(!stage->pimpl()->canCompute())
 			continue;
-		std::cout << "Computing stage '" << stage->name() << "':" << std::endl;
+		ROS_INFO("Computing stage '%s'", stage->name().c_str());
 		bool success = stage->pimpl()->compute();
 		computed = true;
-		std::cout << (success ? "succeeded" : "failed") << std::endl;
+		ROS_INFO("Stage '%s': %s", stage->name().c_str(), success ? "succeeded" : "failed");
 	}
 	return computed;
 }

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -155,7 +155,6 @@ void Introspection::publishAllSolutions(bool wait)
 	moveit_task_constructor_msgs::Solution msg;
 
 	Stage::SolutionProcessor processor = [this, &msg, wait](const SolutionBase& s) {
-		std::cout << "publishing solution with cost: " << s.cost() << std::endl;
 		msg.sub_solution.clear();
 		msg.sub_trajectory.clear();
 		fillSolution(msg, s);

--- a/core/src/solvers/cartesian_path.cpp
+++ b/core/src/solvers/cartesian_path.cpp
@@ -1,0 +1,114 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    generate and validate a straight-line Cartesian path
+*/
+
+#include <moveit/task_constructor/solvers/cartesian_path.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+
+namespace moveit { namespace task_constructor { namespace solvers {
+
+CartesianPath::CartesianPath()
+{
+	auto& p = properties();
+	p.declare<double>("step_size", 0.01, "step size between consecutive waypoints");
+	p.declare<double>("jump_threshold", 1.5, "acceptable fraction of mean joint motion per step");
+	p.declare<double>("min_fraction", 1.0, "fraction of motion required for success");
+	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
+	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
+}
+
+void CartesianPath::init(const core::RobotModelConstPtr &robot_model)
+{
+}
+
+bool CartesianPath::plan(const planning_scene::PlanningSceneConstPtr from,
+                         const planning_scene::PlanningSceneConstPtr to,
+                         const moveit::core::JointModelGroup *jmg,
+	                      double timeout,
+                         robot_trajectory::RobotTrajectoryPtr& result)
+{
+	const moveit::core::LinkModel* link;
+	const std::string& link_name = solvers::getEndEffectorLink(jmg);
+	if (!(link = from->getRobotModel()->getLinkModel(link_name))) {
+		ROS_WARN_STREAM("no unique tip for joint model group: " << jmg->getName());
+		return false;
+	}
+
+	// reach pose of forward kinematics
+	return plan(from, *link, to->getCurrentState().getGlobalLinkTransform(link), jmg, timeout, result);
+}
+
+bool CartesianPath::plan(const planning_scene::PlanningSceneConstPtr from,
+                         const moveit::core::LinkModel &link,
+                         const Eigen::Affine3d &target,
+                         const moveit::core::JointModelGroup *jmg,
+	                      double timeout,
+                         robot_trajectory::RobotTrajectoryPtr &result)
+{
+	const auto& props = properties();
+	planning_scene::PlanningScenePtr sandbox_scene = from->diff();
+
+	auto isValid = [&sandbox_scene](moveit::core::RobotState* state,
+	      const moveit::core::JointModelGroup* jmg,
+	      const double* joint_positions) {
+		state->setJointGroupPositions(jmg, joint_positions);
+		state->update();
+		return !sandbox_scene->isStateColliding(const_cast<const robot_state::RobotState&>(*state), jmg->getName());
+	};
+
+	std::vector<moveit::core::RobotStatePtr> trajectory;
+	double achieved_fraction = sandbox_scene->getCurrentStateNonConst().computeCartesianPath(
+	                              jmg, trajectory, &link, target, true,
+	                              props.get<double>("step_size"),
+	                              props.get<double>("jump_threshold"),
+	                              isValid);
+	if (achieved_fraction >= props.get<double>("min_fraction")) {
+		result.reset(new robot_trajectory::RobotTrajectory(sandbox_scene->getRobotModel(), jmg));
+		for (const auto& waypoint : trajectory)
+			result->addSuffixWayPoint(waypoint, 0.0);
+
+		trajectory_processing::IterativeParabolicTimeParameterization timing;
+		timing.computeTimeStamps(*result,
+		                         props.get<double>("max_velocity_scaling_factor"),
+		                         props.get<double>("max_acceleration_scaling_factor"));
+		return true;
+	}
+	return false;
+}
+
+} } }

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -1,0 +1,137 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke
+   Desc:    plan using MoveIt's PlanningPipeline
+*/
+
+#include <moveit/task_constructor/solvers/pipeline_planner.h>
+#include <moveit/task_constructor/task.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/planning_pipeline/planning_pipeline.h>
+#include <moveit_msgs/MotionPlanRequest.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace moveit { namespace task_constructor { namespace solvers {
+
+PipelinePlanner::PipelinePlanner()
+{
+	auto& p = properties();
+	p.declare<std::string>("planner", "", "planner id");
+
+	p.declare<uint>("num_planning_attempts", 1u, "number of planning attempts");
+	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
+	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
+	p.declare<moveit_msgs::WorkspaceParameters>("workspace_parameters", moveit_msgs::WorkspaceParameters(), "allowed workspace of mobile base?");
+
+	p.declare<double>("goal_joint_tolerance", 1e-4, "tolerance for reaching joint goals");
+	p.declare<double>("goal_position_tolerance", 1e-4, "tolerance for reaching position goals");
+	p.declare<double>("goal_orientation_tolerance", 1e-4, "tolerance for reaching orientation goals");
+}
+
+void PipelinePlanner::init(const core::RobotModelConstPtr &robot_model)
+{
+	planner_ = Task::createPlanner(robot_model);
+}
+
+void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req,
+                           const PropertyMap& p,
+                           const moveit::core::JointModelGroup *jmg,
+                           double timeout)
+{
+	req.group_name = jmg->getName();
+	req.planner_id = p.get<std::string>("planner");
+	req.allowed_planning_time = timeout;
+
+	req.num_planning_attempts = p.get<uint>("num_planning_attempts");
+	req.max_velocity_scaling_factor = p.get<double>("max_velocity_scaling_factor");
+	req.max_acceleration_scaling_factor = p.get<double>("max_acceleration_scaling_factor");
+	req.workspace_parameters = p.get<moveit_msgs::WorkspaceParameters>("workspace_parameters");
+}
+
+bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr from,
+                           const planning_scene::PlanningSceneConstPtr to,
+                           const moveit::core::JointModelGroup *jmg,
+                           double timeout,
+                           robot_trajectory::RobotTrajectoryPtr& result)
+{
+	const auto& props = properties();
+	moveit_msgs::MotionPlanRequest req;
+	initMotionPlanRequest(req, props, jmg, timeout);
+
+	req.goal_constraints.resize(1);
+	req.goal_constraints[0] = kinematic_constraints::constructGoalConstraints(
+	                             to->getCurrentState(), jmg,
+	                             props.get<double>("goal_joint_tolerance"));
+
+	::planning_interface::MotionPlanResponse res;
+	if(!planner_->generatePlan(from, req, res))
+		return false;
+
+	result = res.trajectory_;
+	return true;
+}
+
+bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr from,
+                           const moveit::core::LinkModel &link,
+                           const Eigen::Affine3d& target_eigen,
+                           const moveit::core::JointModelGroup *jmg,
+                           double timeout,
+                           robot_trajectory::RobotTrajectoryPtr& result)
+
+{
+	const auto& props = properties();
+	moveit_msgs::MotionPlanRequest req;
+	initMotionPlanRequest(req, props, jmg, timeout);
+
+	geometry_msgs::PoseStamped target;
+	target.header.frame_id = from->getPlanningFrame();
+	tf::poseEigenToMsg(target_eigen, target.pose);
+
+	req.goal_constraints.resize(1);
+	req.goal_constraints[0] = kinematic_constraints::constructGoalConstraints(
+	                             link.getName(), target,
+	                             props.get<double>("goal_position_tolerance"),
+	                             props.get<double>("goal_orientation_tolerance"));
+
+	::planning_interface::MotionPlanResponse res;
+	if(!planner_->generatePlan(from, req, res))
+		return false;
+
+	result = res.trajectory_;
+	return true;
+}
+
+} } }

--- a/core/src/solvers/planner_interface.cpp
+++ b/core/src/solvers/planner_interface.cpp
@@ -32,66 +32,20 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
+/* Authors: Robert Haschke
+   Desc:    planner interface
 */
 
-#pragma once
+#include <moveit/task_constructor/solvers/planner_interface.h>
+#include <moveit/robot_model/joint_model_group.h>
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+namespace moveit { namespace task_constructor { namespace solvers {
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
-
-namespace moveit_rviz_plugin {
-
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
-public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
-
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
-
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
-};
-
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
-
+std::string getEndEffectorLink(const moveit::core::JointModelGroup *jmg)
+{
+	// TODO: directly return LinkModel*
+	const moveit::core::LinkModel* link = jmg->getOnlyOneEndEffectorTip();
+	return link ? link->getName() : std::string();
 }
+
+} } }

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -386,7 +386,6 @@ void PropagatingEitherWay::sendForward(const InterfaceState& from,
                                        InterfaceState&& to,
                                        SubTrajectory&& t) {
 	auto impl = pimpl();
-	std::cout << "sending state forward" << std::endl;
 	SubTrajectory &trajectory = impl->addTrajectory(std::move(t));
 	trajectory.setStartState(from);
 	impl->nextStarts()->add(std::move(to), &trajectory, NULL);
@@ -397,7 +396,6 @@ void PropagatingEitherWay::sendBackward(InterfaceState&& from,
                                         const InterfaceState& to,
                                         SubTrajectory&& t) {
 	auto impl = pimpl();
-	std::cout << "sending state backward" << std::endl;
 	SubTrajectory& trajectory = impl->addTrajectory(std::move(t));
 	trajectory.setEndState(to);
 	impl->prevEnds()->add(std::move(from), NULL, &trajectory);
@@ -460,7 +458,6 @@ Generator::Generator(const std::string &name)
 
 void Generator::spawn(InterfaceState&& state, SubTrajectory&& t)
 {
-	std::cout << "spawning state forwards and backwards" << std::endl;
 	assert(state.incomingTrajectories().empty() &&
 	       state.outgoingTrajectories().empty());
 	assert(!t.trajectory());

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -216,8 +216,8 @@ SubTrajectory& ComputeBasePrivate::addTrajectory(SubTrajectory&& trajectory) {
 		return *solutions_.insert(std::move(trajectory));
 	} else if (me()->storeFailures()) {
 		// only store failures when introspection is enabled
-		failures_.emplace_back(std::move(trajectory));
-		return failures_.back();
+		auto it = failures_.insert(failures_.end(), std::move(trajectory));
+		return *it;
 	} else
 		return trajectory;
 }

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -308,17 +308,17 @@ bool PropagatingEitherWayPrivate::compute()
 		const InterfaceState& state = fetchStartState();
 		// enforce property initialization from INTERFACE
 		properties_.performInitFrom(Stage::INTERFACE, state.properties(), true);
-		if (me->computeForward(state))
+		if (countFailures(me->computeForward(state)))
 			result |= true;
 	}
 	if ((dir & PropagatingEitherWay::BACKWARD) && hasEndState()) {
 		const InterfaceState& state = fetchEndState();
 		// enforce property initialization from INTERFACE
 		properties_.performInitFrom(Stage::INTERFACE, state.properties(), true);
-		if (me->computeBackward(state))
+		if (countFailures(me->computeBackward(state)))
 			result |= true;
 	}
-	return countFailures(result);
+	return result;
 }
 
 

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -1,28 +1,32 @@
 add_library(${PROJECT_NAME}_stages
-	${PROJECT_INCLUDE}/stages/compute_ik.h
+	${PROJECT_INCLUDE}/stages/modify_planning_scene.h
+	${PROJECT_INCLUDE}/stages/fix_collision_objects.h
+
 	${PROJECT_INCLUDE}/stages/current_state.h
 	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
+	${PROJECT_INCLUDE}/stages/compute_ik.h
+
 	${PROJECT_INCLUDE}/stages/connect.h
 	${PROJECT_INCLUDE}/stages/move_to.h
 	${PROJECT_INCLUDE}/stages/move_relative.h
 
 	${PROJECT_INCLUDE}/stages/cartesian_position_motion.h
 	${PROJECT_INCLUDE}/stages/gripper.h
-	${PROJECT_INCLUDE}/stages/modify_planning_scene.h
-	${PROJECT_INCLUDE}/stages/fix_collision_objects.h
 	${PROJECT_INCLUDE}/stages/move.h
 
+	modify_planning_scene.cpp
+	fix_collision_objects.cpp
+
 	current_state.cpp
-	compute_ik.cpp
 	generate_grasp_pose.cpp
+	compute_ik.cpp
+
 	connect.cpp
 	move_to.cpp
 	move_relative.cpp
 
 	cartesian_position_motion.cpp
 	gripper.cpp
-	modify_planning_scene.cpp
-	fix_collision_objects.cpp
 	move.cpp
 )
 target_link_libraries(${PROJECT_NAME}_stages ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -1,16 +1,28 @@
 add_library(${PROJECT_NAME}_stages
-	${PROJECT_INCLUDE}/stages/cartesian_position_motion.h
 	${PROJECT_INCLUDE}/stages/compute_ik.h
 	${PROJECT_INCLUDE}/stages/current_state.h
 	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
+	${PROJECT_INCLUDE}/stages/connect.h
+	${PROJECT_INCLUDE}/stages/move_to.h
+	${PROJECT_INCLUDE}/stages/move_relative.h
+
+	${PROJECT_INCLUDE}/stages/cartesian_position_motion.h
 	${PROJECT_INCLUDE}/stages/gripper.h
+	${PROJECT_INCLUDE}/stages/modify_planning_scene.h
+	${PROJECT_INCLUDE}/stages/fix_collision_objects.h
 	${PROJECT_INCLUDE}/stages/move.h
 
-	cartesian_position_motion.cpp
 	current_state.cpp
 	compute_ik.cpp
 	generate_grasp_pose.cpp
+	connect.cpp
+	move_to.cpp
+	move_relative.cpp
+
+	cartesian_position_motion.cpp
 	gripper.cpp
+	modify_planning_scene.cpp
+	fix_collision_objects.cpp
 	move.cpp
 )
 target_link_libraries(${PROJECT_NAME}_stages ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/core/src/stages/cartesian_position_motion.cpp
+++ b/core/src/stages/cartesian_position_motion.cpp
@@ -154,7 +154,7 @@ bool CartesianPositionMotion::computeForward(const InterfaceState &from){
 
 		const double achieved_distance= achieved_fraction*(link_pose.translation()-target_point).norm();
 
-		std::cout << "achieved " << achieved_distance << " of cartesian motion" << std::endl;
+		ROS_INFO_NAMED(this->name().c_str(), "achieved %f of cartesian motion", achieved_distance);
 
 		succeeded= achieved_distance >= props.get<double>("min_distance");
 	}
@@ -176,7 +176,7 @@ bool CartesianPositionMotion::computeForward(const InterfaceState &from){
 			1.5, /* jump threshold */
 			is_valid);
 
-		std::cout << "achieved " << achieved_distance << " of cartesian motion" << std::endl;
+		ROS_INFO_NAMED(this->name().c_str(), "achieved %f of cartesian motion", achieved_distance);
 
 		succeeded= achieved_distance >= props.get<double>("min_distance");
 	}
@@ -248,7 +248,7 @@ bool CartesianPositionMotion::computeBackward(const InterfaceState &to){
 		1.5, /* jump threshold */
 		is_valid);
 
-	std::cout << "achieved " << achieved_distance << " of cartesian motion" << std::endl;
+	ROS_INFO_NAMED(this->name().c_str(), "achieved %f of cartesian motion", achieved_distance);
 
 	bool succeeded= achieved_distance >= props.get<double>("min_distance");
 

--- a/core/src/stages/current_state.cpp
+++ b/core/src/stages/current_state.cpp
@@ -39,7 +39,7 @@
 
 namespace moveit { namespace task_constructor { namespace stages {
 
-CurrentState::CurrentState(std::string name = "current state")
+CurrentState::CurrentState(const std::string &name)
    : Generator(name)
 {
 	ran_= false;

--- a/core/src/stages/fix_collision_objects.cpp
+++ b/core/src/stages/fix_collision_objects.cpp
@@ -1,0 +1,140 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Elham Iravani, Robert Haschke
+   Desc:    Fix collisions in input scene
+*/
+
+#include <moveit/task_constructor/stages/fix_collision_objects.h>
+
+#include <moveit/task_constructor/storage.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <rviz_marker_tools/marker_creation.h>
+#include <Eigen/Geometry>
+#include <eigen_conversions/eigen_msg.h>
+#include <ros/console.h>
+
+namespace vm = visualization_msgs;
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+FixCollisionObjects::FixCollisionObjects(const std::string &name)
+  : PropagatingEitherWay(name)
+{
+	auto& p = properties();
+	p.declare<double>("max_penetration", "maximally corrected penetration depth");
+}
+
+void FixCollisionObjects::setMaxPenetration(double penetration)
+{
+	setProperty("max_penetration", penetration);
+}
+
+bool FixCollisionObjects::computeForward(const InterfaceState &from)
+{
+	planning_scene::PlanningScenePtr to = from.scene()->diff();
+	SubTrajectory solution;
+	bool success = fixCollisions(*to, solution.markers());
+	if (!success) solution.setCost(std::numeric_limits<double>::infinity());
+	sendForward(from, InterfaceState(to), std::move(solution));
+	return success;
+}
+
+bool FixCollisionObjects::computeBackward(const InterfaceState &to)
+{
+	planning_scene::PlanningScenePtr from = to.scene()->diff();
+	SubTrajectory solution;
+	bool success = fixCollisions(*from, solution.markers());
+	if (!success) solution.setCost(std::numeric_limits<double>::infinity());
+	sendBackward(InterfaceState(from), to, std::move(solution));
+	return success;
+}
+
+bool FixCollisionObjects::fixCollisions(planning_scene::PlanningScene &scene, std::deque<visualization_msgs::Marker> &markers) const
+{
+	const auto& props = properties();
+	double penetration = props.get<double>("max_penetration");
+
+	collision_detection::CollisionRequest req;
+	collision_detection::CollisionResult res;
+	req.group_name = "";  // check collisions for complete robot
+	req.contacts = true;
+	req.max_contacts = 100;
+	req.max_contacts_per_pair = 5;
+	req.verbose = false;
+	req.distance = false;
+
+	scene.getCollisionWorld()->checkRobotCollision(req, res, *scene.getCollisionRobotUnpadded(), scene.getCurrentState(),
+	                                               scene.getAllowedCollisionMatrix());
+
+	geometry_msgs::Pose pose;
+
+	if (!res.collision)
+		return true;
+
+	vm::Marker m;
+	m.header.frame_id = scene.getPlanningFrame();
+	m.ns = "collisions";
+	rviz_marker_tools::setColor(m.color, rviz_marker_tools::RED);
+
+	ROS_INFO_THROTTLE(1, "collision(s) detected");
+	for (const auto& info : res.contacts) {
+		for (const auto& contact : info.second) {
+			tf::poseEigenToMsg(Eigen::Translation3d(contact.pos) * Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d::UnitX(), contact.normal), m.pose);
+			rviz_marker_tools::makeArrow(m, contact.depth);
+			markers.push_back(m);
+		}
+	}
+
+	// check again
+	scene.getCollisionWorld()->checkRobotCollision(req, res, *scene.getCollisionRobotUnpadded(), scene.getCurrentState(),
+	                                               scene.getAllowedCollisionMatrix());
+	return !res.collision;
+}
+
+void FixCollisionObjects::fixCollision(planning_scene::PlanningScene &scene, geometry_msgs::Pose pose, const std::string& object) const
+{
+	moveit_msgs::CollisionObject collision_obj;
+	collision_obj.header.frame_id = scene.getPlanningFrame();
+	collision_obj.id = object;
+	collision_obj.operation = moveit_msgs::CollisionObject::MOVE;
+
+	collision_obj.primitive_poses.resize(1);
+	collision_obj.primitive_poses[0] = pose;
+
+	if(!scene.processCollisionObjectMsg(collision_obj))
+		std::cout<<"Moving FAILED"<<std::endl;
+}
+
+} } }

--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -153,28 +153,24 @@ bool GenerateGraspPose::compute(){
 		trajectory.setCost(0.0);
 		trajectory.setName(std::to_string(current_angle_));
 
-		// add an arrow marker
-		visualization_msgs::Marker m;
-		m.header.frame_id = scene_->getPlanningFrame();
-		m.ns = "grasp pose";
-		rviz_marker_tools::setColor(m.color, rviz_marker_tools::LIME_GREEN);
-		double scale = 0.1;
-		rviz_marker_tools::makeArrow(m, scale);
-		tf::poseEigenToMsg(grasp_pose * grasp2tool *
-		                   // arrow should point along z (instead of x)
-		                   Eigen::AngleAxisd(-M_PI / 2.0, Eigen::Vector3d::UnitY()) *
-		                   // arrow tip at goal_pose
-		                   Eigen::Translation3d(-scale, 0, 0), m.pose);
-		trajectory.markers().push_back(m);
+		// add frame at grasp pose
+		goal_pose_msg.header.frame_id = scene_->getPlanningFrame();
+		tf::poseEigenToMsg(grasp_pose, goal_pose_msg.pose);
+		rviz_marker_tools::appendFrame(trajectory.markers(), goal_pose_msg, 0.1, "grasp frame");
 
-		// add end-effector marker
-		robot_state.updateStateWithLinkAt(link_name, link_pose);
+		// add end-effector marker visualizing the pose of the end-effector, including all rigidly connected parent links
+		const robot_model::LinkModel* link = robot_state.getLinkModel(link_name);
+		const robot_model::LinkModel* parent = robot_model::RobotModel::getRigidlyConnectedParentLinkModel(link);
+		if (parent != link)  // transform pose into pose suitable to place parent
+			link_pose = link_pose * robot_state.getGlobalLinkTransform(link).inverse() * robot_state.getGlobalLinkTransform(parent);
+
+		robot_state.updateStateWithLinkAt(parent, link_pose);
 		auto appender = [&trajectory](visualization_msgs::Marker& marker, const std::string& name) {
 			marker.ns = "grasp eef";
 			marker.color.a *= 0.5;
 			trajectory.markers().push_back(marker);
 		};
-		generateVisualMarkers(robot_state, appender, jmg->getLinkModelNames());
+		generateVisualMarkers(robot_state, appender, parent->getParentJointModel()->getDescendantLinkModels());
 
 		spawn(std::move(state), std::move(trajectory));
 		return true;

--- a/core/src/stages/modify_planning_scene.cpp
+++ b/core/src/stages/modify_planning_scene.cpp
@@ -1,0 +1,130 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke
+   Desc:    Modify planning scene
+*/
+
+#include <moveit/task_constructor/stages/modify_planning_scene.h>
+#include <moveit/task_constructor/storage.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+ModifyPlanningScene::ModifyPlanningScene(const std::string &name)
+  : PropagatingEitherWay(name)
+{}
+
+void ModifyPlanningScene::attachObjects(const Names& objects, const std::string& attach_link, bool attach)
+{
+	auto it_inserted = attach_objects_.insert(std::make_pair(attach_link, std::make_pair(Names(), attach)));
+	Names &o = it_inserted.first->second.first;
+	o.insert(o.end(), objects.begin(), objects.end());
+}
+
+void ModifyPlanningScene::enableCollisions(const Names& first, const Names& second, bool enable_collision) {
+	collision_matrix_edits_.push_back(CollisionMatrixPairs({first, second, enable_collision}));
+}
+
+void ModifyPlanningScene::enableCollisions(const std::string &first, const moveit::core::JointModelGroup &jmg, bool enable_collision)
+{
+	const auto& links = jmg.getLinkModelNamesWithCollisionGeometry();
+	if (!links.empty())
+		enableCollisions(Names({first}), links, enable_collision);
+}
+
+bool ModifyPlanningScene::computeForward(const InterfaceState &from){
+	sendForward(from, apply(from, false), robot_trajectory::RobotTrajectoryPtr());
+	return true;
+}
+
+bool ModifyPlanningScene::computeBackward(const InterfaceState &to)
+{
+	sendBackward(apply(to, true), to, robot_trajectory::RobotTrajectoryPtr());
+	return true;
+}
+
+void ModifyPlanningScene::attachObjects(planning_scene::PlanningScene &scene,
+                                        const std::pair<std::string, std::pair<Names, bool> >& pair,
+                                        bool invert)
+{
+	moveit_msgs::AttachedCollisionObject obj;
+	obj.link_name = pair.first;
+	bool attach = pair.second.second;
+	if (invert) attach = !attach;
+	obj.object.operation = attach ? (int8_t) moveit_msgs::CollisionObject::ADD
+	                              : (int8_t) moveit_msgs::CollisionObject::REMOVE;
+	for (const std::string& name : pair.second.first) {
+		obj.object.id = name;
+		scene.processAttachedCollisionObjectMsg(obj);
+	}
+}
+
+void ModifyPlanningScene::enableCollisions(planning_scene::PlanningScene &scene,
+                                        const CollisionMatrixPairs& pairs,
+                                        bool invert)
+{
+	collision_detection::AllowedCollisionMatrix& acm = scene.getAllowedCollisionMatrixNonConst();
+	bool enable = invert ? !pairs.enable : pairs.enable;
+	if (pairs.second.empty()) {
+		for (const auto &name : pairs.first)
+			acm.setEntry(name, enable);
+	} else
+		acm.setEntry(pairs.first, pairs.second, enable);
+}
+
+// invert indicates, whether to detach instead of attach (and vice versa)
+// as well as to disable instead of enable collision (and vice versa)
+InterfaceState ModifyPlanningScene::apply(const InterfaceState& from, bool invert)
+{
+	planning_scene::PlanningScenePtr scene = from.scene()->diff();
+	InterfaceState result(scene);
+	// initialize properties from input state
+	result.properties() = from.properties();
+
+	// attach/detach objects
+	for (const auto &pair : attach_objects_)
+		attachObjects(*scene, pair, invert);
+
+	// enable/disable collisions
+	for (const auto &pairs : collision_matrix_edits_)
+		enableCollisions(*scene, pairs, invert);
+
+	if (callback_)
+		callback_(scene, result.properties());
+
+	return result;
+}
+
+} } }

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -139,7 +139,7 @@ bool MoveRelative::compute(const InterfaceState &state, planning_scene::Planning
 	double linear_norm = 0.0, angular_norm = 0.0;
 
 	Eigen::Affine3d target_eigen;
-	const Eigen::Affine3d& link_pose = scene->getFrameTransform(link_name);
+	Eigen::Affine3d link_pose = scene->getFrameTransform(link_name);  // take a copy here, pose will change on success
 
 	boost::any goal = props.get("twist");
 	if (!goal.empty()) {

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -1,0 +1,274 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    Move link along Cartesian direction
+*/
+
+#include <moveit/task_constructor/stages/move_relative.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <rviz_marker_tools/marker_creation.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+MoveRelative::MoveRelative(std::string name, const solvers::PlannerInterfacePtr& planner)
+   : PropagatingEitherWay(name)
+   , planner_(planner)
+{
+	auto& p = properties();
+	p.declare<double>("timeout", 10.0, "planning timeout");
+	p.declare<std::string>("marker_ns", "", "marker namespace");
+	p.declare<std::string>("group", "name of planning group");
+	p.declare<std::string>("link", "", "link to move (default is tip of jmg)");
+	p.declare<double>("min_distance", "minimum distance to move");
+	p.declare<double>("max_distance", "maximum distance to move");
+
+	p.declare<geometry_msgs::TwistStamped>("twist", "Cartesian twist transform");
+	p.declare<geometry_msgs::Vector3Stamped>("direction", "Cartesian translation direction");
+}
+
+void MoveRelative::setGroup(const std::string& group){
+	setProperty("group", group);
+}
+
+void MoveRelative::setLink(const std::string& link){
+	setProperty("link", link);
+}
+
+void MoveRelative::setMinDistance(double distance){
+	setProperty("min_distance", distance);
+}
+
+void MoveRelative::setMaxDistance(double distance){
+	setProperty("max_distance", distance);
+}
+
+void MoveRelative::setMinMaxDistance(double min_distance, double max_distance){
+	setProperty("min_distance", min_distance);
+	setProperty("max_distance", max_distance);
+}
+
+void MoveRelative::along(const geometry_msgs::TwistStamped &twist)
+{
+	setProperty("twist", twist);
+}
+
+void MoveRelative::along(const geometry_msgs::Vector3Stamped &direction)
+{
+	setProperty("direction", direction);
+}
+
+void MoveRelative::init(const planning_scene::PlanningSceneConstPtr &scene)
+{
+	PropagatingEitherWay::init(scene);
+	planner_->init(scene->getRobotModel());
+}
+
+bool MoveRelative::compute(const InterfaceState &state, planning_scene::PlanningScenePtr& scene,
+                           SubTrajectory &trajectory, Direction dir) {
+	scene = state.scene()->diff();
+	assert(scene->getRobotModel());
+
+	const auto& props = properties();
+	double timeout = props.get<double>("timeout");
+	const std::string& group = props.get<std::string>("group");
+	const moveit::core::JointModelGroup* jmg = scene->getRobotModel()->getJointModelGroup(group);
+	if (!jmg) {
+		ROS_WARN_STREAM("MoveTo: invalid joint model group: " << group);
+		return false;
+	}
+
+	// only allow single target
+	size_t count_goals = props.countDefined({"twist", "direction"});
+	if (count_goals != 1) {
+		if (count_goals == 0) ROS_WARN("MoveTo: no goal defined");
+		else ROS_WARN("MoveTo: cannot plan to multiple goals");
+		return false;
+	}
+
+	// Cartesian targets require the link name
+	std::string link_name = props.get<std::string>("link");
+	const moveit::core::LinkModel* link;
+	if (link_name.empty())
+		link_name = solvers::getEndEffectorLink(jmg);
+	if (link_name.empty() || !(link = scene->getRobotModel()->getLinkModel(link_name))) {
+		ROS_WARN_STREAM("MoveTo: no or invalid link name specified: " << link_name);
+		return false;
+	}
+
+	Property prop = props.property("max_distance");
+	double max_distance = prop.value().empty() ? 0.0 : std::abs(boost::any_cast<double>(prop.value()));
+	prop = props.property("min_distance");
+	double min_distance = prop.value().empty() ? -1.0 : boost::any_cast<double>(prop.value());
+
+	bool use_rotation_distance = false;  // measure achieved distance as rotation?
+	Eigen::Vector3d linear;  // linear translation
+	Eigen::Vector3d angular;  // angular rotation
+	double linear_norm = 0.0, angular_norm = 0.0;
+
+	Eigen::Affine3d target_eigen;
+	const Eigen::Affine3d& link_pose = scene->getFrameTransform(link_name);
+
+	boost::any goal = props.get("twist");
+	if (!goal.empty()) {
+		const geometry_msgs::TwistStamped& target = boost::any_cast<geometry_msgs::TwistStamped>(goal);
+		const Eigen::Affine3d& frame_pose = scene->getFrameTransform(target.header.frame_id);
+		tf::vectorMsgToEigen(target.twist.linear, linear);
+		tf::vectorMsgToEigen(target.twist.angular, angular);
+
+		linear_norm = linear.norm();
+		angular_norm = angular.norm();
+		angular /= angular_norm;  // normalize angular
+		use_rotation_distance = linear_norm < std::numeric_limits<double>::epsilon();
+
+		// use max distance?
+		if (max_distance > 0.0) {
+			double scale;
+			if (!use_rotation_distance)  // non-zero linear motion defines distance
+				scale = max_distance / linear_norm;
+			else if (angular_norm > std::numeric_limits<double>::epsilon())
+				scale = max_distance / angular_norm;
+			linear *= scale;
+			linear_norm *= scale;
+			angular_norm *= scale;
+		}
+
+		// invert direction?
+		if (dir == BACKWARD) {
+			linear *= -1.0;
+			angular *= -1.0;
+		}
+
+		// compute absolute transform for link
+		linear = frame_pose.linear() * linear;
+		angular = frame_pose.linear() * angular;
+		target_eigen = link_pose;
+		target_eigen.linear() = target_eigen.linear() * Eigen::AngleAxisd(angular_norm, link_pose.linear().transpose() * angular);
+		target_eigen.translation() += linear;
+	}
+
+	goal = props.get("direction");
+	if (!goal.empty()) {
+		const geometry_msgs::Vector3Stamped& target = boost::any_cast<geometry_msgs::Vector3Stamped>(goal);
+		const Eigen::Affine3d& frame_pose = scene->getFrameTransform(target.header.frame_id);
+		tf::vectorMsgToEigen(target.vector, linear);
+
+		// use max distance?
+		if (max_distance > 0.0) {
+			linear.normalize();
+			linear *= max_distance;
+		}
+		linear_norm = linear.norm();
+
+		// invert direction?
+		if (dir == BACKWARD)
+			linear *= -1.0;
+
+		// compute absolute transform for link
+		linear = frame_pose.linear() * linear;
+		target_eigen = link_pose;
+		target_eigen.translation() += linear;
+	}
+
+	robot_trajectory::RobotTrajectoryPtr robot_trajectory;
+	bool success = planner_->plan(state.scene(), *link, target_eigen, jmg, timeout, robot_trajectory);
+
+	// min_distance reached?
+	if (success && min_distance > 0.0) {
+		const robot_state::RobotState& reached_state = robot_trajectory->getLastWayPoint();
+		Eigen::Affine3d reached_pose = reached_state.getGlobalLinkTransform(link);
+		if (use_rotation_distance) {
+			Eigen::AngleAxisd rotation(reached_pose.linear() * link_pose.linear().transpose());
+			success = rotation.angle() > min_distance;
+		} else
+			success = (reached_pose.translation() - link_pose.translation()).norm() > min_distance;
+	}
+
+	// store result
+	if (success || (robot_trajectory && storeFailures())) {
+		scene->setCurrentState(robot_trajectory->getLastWayPoint());
+		if (dir == BACKWARD) robot_trajectory->reverse();
+		trajectory.setTrajectory(robot_trajectory);
+	}
+
+	// add an arrow marker
+	visualization_msgs::Marker m;
+	m.ns = props.get<std::string>("marker_ns");
+	if (!m.ns.empty()) {
+		m.header.frame_id = scene->getPlanningFrame();
+		if (linear_norm > 1e-3) {
+			rviz_marker_tools::setColor(m.color, success ? rviz_marker_tools::LIME_GREEN
+			                                             : rviz_marker_tools::RED);
+			rviz_marker_tools::makeArrow(m, linear_norm);
+			auto quat = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d::UnitX(), linear);
+			Eigen::Vector3d pos(link_pose.translation());
+			if (dir == BACKWARD)  {
+				// flip arrow direction
+				quat = quat * Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY());
+				// arrow tip at goal_pose
+				pos += quat * Eigen::Vector3d(-linear_norm, 0, 0);
+			}
+			tf::pointEigenToMsg(pos, m.pose.position);
+			tf::quaternionEigenToMsg(quat, m.pose.orientation);
+			trajectory.markers().push_back(m);
+		}
+	}
+
+	return success;
+}
+
+bool MoveRelative::computeForward(const InterfaceState &from)
+{
+	planning_scene::PlanningScenePtr to;
+	SubTrajectory trajectory;
+
+	bool success = compute(from, to, trajectory, FORWARD);
+	if (!success) trajectory.setCost(std::numeric_limits<double>::infinity());
+	sendForward(from, InterfaceState(to), std::move(trajectory));
+	return success;
+}
+
+bool MoveRelative::computeBackward(const InterfaceState &to)
+{
+	planning_scene::PlanningScenePtr from;
+	SubTrajectory trajectory;
+
+	bool success = compute(to, from, trajectory, BACKWARD);
+	if (!success) trajectory.setCost(std::numeric_limits<double>::infinity());
+	sendBackward(InterfaceState(from), to, std::move(trajectory));
+	return success;
+}
+
+} } }

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -214,10 +214,12 @@ bool MoveRelative::compute(const InterfaceState &state, planning_scene::Planning
 			success = rotation.angle() > min_distance;
 		} else
 			success = (reached_pose.translation() - link_pose.translation()).norm() > min_distance;
+	} else if (!success && min_distance == 0.0) { // if min_distance is zero, we succeed in any case
+		success = true;
 	}
 
 	// store result
-	if (success || (robot_trajectory && storeFailures())) {
+	if (robot_trajectory && (success || storeFailures())) {
 		scene->setCurrentState(robot_trajectory->getLastWayPoint());
 		if (dir == BACKWARD) robot_trajectory->reverse();
 		trajectory.setTrajectory(robot_trajectory);

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -1,0 +1,193 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Michael Goerner, Robert Haschke
+   Desc:    Move to joint-state or Cartesian goal pose
+*/
+
+#include <moveit/task_constructor/stages/move_to.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+MoveTo::MoveTo(std::string name, const solvers::PlannerInterfacePtr& planner)
+   : PropagatingEitherWay(name)
+   , planner_(planner)
+{
+	auto& p = properties();
+	p.declare<double>("timeout", 10.0, "planning timeout");
+	p.declare<std::string>("group", "name of planning group");
+	p.declare<std::string>("link", "", "link to move (default is tip of jmg)");
+
+	p.declare<geometry_msgs::PoseStamped>("pose", "Cartesian target pose");
+	p.declare<geometry_msgs::PointStamped>("point", "Cartesian target point");
+	p.declare<std::string>("joint_pose", "named joint pose");
+}
+
+void MoveTo::setGroup(const std::string& group){
+	setProperty("group", group);
+}
+
+void MoveTo::setLink(const std::string& link){
+	setProperty("link", link);
+}
+
+void MoveTo::setGoal(const geometry_msgs::PoseStamped &pose)
+{
+	setProperty("pose", pose);
+}
+
+void MoveTo::setGoal(const geometry_msgs::PointStamped &point)
+{
+	setProperty("point", point);
+}
+
+void MoveTo::setGoal(const std::string &joint_pose)
+{
+	setProperty("joint_pose", joint_pose);
+}
+
+void MoveTo::init(const planning_scene::PlanningSceneConstPtr &scene)
+{
+	PropagatingEitherWay::init(scene);
+	planner_->init(scene->getRobotModel());
+}
+
+bool MoveTo::compute(const InterfaceState &state, planning_scene::PlanningScenePtr& scene,
+                     SubTrajectory &trajectory, Direction dir) {
+	scene = state.scene()->diff();
+	assert(scene->getRobotModel());
+
+	const auto& props = properties();
+	double timeout = props.get<double>("timeout");
+	const std::string& group = props.get<std::string>("group");
+	const moveit::core::JointModelGroup* jmg = scene->getRobotModel()->getJointModelGroup(group);
+	if (!jmg) {
+		ROS_WARN_STREAM("MoveTo: invalid joint model group: " << group);
+		return false;
+	}
+
+	// only allow single target
+	size_t count_goals = props.countDefined({"joint_pose", "pose", "point"});
+	if (count_goals != 1) {
+		if (count_goals == 0) ROS_WARN("MoveTo: no goal defined");
+		else ROS_WARN("MoveTo: cannot plan to multiple goals");
+		return false;
+	}
+
+	robot_trajectory::RobotTrajectoryPtr robot_trajectory;
+	bool success = false;
+
+	boost::any goal = props.get("joint_pose");
+	if (!goal.empty()) {
+		const std::string& named_joint_pose = boost::any_cast<std::string>(goal);
+		if (!scene->getCurrentStateNonConst().setToDefaultValues(jmg, named_joint_pose)) {
+			ROS_WARN("MoveTo: unknown joint pose '%s' for jmg '%s'", named_joint_pose.c_str(), group.c_str());
+			return false;
+		}
+		success = planner_->plan(state.scene(), scene, jmg, timeout, robot_trajectory);
+	} else {
+		// Cartesian targets require the link name
+		std::string link_name = props.get<std::string>("link");
+		const moveit::core::LinkModel* link;
+		if (link_name.empty())
+			link_name = solvers::getEndEffectorLink(jmg);
+		if (link_name.empty() || !(link = scene->getRobotModel()->getLinkModel(link_name))) {
+			ROS_WARN_STREAM("MoveTo: no or invalid link name specified: " << link_name);
+			return false;
+		}
+
+		Eigen::Affine3d target_eigen;
+
+		goal = props.get("pose");
+		if (!goal.empty()) {
+			const geometry_msgs::PoseStamped& target = boost::any_cast<geometry_msgs::PoseStamped>(goal);
+			tf::poseMsgToEigen(target.pose, target_eigen);
+
+			// transform target into global frame
+			const Eigen::Affine3d& frame = scene->getFrameTransform(target.header.frame_id);
+			target_eigen = frame * target_eigen;
+		}
+
+		goal = props.get("point");
+		if (!goal.empty()) {
+			const geometry_msgs::PointStamped& target = boost::any_cast<geometry_msgs::PointStamped>(goal);
+			Eigen::Vector3d target_point;
+			tf::pointMsgToEigen(target.point, target_point);
+
+			// transform target into global frame
+			const Eigen::Affine3d& frame = scene->getFrameTransform(target.header.frame_id);
+			target_point = frame * target_point;
+
+			// retain link orientation
+			Eigen::Affine3d target_eigen = scene->getCurrentState().getGlobalLinkTransform(link_name);
+			target_eigen.translation() = target_point;
+		}
+
+		success = planner_->plan(state.scene(), *link, target_eigen, jmg, timeout, robot_trajectory);
+	}
+
+	// store result
+	if (success || (robot_trajectory && storeFailures())) {
+		scene->setCurrentState(robot_trajectory->getLastWayPoint());
+		if (dir == BACKWARD) robot_trajectory->reverse();
+		trajectory.setTrajectory(robot_trajectory);
+	}
+
+	return success;
+}
+
+bool MoveTo::computeForward(const InterfaceState &from){
+	planning_scene::PlanningScenePtr to;
+	SubTrajectory trajectory;
+
+	bool success = compute(from, to, trajectory, FORWARD);
+	if (!success) trajectory.setCost(std::numeric_limits<double>::infinity());
+	sendForward(from, InterfaceState(to), std::move(trajectory));
+	return success;
+}
+
+bool MoveTo::computeBackward(const InterfaceState &to)
+{
+	planning_scene::PlanningScenePtr from;
+	SubTrajectory trajectory;
+
+	bool success = compute(to, from, trajectory, BACKWARD);
+	if (!success) trajectory.setCost(std::numeric_limits<double>::infinity());
+	sendBackward(InterfaceState(from), to, std::move(trajectory));
+	return success;
+}
+
+} } }

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -100,7 +100,8 @@ void Interface::updatePriority(InterfaceState &state, const InterfaceState::Prio
 {
 	if (priority < state.priority()) {
 		auto it = std::find_if(begin(), end(), [&state](const InterfaceState& other) { return &state == &other; });
-		assert(it != end());  // state should be part of this interface
+		// state should be part of the interface
+		assert(it != end());
 		state.priority_ = priority;
 		if (notify_) notify_(it, true);
 	}

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -69,6 +69,10 @@ void Task::initModel () {
 		throw Exception("Task failed to construct RobotModel");
 }
 
+const moveit::core::RobotModelPtr Task::getRobotModel() const {
+	return rml_ ? rml_->getModel() : moveit::core::RobotModelPtr();
+}
+
 planning_scene::PlanningScenePtr Task::initScene(ros::Duration timeout) {
 	assert(rml_);
 
@@ -182,10 +186,19 @@ void Task::reset()
 
 void Task::init(const planning_scene::PlanningSceneConstPtr &scene)
 {
-	WrapperBase::init(scene);
+	auto impl = pimpl();
+	// initialize push connections of wrapped child
+	StagePrivate *child = wrapped()->pimpl();
+	child->setPrevEnds(impl->pendingBackward());
+	child->setNextStarts(impl->pendingForward());
+
+	// explicitly call ContainerBase::init(), not WrapperBase::init()
+	// to keep the just set push interface for the wrapped child
+	ContainerBase::init(scene);
+
 	// provide introspection instance to all stages
-	pimpl()->setIntrospection(introspection_.get());
-	pimpl()->traverseStages([this](Stage& stage, int) {
+	impl->setIntrospection(introspection_.get());
+	impl->traverseStages([this](Stage& stage, int) {
 		stage.pimpl()->setIntrospection(introspection_.get());
 		return true;
 	}, 1, UINT_MAX);
@@ -224,9 +237,7 @@ bool Task::plan()
 
 size_t Task::numSolutions() const
 {
-	auto w = stages();
-	// during initial insert() we call numSolutions(), but wrapped() is not yet defined
-	return w ? w->numSolutions() : 0;
+	return stages()->numSolutions();
 }
 
 void Task::processSolutions(const ContainerBase::SolutionProcessor &processor) const
@@ -242,7 +253,7 @@ void Task::publishAllSolutions(bool wait)
 
 void Task::onNewSolution(const SolutionBase &s)
 {
-	WrapperBase::onNewSolution(s);
+	// no need to call WrapperBase::onNewSolution!
 	if (introspection_)
 		introspection_->publishSolution(s);
 }

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -58,7 +58,7 @@ Task::Task(const std::string& id, ContainerBase::pointer &&container)
 	initModel();
 
 	// monitor state on commandline
-	addTaskCallback(&printState);
+	//addTaskCallback(std::bind(&Task::printState, this, std::ref(std::cout)));
 	// enable introspection by default
 	enableIntrospection(true);
 }
@@ -232,6 +232,7 @@ bool Task::plan()
 		} else
 			break;
 	}
+	printState();
 	return numSolutions() > 0;
 }
 
@@ -285,12 +286,13 @@ std::string Task::id() const
 	return id_;
 }
 
-void Task::printState(const Task &t){
-	ContainerBase::StageCallback processor = [](const Stage& stage, int depth) -> bool {
-		std::cout << std::string(2*depth, ' ') << stage << std::endl;
+void Task::printState(std::ostream& os) const
+{
+	ContainerBase::StageCallback processor = [&os](const Stage& stage, int depth) -> bool {
+		os << std::string(2*depth, ' ') << stage << std::endl;
 		return true;
 	};
-	t.stages()->traverseRecursively(processor);
+	stages()->traverseRecursively(processor);
 }
 
 } }

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -55,7 +55,7 @@ TEST_F(BaseTest, serialContainer) {
 	SerialContainer c("serial");
 	SerialContainerPrivate *cp = c.pimpl();
 	// pretend, that the container is connected
-	InterfacePtr dummy(new Interface(Interface::NotifyFunction()));
+	InterfacePtr dummy(new Interface);
 	cp->setNextStarts(dummy);
 	cp->setPrevEnds(dummy);
 	planning_scene::PlanningScenePtr scene;

--- a/core/test/test_plan_generate_grasp_pose.cpp
+++ b/core/test/test_plan_generate_grasp_pose.cpp
@@ -47,7 +47,5 @@ int main(int argc, char** argv){
 
 	t.plan();
 
-	Task::printState(t);
-
 	return 0;
 }

--- a/core/test/test_stage.cpp
+++ b/core/test/test_stage.cpp
@@ -18,8 +18,8 @@ public:
 		robot_model_loader::RobotModelLoader loader;
 		ps.reset(new planning_scene::PlanningScene(loader.getModel()));
 
-		prev.reset(new Interface(Interface::NotifyFunction()));
-		next.reset(new Interface(Interface::NotifyFunction()));
+		prev.reset(new Interface);
+		next.reset(new Interface);
 		pimpl()->setPrevEnds(prev);
 		pimpl()->setNextStarts(next);
 	}

--- a/visualization/motion_planning_tasks/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(utils)
+add_subdirectory(properties)
 add_subdirectory(src)
 add_subdirectory(test)

--- a/visualization/motion_planning_tasks/properties/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/properties/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(MOVEIT_LIB_NAME motion_planning_tasks_properties)
+
+set(SOURCES
+	property_factory.cpp
+)
+add_library(${MOVEIT_LIB_NAME} SHARED ${SOURCES})
+
+target_link_libraries(${MOVEIT_LIB_NAME}
+	${QT_LIBRARIES}
+)
+target_include_directories(${MOVEIT_LIB_NAME}
+	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+)
+
+install(TARGETS ${MOVEIT_LIB_NAME}
+	ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})

--- a/visualization/motion_planning_tasks/properties/property_factory.cpp
+++ b/visualization/motion_planning_tasks/properties/property_factory.cpp
@@ -1,0 +1,100 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Haschke */
+
+#include "property_factory.h"
+#include <boost/functional/factory.hpp>
+#include <moveit/task_constructor/properties.h>
+
+#include <rviz/properties/property_tree_model.h>
+#include <rviz/properties/string_property.h>
+#include <rviz/properties/float_property.h>
+
+using namespace moveit::task_constructor;
+
+namespace moveit_rviz_plugin {
+
+/// TODO: We also need to provide methods to sync both properties in both directions.
+/// In our Property we could store a callback function to update the rviz::Property.
+/// The rviz::Property can simply use a lambda-function slot to update our Property.
+/// However, we need to avoid infinite loops in doing so. Our Property cannot compare values...
+template <typename T, typename RVIZProp>
+RVIZProp* helper(const QString& name, Property* prop) {
+	T value = prop->defined() ? boost::any_cast<T>(prop->value()) : T();
+	return new RVIZProp(name, value, QString::fromStdString(prop->description()));
+}
+
+PropertyFactory::PropertyFactory()
+{
+	// registe some standard types
+	registerType<double>(&helper<double, rviz::FloatProperty>);
+	registerType<QString>(&helper<QString, rviz::StringProperty>);
+}
+
+PropertyFactory& PropertyFactory::instance()
+{
+	static PropertyFactory instance_;
+	return instance_;
+}
+
+void PropertyFactory::registerType(const std::string &type_name, const FactoryFunction &f)
+{
+	registry_.insert(std::make_pair(type_name, f));
+}
+
+rviz::Property* PropertyFactory::create(const std::string& prop_name, Property* prop) const
+{
+	auto it = registry_.find(prop->typeName());
+	if (it == registry_.end()) return nullptr;
+	return it->second(QString::fromStdString(prop_name), prop);
+}
+
+rviz::PropertyTreeModel* createPropertyTreeModel(PropertyMap& properties, QObject* parent) {
+	PropertyFactory& factory = PropertyFactory::instance();
+
+	rviz::Property* root = new rviz::Property();
+	rviz::PropertyTreeModel *model = new rviz::PropertyTreeModel(root, parent);
+	for (auto& prop : properties) {
+		rviz::Property* rviz_prop = factory.create(prop.first, &prop.second);
+		if (!rviz_prop) rviz_prop = new rviz::Property(QString::fromStdString(prop.first));
+		rviz_prop->setParent(root);
+	}
+	// just to see something, when no properties are defined
+	if (model->rowCount() == 0)
+		new rviz::Property("no properties", QVariant(), QString(), root);
+	return model;
+}
+
+}

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -32,66 +32,53 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Robert Haschke
-   Desc:   Monitor manipulation tasks and visualize their solutions
-*/
+/* Author: Robert Haschke */
 
 #pragma once
 
-#include "task_panel.h"
-#include "ui_task_panel.h"
-#include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include <QObject>
+#include <QString>
+#include <map>
+#include <functional>
+#include <typeindex>
 
-#include <rviz/panel.h>
-#include <rviz/properties/property_tree_model.h>
-#include <QPointer>
+namespace rviz {
+class Property;
+class PropertyTreeModel;
+}
+namespace moveit { namespace task_constructor {
+class Property;
+class PropertyMap;
+} }
 
 namespace moveit_rviz_plugin {
 
-class BaseTaskModel;
-class TaskListModel;
-class TaskDisplay;
-
-class TaskPanelPrivate : public Ui_TaskPanel {
+class PropertyFactory
+{
 public:
-	TaskPanelPrivate(TaskPanel *q_ptr);
+	static PropertyFactory& instance();
 
-	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	typedef std::function<rviz::Property*(const QString& name, moveit::task_constructor::Property*)> FactoryFunction;
 
-	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
+	/// register a new factory function for type T
+	template <typename T>
+	void registerType(const FactoryFunction& f) { registerType(std::type_index(typeid(T)).name(), f); }
+
+	/// retrieve rviz property for given task_constructor property
+	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property *prop) const;
+
+private:
+	std::map<std::string, FactoryFunction> registry_;
+
+	/// class is singleton
+	PropertyFactory();
+	PropertyFactory(const PropertyFactory&) = delete;
+	void operator=(const PropertyFactory&) = delete;
+
+	void registerType(const std::string& type_name, const FactoryFunction& f);
 };
 
-
-class TaskViewPrivate : public Ui_TaskView {
-public:
-	TaskViewPrivate(TaskView *q_ptr);
-
-	/// retrieve TaskListModel corresponding to given index
-	inline std::pair<TaskListModel*, TaskDisplay*>
-	getTaskListModel(const QModelIndex &index) const;
-
-	/// retrieve TaskModel corresponding to given index
-	inline std::pair<BaseTaskModel*, QModelIndex>
-	getTaskModel(const QModelIndex& index) const;
-
-	/// unlock locked_display_ if given display is different
-	void lock(TaskDisplay *display);
-
-	TaskView *q_ptr;
-	QPointer<TaskDisplay> locked_display_;
-};
-
-
-class TaskSettingsPrivate : public Ui_TaskSettings {
-public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
-
-	TaskSettings *q_ptr;
-};
+/// turn a PropertyMap into an rviz::PropertyTreeModel
+rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::PropertyMap &properties, QObject *parent = nullptr);
 
 }

--- a/visualization/motion_planning_tasks/src/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(MOVEIT_LIB_NAME motion_planning_tasks_rviz_plugin)
 
-qt_wrap_ui(UIC_FILES task_panel.ui)
+qt_wrap_ui(UIC_FILES
+	task_panel.ui
+	task_view.ui
+	task_settings.ui
+)
 
 add_library(${MOVEIT_LIB_NAME}
 	factory_model.cpp
@@ -22,7 +26,7 @@ add_library(${MOVEIT_LIB_NAME}
 
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 target_link_libraries(${MOVEIT_LIB_NAME}
-	motion_planning_tasks_utils moveit_task_visualization_tools
+	motion_planning_tasks_utils motion_planning_tasks_properties moveit_task_visualization_tools
 	${catkin_LIBRARIES} ${QT_LIBRARIES}
 )
 target_include_directories(${MOVEIT_LIB_NAME}

--- a/visualization/motion_planning_tasks/src/local_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/local_task_model.cpp
@@ -36,6 +36,7 @@
 
 #include "local_task_model.h"
 #include "factory_model.h"
+#include "properties/property_factory.h"
 #include <moveit/task_constructor/container_p.h>
 
 #include <ros/console.h>
@@ -230,6 +231,16 @@ DisplaySolutionPtr LocalTaskModel::getSolution(const QModelIndex &index)
 {
 	// TODO implement
 	return DisplaySolutionPtr();
+}
+
+rviz::PropertyTreeModel* LocalTaskModel::getPropertyModel(const QModelIndex &index)
+{
+	Node *n = node(index);
+	if (!n) return nullptr;
+	auto it_inserted = properties_.insert(std::make_pair(n, nullptr));
+	if (it_inserted.second)  // newly inserted, create new model
+		it_inserted.first->second = createPropertyTreeModel(n->me()->properties(), this);
+	return it_inserted.first->second;
 }
 
 }

--- a/visualization/motion_planning_tasks/src/local_task_model.h
+++ b/visualization/motion_planning_tasks/src/local_task_model.h
@@ -49,6 +49,7 @@ class LocalTaskModel
 	typedef moveit::task_constructor::StagePrivate Node;
 	Node *root_;
 	StageFactoryPtr stage_factory_;
+	std::map<Node*, rviz::PropertyTreeModel*> properties_;
 
 	inline Node* node(const QModelIndex &index) const;
 	QModelIndex index(Node *n) const;
@@ -73,6 +74,8 @@ public:
 
 	QAbstractItemModel* getSolutionModel(const QModelIndex& index) override;
 	DisplaySolutionPtr getSolution(const QModelIndex &index) override;
+
+	rviz::PropertyTreeModel* getPropertyModel(const QModelIndex& index) override;
 };
 
 }

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -40,6 +40,8 @@
 #include <moveit/task_constructor/container.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit_task_constructor_msgs/GetSolution.h>
+#include <rviz/properties/property_tree_model.h>
+#include <rviz/properties/property.h>
 #include <ros/console.h>
 #include <ros/service_client.h>
 
@@ -64,9 +66,11 @@ struct RemoteTaskModel::Node {
 	InterfaceFlags interface_flags_;
 	NodeFlags node_flags_;
 	std::unique_ptr<RemoteSolutionModel> solutions_;
+	std::unique_ptr<rviz::PropertyTreeModel> properties_;
 
 	inline Node(Node *parent) : parent_(parent) {
 		solutions_.reset(new RemoteSolutionModel());
+		properties_.reset(new rviz::PropertyTreeModel(new rviz::Property()));
 	}
 
 	bool setName(const QString& name) {
@@ -367,6 +371,13 @@ DisplaySolutionPtr RemoteTaskModel::getSolution(const QModelIndex &index)
 		return result;
 	}
 	return it->second;
+}
+
+rviz::PropertyTreeModel* RemoteTaskModel::getPropertyModel(const QModelIndex &index)
+{
+	Node *n = node(index);
+	if (!n) return nullptr;
+	return n->properties_.get();
 }
 
 namespace detail {

--- a/visualization/motion_planning_tasks/src/remote_task_model.h
+++ b/visualization/motion_planning_tasks/src/remote_task_model.h
@@ -87,6 +87,8 @@ public:
 
 	QAbstractItemModel* getSolutionModel(const QModelIndex& index) override;
 	DisplaySolutionPtr getSolution(const QModelIndex &index) override;
+
+	rviz::PropertyTreeModel* getPropertyModel(const QModelIndex& index) override;
 };
 
 

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -264,7 +264,7 @@ void TaskDisplay::onTasksInserted(const QModelIndex &parent, int first, int last
 	TaskListModel* m = static_cast<TaskListModel*>(sender());
 	for (; first <= last; ++first) {
 		QModelIndex idx = m->index(first, 0, parent);
-		tasks_property_->addChild(new rviz::Property(idx.data().toString(), idx.sibling(idx.row(), 1).data()));
+		tasks_property_->addChild(new rviz::Property(idx.data().toString(), idx.sibling(idx.row(), 1).data()), first);
 	}
 }
 

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -132,6 +132,9 @@ void TaskDisplay::loadRobotModel()
 
 	// share the planning scene with task models
 	task_list_model_->setScene(trajectory_visual_->getScene());
+
+	// perform any postponed subscription to topics (after scene is well-defined)
+	changedTaskSolutionTopic();
 }
 
 void TaskDisplay::reset()
@@ -221,6 +224,10 @@ void TaskDisplay::showMarkers(const DisplaySolutionPtr &s) {
 
 void TaskDisplay::changedTaskSolutionTopic()
 {
+	// postpone setup until scene is well-defined
+	if (!trajectory_visual_->getScene())
+		return;
+
 	task_description_sub.shutdown();
 	task_statistics_sub.shutdown();
 	task_solution_sub.shutdown();

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -50,6 +50,7 @@
 #include <memory>
 
 namespace ros { class ServiceClient; }
+namespace rviz { class PropertyTreeModel; }
 
 namespace moveit_rviz_plugin {
 
@@ -84,8 +85,13 @@ public:
 	Qt::ItemFlags flags(const QModelIndex &index) const override;
 	unsigned int taskFlags() const { return flags_; }
 
+	/// get solution model for given stage index
 	virtual QAbstractItemModel* getSolutionModel(const QModelIndex& index) = 0;
+	/// get solution for given solution index
 	virtual DisplaySolutionPtr getSolution(const QModelIndex &index) = 0;
+
+	/// get property model for given stage index
+	virtual rviz::PropertyTreeModel* getPropertyModel(const QModelIndex& index) = 0;
 };
 
 

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -82,15 +82,40 @@ public:
 	void load(const rviz::Config& config) override;
 	void save(rviz::Config config) const override;
 
+protected Q_SLOTS:
+	void showStageDockWidget();
+};
+
+
+class MetaTaskListModel;
+class TaskViewPrivate;
+class TaskView : public QWidget {
+	Q_OBJECT
+	Q_DECLARE_PRIVATE(TaskView)
+	TaskViewPrivate *d_ptr;
+
+public:
+	TaskView(QWidget* parent = 0);
+
 public Q_SLOTS:
 	void addTask();
-	void showStageDockWidget();
 
 protected Q_SLOTS:
 	void removeSelectedStages();
 	void onCurrentStageChanged(const QModelIndex &current, const QModelIndex &previous);
 	void onCurrentSolutionChanged(const QModelIndex &current, const QModelIndex &previous);
 	void onSolutionSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+};
+
+
+class TaskSettingsPrivate;
+class TaskSettings : public QWidget {
+	Q_OBJECT
+	Q_DECLARE_PRIVATE(TaskSettings)
+	TaskSettingsPrivate *d_ptr;
+
+public:
+	TaskSettings(QWidget* parent = 0);
 };
 
 }

--- a/visualization/motion_planning_tasks/src/task_panel.ui
+++ b/visualization/motion_planning_tasks/src/task_panel.ui
@@ -14,9 +14,6 @@
    <string>Tasks Panel</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="spacing">
-    <number>0</number>
-   </property>
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -30,193 +27,49 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="tab_tasks">
-      <attribute name="icon">
-       <iconset resource="resources.qrc">
-        <normaloff>:/icons/tasks.png</normaloff>:/icons/tasks.png</iconset>
-      </attribute>
-      <attribute name="title">
-       <string/>
-      </attribute>
-      <layout class="QVBoxLayout" name="tab_tasks_layout">
-       <property name="spacing">
-        <number>0</number>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="button_show_settings">
+       <property name="text">
+        <string>...</string>
        </property>
-       <property name="leftMargin">
-        <number>0</number>
+       <property name="icon">
+        <iconset resource="resources.qrc">
+         <normaloff>:/icons/settings.png</normaloff>:/icons/settings.png</iconset>
        </property>
-       <property name="topMargin">
-        <number>0</number>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
-       <property name="rightMargin">
-        <number>0</number>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-       <property name="bottomMargin">
-        <number>0</number>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-       <item>
-        <layout class="QHBoxLayout" name="tasks_view_label_layout">
-         <property name="spacing">
-          <number>6</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="tasks_view_label">
-           <property name="text">
-            <string>Task Tree</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="button_show_stage_dock_widget">
-           <property name="maximumSize">
-            <size>
-             <width>18</width>
-             <height>18</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="icon">
-            <iconset resource="resources.qrc">
-             <normaloff>:/icons/new-stage.png</normaloff>:/icons/new-stage.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QSplitter" name="splitter">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <widget class="moveit_rviz_plugin::TaskListView" name="tasks_view">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-            <horstretch>2</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="contextMenuPolicy">
-           <enum>Qt::ActionsContextMenu</enum>
-          </property>
-          <attribute name="headerStretchLastSection">
-           <bool>false</bool>
-          </attribute>
-         </widget>
-         <widget class="moveit_rviz_plugin::AutoAdjustingTreeView" name="solutions_view">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="selectionMode">
-           <enum>QAbstractItemView::ExtendedSelection</enum>
-          </property>
-          <property name="rootIsDecorated">
-           <bool>false</bool>
-          </property>
-          <property name="uniformRowHeights">
-           <bool>true</bool>
-          </property>
-          <property name="sortingEnabled">
-           <bool>true</bool>
-          </property>
-          <attribute name="headerStretchLastSection">
-           <bool>false</bool>
-          </attribute>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_settings">
-      <attribute name="icon">
-       <iconset resource="resources.qrc">
-        <normaloff>:/icons/settings.png</normaloff>:/icons/settings.png</iconset>
-      </attribute>
-      <attribute name="title">
-       <string/>
-      </attribute>
-      <layout class="QVBoxLayout" name="tab_settings_layout">
-       <property name="spacing">
-        <number>0</number>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QToolButton" name="button_show_stage_dock_widget">
+       <property name="text">
+        <string>...</string>
        </property>
-       <property name="leftMargin">
-        <number>0</number>
+       <property name="icon">
+        <iconset resource="resources.qrc">
+         <normaloff>:/icons/new-stage.png</normaloff>:/icons/new-stage.png</iconset>
        </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="settings_view_label">
-         <property name="text">
-          <string>Settings</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="rviz::PropertyTreeWidget" name="settings_view"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
-  <action name="actionRemoveTaskTreeRows">
-   <property name="text">
-    <string>Remove</string>
-   </property>
-   <property name="toolTip">
-    <string>Remove selected rows</string>
-   </property>
-   <property name="shortcut">
-    <string>Del</string>
-   </property>
-   <property name="shortcutContext">
-    <enum>Qt::WidgetShortcut</enum>
-   </property>
-  </action>
-  <action name="actionAddLocalTask">
-   <property name="text">
-    <string>Add task</string>
-   </property>
-  </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>rviz::PropertyTreeWidget</class>
-   <extends>QTreeView</extends>
-   <header location="global">rviz/properties/property_tree_widget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>moveit_rviz_plugin::TaskListView</class>
-   <extends>QTreeView</extends>
-   <header>task_list_model.h</header>
-  </customwidget>
-  <customwidget>
-   <class>moveit_rviz_plugin::AutoAdjustingTreeView</class>
-   <extends>QTreeView</extends>
-   <header>task_list_model.h</header>
-  </customwidget>
- </customwidgets>
  <resources>
   <include location="resources.qrc"/>
  </resources>

--- a/visualization/motion_planning_tasks/src/task_settings.ui
+++ b/visualization/motion_planning_tasks/src/task_settings.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>moveit_rviz_plugin::TaskSettings</class>
+ <widget class="QWidget" name="moveit_rviz_plugin::TaskSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QVBoxLayout" name="tab_settings_layout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="settings_view_label">
+       <property name="text">
+        <string>Settings</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="rviz::PropertyTreeWidget" name="settings_view"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>rviz::PropertyTreeWidget</class>
+   <extends>QTreeView</extends>
+   <header location="global">rviz/properties/property_tree_widget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/visualization/motion_planning_tasks/src/task_view.ui
+++ b/visualization/motion_planning_tasks/src/task_view.ui
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>moveit_rviz_plugin::TaskView</class>
+ <widget class="QWidget" name="moveit_rviz_plugin::TaskView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Tasks Panel</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="tasks_property_splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="QWidget" name="">
+      <layout class="QVBoxLayout" name="verticalLayout1">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="tasks_view_label">
+         <property name="text">
+          <string>Task Tree</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSplitter" name="tasks_solutions_splitter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <widget class="moveit_rviz_plugin::TaskListView" name="tasks_view">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>2</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="contextMenuPolicy">
+           <enum>Qt::ActionsContextMenu</enum>
+          </property>
+          <attribute name="headerStretchLastSection">
+           <bool>false</bool>
+          </attribute>
+         </widget>
+         <widget class="moveit_rviz_plugin::AutoAdjustingTreeView" name="solutions_view">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+          <property name="rootIsDecorated">
+           <bool>false</bool>
+          </property>
+          <property name="uniformRowHeights">
+           <bool>true</bool>
+          </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
+          </property>
+          <attribute name="headerStretchLastSection">
+           <bool>false</bool>
+          </attribute>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <layout class="QVBoxLayout" name="verticalLayout2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="property_view_label">
+         <property name="text">
+          <string>Properties</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="rviz::PropertyTreeWidget" name="property_view"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+  <action name="actionRemoveTaskTreeRows">
+   <property name="text">
+    <string>Remove</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove selected rows</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetShortcut</enum>
+   </property>
+  </action>
+  <action name="actionAddLocalTask">
+   <property name="text">
+    <string>Add task</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>moveit_rviz_plugin::TaskListView</class>
+   <extends>QTreeView</extends>
+   <header>task_list_model.h</header>
+  </customwidget>
+  <customwidget>
+   <class>moveit_rviz_plugin::AutoAdjustingTreeView</class>
+   <extends>QTreeView</extends>
+   <header>task_list_model.h</header>
+  </customwidget>
+  <customwidget>
+   <class>rviz::PropertyTreeWidget</class>
+   <extends>QTreeView</extends>
+   <header location="global">rviz/properties/property_tree_widget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
**This is work in progress and not intended for merging!**
**This branch maybe subject to rebases.**
This PR is only for your information. It adds the following features:
- Further modularize stages, avoiding duplication of planning code
- Replace one-fits-all module "Gripper" that was modifying planning scene, planning robot motion, etc.
- provide parallel containers

new stages:
- MoveTo + MoveRelative as planning stages, accepting joint-space + Cartesian space targets
- Connect, replacing old Move, allowing for planning between joint states stored in Interface states
- These planning stages are driven by instances of PlannerInterface providing the actual planning capability. Currently MoveIt's planning pipeline and computeCartesianPath are provided.
- ModifyPlanningScene to attach objects, enable/disable collision pairs
- FixCollisionObjects to fix (initial) collisions of objects via small motions (untested)
- Alternatives + Fallbacks: parallel containers
