### PR TITLE
add a simple GeneratePose stage

### DIFF
--- a/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
@@ -38,16 +38,15 @@
 
 #pragma once
 
-#include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/stages/generate_pose.h>
 
 namespace moveit { namespace task_constructor { namespace stages {
 
-class GenerateGraspPose : public MonitoringGenerator {
+class GenerateGraspPose : public GeneratePose {
 public:
 	GenerateGraspPose(const std::string& name);
 
-	void reset() override;
-	bool canCompute() const override;
+	void init(const core::RobotModelConstPtr &robot_model) override;
 	bool compute() override;
 
 	void setEndEffector(const std::string &eef);
@@ -57,10 +56,6 @@ public:
 
 protected:
 	void onNewSolution(const SolutionBase& s) override;
-
-protected:
-	planning_scene::PlanningScenePtr scene_;
-	double current_angle_ = 0.0;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/generate_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_pose.h
@@ -47,6 +47,7 @@ class GeneratePose : public MonitoringGenerator {
 public:
 	GeneratePose(const std::string& name);
 
+	void reset() override;
 	bool canCompute() const override;
 	bool compute() override;
 
@@ -57,7 +58,7 @@ public:
 protected:
 	void onNewSolution(const SolutionBase& s) override;
 
-	std::deque<planning_scene::PlanningSceneConstPtr> scenes_;
+	std::deque<planning_scene::PlanningScenePtr> scenes_;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/generate_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_pose.h
@@ -1,0 +1,63 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018, Hamburg University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Michael Goerner
+   Desc:    Generator Stage for poses
+*/
+
+#pragma once
+
+#include <moveit/task_constructor/stage.h>
+#include <geometry_msgs/PoseStamped.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+class GeneratePose : public MonitoringGenerator {
+public:
+	GeneratePose(const std::string& name);
+
+	bool canCompute() const override;
+	bool compute() override;
+
+	void setPose(const geometry_msgs::PoseStamped pose){
+		setProperty("pose", std::move(pose));
+	}
+
+protected:
+	void onNewSolution(const SolutionBase& s) override;
+
+	std::deque<planning_scene::PlanningSceneConstPtr> scenes_;
+};
+
+} } }

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${PROJECT_NAME}_stages
 	${PROJECT_INCLUDE}/stages/current_state.h
 	${PROJECT_INCLUDE}/stages/fixed_state.h
 	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
+	${PROJECT_INCLUDE}/stages/generate_pose.h
 	${PROJECT_INCLUDE}/stages/compute_ik.h
 
 	${PROJECT_INCLUDE}/stages/connect.h
@@ -24,6 +25,7 @@ add_library(${PROJECT_NAME}_stages
 	current_state.cpp
 	fixed_state.cpp
 	generate_grasp_pose.cpp
+	generate_pose.cpp
 	compute_ik.cpp
 
 	connect.cpp

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(${PROJECT_NAME}_stages
 
 	${PROJECT_INCLUDE}/stages/current_state.h
 	${PROJECT_INCLUDE}/stages/fixed_state.h
-	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
 	${PROJECT_INCLUDE}/stages/generate_pose.h
+	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
 	${PROJECT_INCLUDE}/stages/compute_ik.h
 
 	${PROJECT_INCLUDE}/stages/connect.h

--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -112,6 +112,12 @@ void GenerateGraspPose::onNewSolution(const SolutionBase& s)
 	robot_state::RobotState &robot_state = scene->getCurrentStateNonConst();
 	robot_state.setToDefaultValues(jmg , props.get<std::string>("pregrasp"));
 
+	const std::string& object_name = props.get<std::string>("object");
+	if (!scene->knowsFrameTransform(object_name)) {
+		ROS_WARN_STREAM_NAMED("GenerateGraspPose", "unknown object: " << object_name);
+		return;
+	}
+
 	scenes_.push_back(scene);
 }
 
@@ -122,12 +128,9 @@ bool GenerateGraspPose::compute() {
 	scenes_.pop_front();
 
 	const auto& props = properties();
-	const std::string& object_name = props.get<std::string>("object");
-	if (!scene->knowsFrameTransform(object_name))
-		throw std::runtime_error("unknown object: " + object_name);
 
 	geometry_msgs::PoseStamped target_pose_msg;
-	target_pose_msg.header.frame_id = object_name;
+	target_pose_msg.header.frame_id = props.get<std::string>("object");
 
 	double current_angle_ = 0.0;
 	while (current_angle_ < 2.*M_PI && current_angle_ > -2.*M_PI) {

--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -47,7 +47,7 @@
 namespace moveit { namespace task_constructor { namespace stages {
 
 GenerateGraspPose::GenerateGraspPose(const std::string& name)
-   : MonitoringGenerator(name)
+   : GeneratePose(name)
 {
 	auto& p = properties();
 	p.declare<std::string>("eef", "name of end-effector");
@@ -56,15 +56,15 @@ GenerateGraspPose::GenerateGraspPose(const std::string& name)
 	p.declare<double>("angle_delta", 0.1, "angular steps (rad)");
 }
 
-void GenerateGraspPose::setEndEffector(const std::string &eef){
+void GenerateGraspPose::setEndEffector(const std::string &eef) {
 	setProperty("eef", eef);
 }
 
-void GenerateGraspPose::setNamedPose(const std::string &pose_name){
+void GenerateGraspPose::setNamedPose(const std::string &pose_name) {
 	setProperty("pregrasp", pose_name);
 }
 
-void GenerateGraspPose::setObject(const std::string &object){
+void GenerateGraspPose::setObject(const std::string &object) {
 	setProperty("object", object);
 }
 
@@ -72,50 +72,70 @@ void GenerateGraspPose::setAngleDelta(double delta){
 	setProperty("angle_delta", delta);
 }
 
-void GenerateGraspPose::reset()
+void GenerateGraspPose::init(const core::RobotModelConstPtr& robot_model)
 {
-	scene_.reset();
-	current_angle_ = 0.0;
-	MonitoringGenerator::reset();
+	InitStageException errors;
+	try { GeneratePose::init(robot_model); }
+	catch (InitStageException &e) { errors.append(e); }
+
+	const auto& props = properties();
+
+	// check angle_delta
+	if (props.get<double>("angle_delta") == 0.)
+		errors.push_back(*this, "angle_delta must be non-zero");
+
+	// check availability of eef
+	const std::string& eef = props.get<std::string>("eef");
+	if (!robot_model->hasEndEffector(eef))
+		errors.push_back(*this, "unknown end effector: " + eef);
+	else {
+		// check availability of eef pose
+		const moveit::core::JointModelGroup* jmg = robot_model->getEndEffector(eef);
+		const std::string& name = props.get<std::string>("pregrasp");
+		std::map<std::string, double> m;
+		if (!jmg->getVariableDefaultPositions(name, m))
+			errors.push_back(*this, "unknown end effector pose: " + name);
+	}
+
+	if (errors) throw errors;
 }
 
 void GenerateGraspPose::onNewSolution(const SolutionBase& s)
 {
-	if (scene_)
-		ROS_WARN_NAMED("GenerateGraspPose", "got additional solution from monitored stage");
-	scene_ = s.end()->scene()->diff();
-}
+	planning_scene::PlanningScenePtr scene = s.end()->scene()->diff();
 
-bool GenerateGraspPose::canCompute() const{
-	return scene_ && current_angle_ < 2*M_PI && current_angle_ > -2*M_PI;
-}
-
-bool GenerateGraspPose::compute(){
+	// set end effector pose
 	const auto& props = properties();
 	const std::string& eef = props.get<std::string>("eef");
+	const moveit::core::JointModelGroup* jmg = scene->getRobotModel()->getEndEffector(eef);
 
-	assert(scene_->getRobotModel()->hasEndEffector(eef) && "The specified end effector is not defined in the srdf");
-	const moveit::core::JointModelGroup* jmg = scene_->getRobotModel()->getEndEffector(eef);
+	robot_state::RobotState &robot_state = scene->getCurrentStateNonConst();
+	robot_state.setToDefaultValues(jmg , props.get<std::string>("pregrasp"));
 
-	robot_state::RobotState &robot_state = scene_->getCurrentStateNonConst();
-	const std::string& joint_pose = props.get<std::string>("pregrasp");
-	if(!joint_pose.empty()){
-		robot_state.setToDefaultValues(jmg , joint_pose);
-	}
+	scenes_.push_back(scene);
+}
 
+bool GenerateGraspPose::compute() {
+	if (scenes_.empty())
+		return false;
+	planning_scene::PlanningSceneConstPtr scene = scenes_[0];
+	scenes_.pop_front();
+
+	const auto& props = properties();
 	const std::string& object_name = props.get<std::string>("object");
-	if (!scene_->knowsFrameTransform(object_name))
-		throw std::runtime_error("requested object does not exist or could not be retrieved");
+	if (!scene->knowsFrameTransform(object_name))
+		throw std::runtime_error("unknown object: " + object_name);
 
 	geometry_msgs::PoseStamped target_pose_msg;
 	target_pose_msg.header.frame_id = object_name;
 
-	while( canCompute() ) {
+	double current_angle_ = 0.0;
+	while (current_angle_ < 2.*M_PI && current_angle_ > -2.*M_PI) {
 		// rotate object pose about z-axis
 		Eigen::Affine3d target_pose(Eigen::AngleAxisd(current_angle_, Eigen::Vector3d::UnitZ()));
 		current_angle_ += props.get<double>("angle_delta");
 
-		InterfaceState state(scene_);
+		InterfaceState state(scene);
 		tf::poseEigenToMsg(target_pose, target_pose_msg.pose);
 		state.properties().set("target_pose", target_pose_msg);
 
@@ -127,10 +147,8 @@ bool GenerateGraspPose::compute(){
 		rviz_marker_tools::appendFrame(trajectory.markers(), target_pose_msg, 0.1, "grasp frame");
 
 		spawn(std::move(state), std::move(trajectory));
-		return true;
 	}
-
-	return false;
+	return true;
 }
 
 } } }

--- a/core/src/stages/generate_pose.cpp
+++ b/core/src/stages/generate_pose.cpp
@@ -53,6 +53,12 @@ GeneratePose::GeneratePose(const std::string& name)
 	p.declare<geometry_msgs::PoseStamped>("pose", "target pose to pass on in spawned states");
 }
 
+void GeneratePose::reset()
+{
+	MonitoringGenerator::reset();
+	scenes_.clear();
+}
+
 void GeneratePose::onNewSolution(const SolutionBase& s)
 {
 	scenes_.push_back(s.end()->scene()->diff());

--- a/core/src/stages/generate_pose.cpp
+++ b/core/src/stages/generate_pose.cpp
@@ -1,0 +1,100 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld + Hamburg University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke, Michael Goerner */
+
+#include <moveit/task_constructor/stages/generate_pose.h>
+#include <moveit/task_constructor/storage.h>
+#include <moveit/task_constructor/marker_tools.h>
+#include <rviz_marker_tools/marker_creation.h>
+
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <Eigen/Geometry>
+#include <eigen_conversions/eigen_msg.h>
+
+namespace moveit { namespace task_constructor { namespace stages {
+
+GeneratePose::GeneratePose(const std::string& name)
+   : MonitoringGenerator(name)
+{
+	auto& p = properties();
+	p.declare<geometry_msgs::PoseStamped>("pose", "target pose to pass on in spawned states");
+}
+
+void GeneratePose::onNewSolution(const SolutionBase& s)
+{
+	scenes_.push_back(s.end()->scene()->diff());
+}
+
+bool GeneratePose::canCompute() const {
+	return scenes_.size() > 0;
+}
+
+bool GeneratePose::compute(){
+	const auto& props = properties();
+
+	geometry_msgs::PoseStamped target_pose = props.get<geometry_msgs::PoseStamped>("pose");
+
+	if(scenes_.empty()) throw std::runtime_error("GeneratePose called without checking canCompute.");
+
+	planning_scene::PlanningSceneConstPtr scene = scenes_[0];
+	scenes_.pop_front();
+
+	// take care of frame transforms
+	const std::string& frame = target_pose.header.frame_id;
+	if( !frame.empty() && frame != scene->getPlanningFrame() ){
+		if ( !scene->knowsFrameTransform(frame) )
+			throw std::runtime_error("GeneratePose does not know frame '" + frame + "'");
+
+		Eigen::Affine3d pose;
+		tf::poseMsgToEigen(target_pose.pose, pose);
+		pose = scene->getFrameTransform(target_pose.header.frame_id) * pose;
+		tf::poseEigenToMsg(pose, target_pose.pose);
+		target_pose.header.frame_id = scene->getPlanningFrame();
+	}
+
+	InterfaceState state(scene);
+	state.properties().set("target_pose", target_pose);
+
+	SubTrajectory trajectory;
+	trajectory.setCost(0.0);
+
+	rviz_marker_tools::appendFrame(trajectory.markers(), target_pose, 0.1, "pose frame");
+
+	spawn(std::move(state), std::move(trajectory));
+	return true;
+}
+
+} } }


### PR DESCRIPTION
ComputeIK is a wrapper, so we can't just give it a pose to compute.

This stage is useful to specify link poses relative to planning scenes generated by other stages,
i.e. a generator stage for ``go here at some point after stage X has changed the planning scene''.