### PR TITLE
pick: reusable stage for picking up an object

### DIFF
--- a/core/demo/plan_pick_pa10.cpp
+++ b/core/demo/plan_pick_pa10.cpp
@@ -91,7 +91,7 @@ int main(int argc, char** argv){
 	{
 		auto gengrasp = std::make_unique<stages::GenerateGraspPose>("generate grasp pose");
 		gengrasp->properties().configureInitFrom(Stage::PARENT);
-		gengrasp->setGripperGraspPose("open");
+		gengrasp->setNamedPose("open");
 		gengrasp->setObject("object");
 		gengrasp->setToolToGraspTF(Eigen::Translation3d(0,0,.05)*
 		                           Eigen::AngleAxisd(-0.5*M_PI, Eigen::Vector3d::UnitY()),

--- a/core/demo/plan_pick_trixi.cpp
+++ b/core/demo/plan_pick_trixi.cpp
@@ -1,11 +1,8 @@
 #include <moveit/task_constructor/task.h>
 
 #include <moveit/task_constructor/stages/current_state.h>
-#include <moveit/task_constructor/stages/gripper.h>
-#include <moveit/task_constructor/stages/move.h>
-#include <moveit/task_constructor/stages/generate_grasp_pose.h>
-#include <moveit/task_constructor/stages/cartesian_position_motion.h>
-#include <moveit/task_constructor/stages/compute_ik.h>
+#include <moveit/task_constructor/stages/simple_grasp.h>
+#include <moveit/task_constructor/stages/pick.h>
 
 #include <ros/ros.h>
 #include <moveit_msgs/CollisionObject.h>
@@ -42,73 +39,29 @@ int main(int argc, char** argv){
 	spawnObject();
 
 	Task t;
+	t.setProperty("eef", std::string("left_gripper"));
+	t.setProperty("object", std::string("object"));
 
-	t.add( std::make_unique<stages::CurrentState>("current state") );
+	t.add(std::make_unique<stages::CurrentState>("current state"));
 
-	{
-		auto move= std::make_unique<stages::Gripper>("open gripper");
-		move->setEndEffector("left_gripper");
-		move->setTo("open");
-		t.add(std::move(move));
-	}
+	auto grasp_generator = std::make_unique<stages::SimpleGrasp>();
+	grasp_generator->setToolToGraspTF(Eigen::Affine3d::Identity(), "l_gripper_tool_frame");
+	grasp_generator->setAngleDelta(.2);
+	grasp_generator->setPreGraspPose("open");
+	grasp_generator->setPreGraspPose("close");
 
-	{
-		auto move= std::make_unique<stages::Move>("move to pre-grasp");
-		move->setGroup("left_arm");
-		move->setPlannerId("RRTConnectkConfigDefault");
-		move->setTimeout(8.0);
-		t.add(std::move(move));
-	}
+	auto pick = std::make_unique<stages::Pick>(std::move(grasp_generator));
+	geometry_msgs::TwistStamped approach;
+	approach.header.frame_id = "object";
+	approach.twist.linear.x = 1.0;
+	pick->setApproachMotion(approach, 0.03, 0.1);
 
-	{
-		auto move= std::make_unique<stages::CartesianPositionMotion>("proceed to grasp pose");
-		move->addSolutionCallback(std::bind(&Introspection::publishSolution, &t.introspection(), std::placeholders::_1));
-		move->setGroup("left_arm");
-		move->setLink("l_gripper_tool_frame");
-		move->setMinMaxDistance(.03, 0.1);
-		move->setCartesianStepSize(0.02);
+	geometry_msgs::TwistStamped lift;
+	lift.header.frame_id = "base_link";
+	lift.twist.linear.z = 1.0;
+	pick->setLiftMotion(lift, 0.03, 0.05);
 
-		geometry_msgs::PointStamped target;
-		target.header.frame_id= "object";
-		move->towards(target);
-		t.add(std::move(move));
-	}
-
-	{
-		auto gengrasp= std::make_unique<stages::GenerateGraspPose>("generate grasp pose");
-		gengrasp->setEndEffector("left_gripper");
-		gengrasp->setGripperGraspPose("open");
-		gengrasp->setObject("object");
-		gengrasp->setToolToGraspTF(Eigen::Affine3d::Identity(), "l_gripper_tool_frame");
-		gengrasp->setAngleDelta(.2);
-
-		auto ik = std::make_unique<stages::ComputeIK>("compute ik", std::move(gengrasp));
-		ik->setEndEffector("left_gripper");
-		t.add(std::move(ik));
-	}
-
-	{
-		auto move= std::make_unique<stages::Gripper>("grasp");
-		move->setEndEffector("left_gripper");
-		move->setAttachLink("l_gripper_tool_frame");
-		move->setTo("closed");
-		move->graspObject("object");
-		t.add(std::move(move));
-	}
-
-	{
-		auto move= std::make_unique<stages::CartesianPositionMotion>("lift object");
-		move->setGroup("left_arm");
-		move->setLink("l_gripper_tool_frame");
-		move->setMinMaxDistance(0.03, 0.05);
-		move->setCartesianStepSize(0.01);
-
-		geometry_msgs::Vector3Stamped direction;
-		direction.header.frame_id= "base_link";
-		direction.vector.z= 1.0;
-		move->along(direction);
-		t.add(std::move(move));
-	}
+	t.add(std::move(pick));
 
 	try {
 		t.plan();

--- a/core/demo/plan_pick_ur5.cpp
+++ b/core/demo/plan_pick_ur5.cpp
@@ -78,7 +78,7 @@ int main(int argc, char** argv){
 	{
 		auto gengrasp = std::make_unique<stages::GenerateGraspPose>("generate grasp pose");
 		gengrasp->properties().configureInitFrom(Stage::PARENT);
-		gengrasp->setGripperGraspPose("open");
+		gengrasp->setNamedPose("open");
 		gengrasp->setObject("object");
 		gengrasp->setToolToGraspTF(Eigen::Translation3d(.03,0,0), "s_model_tool0");
 		gengrasp->setAngleDelta(-.2);

--- a/core/include/moveit/task_constructor/stages/modify_planning_scene.h
+++ b/core/include/moveit/task_constructor/stages/modify_planning_scene.h
@@ -60,7 +60,7 @@ namespace moveit { namespace task_constructor { namespace stages {
 class ModifyPlanningScene : public PropagatingEitherWay {
 public:
 	typedef std::vector<std::string> Names;
-	typedef std::function<void(planning_scene::PlanningScenePtr scene, PropertyMap& properties)> ApplyCallback;
+	typedef std::function<void(const planning_scene::PlanningScenePtr& scene, const PropertyMap& properties)> ApplyCallback;
 	ModifyPlanningScene(const std::string& name = "modify planning scene");
 
 	bool computeForward(const InterfaceState& from) override;

--- a/core/include/moveit/task_constructor/stages/pick.h
+++ b/core/include/moveit/task_constructor/stages/pick.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2017, Hamburg University
+ *  Copyright (c) 2018, Bielefeld University
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,42 +32,48 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Authors: Michael Goerner
-   Desc:    Generator Stage for simple grasp poses
-*/
+/* Authors: Robert Haschke */
 
 #pragma once
 
-#include <moveit/task_constructor/stage.h>
-#include <geometry_msgs/TransformStamped.h>
-#include <Eigen/Geometry>
+#include <moveit/task_constructor/container.h>
+#include <geometry_msgs/TwistStamped.h>
 
 namespace moveit { namespace task_constructor { namespace stages {
 
-class GenerateGraspPose : public Generator {
+/** Pick wraps a complete pipeline to pick up an object with a given end effector.
+ *
+ * Picking consist of the following sub stages:
+ * - reaching to the object + "pre-grasp" end effector posture
+ * - linearly approaching the object along an approach direction/twist
+ * - "grasp" end effector posture
+ * - attach object
+ * - lift along along a given direction/twist
+ *
+ * The end effector postures corresponding to pre-grasp and grasp as well as
+ * the end effector's Cartesian pose needs to be provided by an external grasp stage.
+ */
+class Pick : public SerialContainer {
+	Stage* grasp_stage_ = nullptr;
+	Stage* approach_stage_ = nullptr;
+	Stage* lift_stage_ = nullptr;
+
 public:
-	GenerateGraspPose(std::string name);
+	Pick(Stage::pointer &&grasp_stage, const std::string& name = "pick");
 
-	void init(const planning_scene::PlanningSceneConstPtr& scene) override;
-	bool canCompute() const override;
-	bool compute() override;
+	void init(const planning_scene::PlanningSceneConstPtr &scene);
 
-	void setEndEffector(const std::string &eef);
-	void setNamedPose(const std::string &pose_name);
-	void setObject(const std::string &object);
-
-	void setToolToGraspTF(const geometry_msgs::TransformStamped &transform);
-	void setToolToGraspTF(const Eigen::Affine3d& transform, const std::string& link = "");
-	template <typename T>
-	void setToolToGraspTF(const T& t, const std::string& link = "") {
-		Eigen::Affine3d transform; transform = t;
-		setToolToGraspTF(transform, link);
+	void setEndEffector(const std::string& eef) {
+		properties().set<std::string>("eef", eef);
 	}
-	void setAngleDelta(double delta);
+	void setObject(const std::string& object) {
+		properties().set<std::string>("object", object);
+	}
 
-protected:
-	planning_scene::PlanningScenePtr scene_;
-	double current_angle_ = 0.0;
+	void setApproachMotion(const geometry_msgs::TwistStamped& motion,
+	                       double min_distance, double max_distance);
+	void setLiftMotion(const geometry_msgs::TwistStamped& motion,
+	                   double min_distance, double max_distance);
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/simple_grasp.h
+++ b/core/include/moveit/task_constructor/stages/simple_grasp.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2017, Hamburg University
+ *  Copyright (c) 2018, Bielefeld University
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -32,42 +32,66 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Authors: Michael Goerner
-   Desc:    Generator Stage for simple grasp poses
-*/
+/* Authors: Robert Haschke */
 
 #pragma once
 
-#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/container.h>
+#include <moveit/macros/class_forward.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <Eigen/Geometry>
 
+namespace moveit { namespace core { MOVEIT_CLASS_FORWARD(RobotModel) } }
 namespace moveit { namespace task_constructor { namespace stages {
 
-class GenerateGraspPose : public Generator {
+/** Simple Grasp Stage
+ *
+ * Given a named pre-grasp and grasp posture the stage generates
+ * fully-qualified pre-grasp and grasp robot states, connected
+ * by a grasping trajectory of the end-effector.
+ */
+class SimpleGrasp : public SerialContainer {
+	moveit::core::RobotModelConstPtr model_;
+
 public:
-	GenerateGraspPose(std::string name);
+	SimpleGrasp(const std::string& name = "grasp");
 
-	void init(const planning_scene::PlanningSceneConstPtr& scene) override;
-	bool canCompute() const override;
-	bool compute() override;
+	void init(const planning_scene::PlanningSceneConstPtr &scene);
 
-	void setEndEffector(const std::string &eef);
-	void setNamedPose(const std::string &pose_name);
-	void setObject(const std::string &object);
+	void setEndEffector(const std::string& eef) {
+		properties().set<std::string>("eef", eef);
+	}
+	void setObject(const std::string& object) {
+		properties().set<std::string>("object", object);
+	}
 
-	void setToolToGraspTF(const geometry_msgs::TransformStamped &transform);
+	void setPreGraspPose(const std::string& pregrasp) {
+		properties().set<std::string>("pregrasp", pregrasp);
+	}
+	void setGraspPose(const std::string& grasp) {
+		properties().set<std::string>("grasp", grasp);
+	}
+
+	void setToolToGraspTF(const geometry_msgs::TransformStamped &transform) {
+		properties().set("tool_to_grasp_tf", transform);
+	}
 	void setToolToGraspTF(const Eigen::Affine3d& transform, const std::string& link = "");
 	template <typename T>
 	void setToolToGraspTF(const T& t, const std::string& link = "") {
 		Eigen::Affine3d transform; transform = t;
 		setToolToGraspTF(transform, link);
 	}
-	void setAngleDelta(double delta);
 
-protected:
-	planning_scene::PlanningScenePtr scene_;
-	double current_angle_ = 0.0;
+	void setAngleDelta(double angle_delta) {
+		properties().set("angle_delta", angle_delta);
+	}
+
+	void setMaxIKSolutions(uint32_t max_ik_solutions) {
+		properties().set("max_ik_solutions", max_ik_solutions);
+	}
+	void setTimeout(double timeout) {
+		properties().set("timeout", timeout);
+	}
 };
 
 } } }

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -10,6 +10,9 @@ add_library(${PROJECT_NAME}_stages
 	${PROJECT_INCLUDE}/stages/move_to.h
 	${PROJECT_INCLUDE}/stages/move_relative.h
 
+	${PROJECT_INCLUDE}/stages/simple_grasp.h
+	${PROJECT_INCLUDE}/stages/pick.h
+
 	${PROJECT_INCLUDE}/stages/cartesian_position_motion.h
 	${PROJECT_INCLUDE}/stages/gripper.h
 	${PROJECT_INCLUDE}/stages/move.h
@@ -24,6 +27,9 @@ add_library(${PROJECT_NAME}_stages
 	connect.cpp
 	move_to.cpp
 	move_relative.cpp
+
+	simple_grasp.cpp
+	pick.cpp
 
 	cartesian_position_motion.cpp
 	gripper.cpp

--- a/core/src/stages/pick.cpp
+++ b/core/src/stages/pick.cpp
@@ -1,0 +1,122 @@
+#include <moveit/task_constructor/stages/pick.h>
+
+#include <moveit/task_constructor/solvers/cartesian_path.h>
+#include <moveit/task_constructor/solvers/pipeline_planner.h>
+
+#include <moveit/task_constructor/container.h>
+#include <moveit/task_constructor/stages/move_to.h>
+#include <moveit/task_constructor/stages/move_relative.h>
+#include <moveit/task_constructor/stages/connect.h>
+#include <moveit/task_constructor/stages/modify_planning_scene.h>
+
+#include <moveit/planning_scene/planning_scene.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+Pick::Pick(Stage::pointer&& grasp_stage, const std::string& name)
+   : SerialContainer(name)
+{
+	PropertyMap* p = &properties();
+	// propagate properties from children
+	p->declare<std::string>("eef", "end effector name");
+	p->declare<std::string>("object", "name of object to grasp");
+	p->configureInitFrom(Stage::PARENT, { "eef", "object" });
+
+	p->declare<std::string>("eef_group", "internal");
+	p->declare<std::string>("eef_parent_group", "internal");
+
+	auto cartesian = std::make_shared<solvers::CartesianPath>();
+	auto pipeline = std::make_shared<solvers::PipelinePlanner>();
+	pipeline->setTimeout(8.0);
+	pipeline->setPlannerId("RRTConnectkConfigDefault");
+
+	{
+		auto move = std::make_unique<MoveTo>("open gripper", pipeline);
+		move->restrictDirection(MoveTo::FORWARD);
+		p = &move->properties();
+		p->property("group").configureInitFrom(Stage::PARENT, "eef_group");
+		move->setGoal("open");  // TODO: retrieve from grasp stage
+		insert(std::move(move));
+	}
+
+	{
+		auto move = std::make_unique<Connect>("move to object", pipeline);
+		p = &move->properties();
+		p->property("group").configureInitFrom(Stage::PARENT, "eef_parent_group");
+		insert(std::move(move));
+	}
+
+	{
+		auto approach = std::make_unique<MoveRelative>("approach object", cartesian);
+		approach->restrictDirection(MoveRelative::BACKWARD);
+		p = &approach->properties();
+		p->property("group").configureInitFrom(Stage::PARENT, "eef_parent_group");
+		p->set("marker_ns", std::string("approach"));
+		approach_stage_ = approach.get();
+		insert(std::move(approach));
+	}
+
+	grasp_stage_ = grasp_stage.get();
+	insert(std::move(grasp_stage));
+
+	{
+		auto attach = std::make_unique<ModifyPlanningScene>("attach object");
+		p = &attach->properties();
+		p->configureInitFrom(Stage::PARENT, { "eef", "object" });
+		attach->restrictDirection(ModifyPlanningScene::FORWARD);
+
+		attach->setCallback([this](const planning_scene::PlanningScenePtr& scene, const PropertyMap& p){
+			const std::string& eef = p.get<std::string>("eef");
+			moveit_msgs::AttachedCollisionObject obj;
+			obj.object.operation = moveit_msgs::CollisionObject::ADD;
+			obj.link_name = scene->getRobotModel()->getEndEffector(eef)->getEndEffectorParentGroup().second;
+			obj.object.id = p.get<std::string>("object");
+			scene->processAttachedCollisionObjectMsg(obj);
+		});
+		insert(std::move(attach));
+	}
+
+	{
+		auto lift = std::make_unique<MoveRelative>("lift object", cartesian);
+		lift->restrictDirection(MoveRelative::FORWARD);
+		p = &lift->properties();
+		p->property("group").configureInitFrom(Stage::PARENT, "eef_parent_group");
+		p->set("marker_ns", std::string("lift"));
+		lift_stage_ = lift.get();
+		insert(std::move(lift));
+	}
+}
+
+void Pick::init(const planning_scene::PlanningSceneConstPtr& scene)
+{
+	// inherit properties from parent
+	PropertyMap* p = &properties();
+	p->performInitFrom(Stage::PARENT, parent()->properties());
+
+	// init internal properties
+	const std::string &eef = p->get<std::string>("eef");
+	const moveit::core::JointModelGroup *jmg = scene->getRobotModel()->getEndEffector(eef);
+	p->set<std::string>("eef_group", jmg->getName());
+	p->set<std::string>("eef_parent_group", jmg->getEndEffectorParentGroup().first);
+
+	// propagate my properties to children (and do standard init)
+	SerialContainer::init(scene);
+}
+
+void Pick::setApproachMotion(const geometry_msgs::TwistStamped& motion, double min_distance, double max_distance)
+{
+	auto& p = approach_stage_->properties();
+	p.set("twist", motion);
+	p.set("min_distance", min_distance);
+	p.set("max_distance", max_distance);
+}
+
+void Pick::setLiftMotion(const geometry_msgs::TwistStamped& motion, double min_distance, double max_distance)
+{
+	auto& p = lift_stage_->properties();
+	p.set("twist", motion);
+	p.set("min_distance", min_distance);
+	p.set("max_distance", max_distance);
+}
+
+} } }

--- a/core/src/stages/simple_grasp.cpp
+++ b/core/src/stages/simple_grasp.cpp
@@ -1,0 +1,130 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke */
+
+#include <moveit/task_constructor/stages/simple_grasp.h>
+
+#include <moveit/task_constructor/stages/generate_grasp_pose.h>
+#include <moveit/task_constructor/stages/compute_ik.h>
+#include <moveit/task_constructor/stages/modify_planning_scene.h>
+#include <moveit/task_constructor/stages/move_to.h>
+#include <moveit/task_constructor/solvers/pipeline_planner.h>
+
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <Eigen/Geometry>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+SimpleGrasp::SimpleGrasp(const std::string& name)
+   : SerialContainer(name)
+{
+	PropertyMap* p = &properties();
+	// propagate properties from children
+	p->declare<std::string>("eef", "end effector name");
+	p->declare<std::string>("object", "name of object to grasp");
+	p->configureInitFrom(Stage::PARENT, { "eef", "object" });
+
+	p->declare<std::string>("pregrasp", "pre-grasp pose of eef");
+	p->declare<std::string>("grasp", "grasp pose of eef");
+
+	p->declare<geometry_msgs::TransformStamped>("tool_to_grasp_tf", geometry_msgs::TransformStamped(),
+	                                            "transform from robot tool frame to grasp frame");
+	p->declare<double>("angle_delta", 0.1, "angular steps (rad)");
+
+	p->declare<uint32_t>("max_ik_solutions", 1);
+	p->declare<double>("timeout", 1.0);
+
+	{
+		auto gengrasp = std::make_unique<GenerateGraspPose>("generate grasp pose");
+		p = &gengrasp->properties();
+		const std::initializer_list<std::string>& grasp_prop_names = { "eef", "pregrasp", "object", "angle_delta" };
+		p->configureInitFrom(Stage::PARENT, grasp_prop_names);
+
+		auto ik = std::make_unique<ComputeIK>("compute ik", std::move(gengrasp));
+		p = &ik->properties();
+		p->configureInitFrom(Stage::PARENT, grasp_prop_names);
+		p->configureInitFrom(Stage::PARENT, { "max_ik_solutions", "timeout" });
+		insert(std::move(ik));
+	}
+	{
+		auto allow_touch = std::make_unique<ModifyPlanningScene>("enable object collision");
+		p = &allow_touch->properties();
+		p->configureInitFrom(Stage::PARENT, { "eef", "object" });
+		allow_touch->restrictDirection(ModifyPlanningScene::FORWARD);
+
+		allow_touch->setCallback([this](const planning_scene::PlanningScenePtr& scene, const PropertyMap& p){
+			collision_detection::AllowedCollisionMatrix& acm = scene->getAllowedCollisionMatrixNonConst();
+			const std::string& eef = p.get<std::string>("eef");
+			const std::string& object = p.get<std::string>("object");
+			acm.setEntry(object, scene->getRobotModel()->getEndEffector(eef)
+			             ->getLinkModelNamesWithCollisionGeometry(), true);
+		});
+		insert(std::move(allow_touch));
+	}
+	{
+		auto pipeline = std::make_shared<solvers::PipelinePlanner>();
+		pipeline->setTimeout(8.0);
+		pipeline->setPlannerId("RRTConnectkConfigDefault");
+
+		auto move = std::make_unique<MoveTo>("close gripper", pipeline);
+		move->restrictDirection(MoveTo::FORWARD);
+		p = &move->properties();
+		p->property("joint_pose").configureInitFrom(Stage::PARENT, "grasp");
+		p->property("group").configureInitFrom(Stage::PARENT, [this](const PropertyMap& parent_map){
+			const std::string& eef = parent_map.get<std::string>("eef");
+			const moveit::core::JointModelGroup* jmg = model_->getEndEffector(eef);
+			return boost::any(jmg->getName());
+		});
+		insert(std::move(move));
+	}
+}
+
+void SimpleGrasp::init(const planning_scene::PlanningSceneConstPtr& scene)
+{
+	model_ = scene->getRobotModel();
+	SerialContainer::init(scene);
+}
+
+void SimpleGrasp::setToolToGraspTF(const Eigen::Affine3d& transform, const std::string& link) {
+	geometry_msgs::TransformStamped stamped;
+	stamped.header.frame_id = link;
+	stamped.child_frame_id = "grasp_frame";
+	tf::transformEigenToMsg(transform, stamped.transform);
+	setToolToGraspTF(stamped);
+}
+
+} } }


### PR DESCRIPTION
Implementation of a pick container. Example in trixi. but not yet working. Suffers from some missing configuration(s) for property forwarding - as @v4hn asked for making it all explicit ;-)

To assist the user in spotting these miss-configurations, I suggest - in case of property exceptions (we need a new exception type for this) - to climb the property tree and check where and why the definition is missing. Doing this manually is a nightmare.