### PR TITLE
ComputeIK: fix frame_id abuse

### DIFF
--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -151,9 +151,10 @@ bool GenerateGraspPose::compute(){
 
 		InterfaceState state(scene_);
 		geometry_msgs::PoseStamped goal_pose_msg;
-		goal_pose_msg.header.frame_id = link_name;
+		goal_pose_msg.header.frame_id = scene_->getPlanningFrame();
 		tf::poseEigenToMsg(link_pose, goal_pose_msg.pose);
 		state.properties().set("target_pose", goal_pose_msg);
+		state.properties().set("target_link", link_name);
 
 		SubTrajectory trajectory;
 		trajectory.setCost(0.0);


### PR DESCRIPTION
frame_id was used to specify the robot frame to move to target.
This is just wrong and does not leave the option to specify targets w.r.t. other frames...

Now there is a separate `target_link` property instead.

This patch changes the semantics of the `PoseStamped` message expected by `ComputeIK`,
so maybe your demo code is affected.