### PR TITLE
reworked connect stage

### DIFF
--- a/core/demo/plan_pick_pa10.cpp
+++ b/core/demo/plan_pick_pa10.cpp
@@ -73,16 +73,10 @@ int main(int argc, char** argv){
 		stage->setMaxPenetration(0.1);
 		t.add(std::move(stage));
 	}
-	{
-		auto move = std::make_unique<stages::MoveTo>("open gripper", pipeline);
-		move->restrictDirection(stages::MoveTo::FORWARD);
-		move->properties().property("group").configureInitFrom(Stage::PARENT, "gripper");
-		move->setGoal("open");
-		t.add(std::move(move));
-	}
 
 	{
-		auto move = std::make_unique<stages::Connect>("move to object", pipeline);
+		stages::Connect::GroupPlannerVector planners = {{"left_hand", pipeline}, {"left_arm", pipeline}};
+		auto move = std::make_unique<stages::Connect>("connect", planners);
 		move->properties().configureInitFrom(Stage::PARENT);
 		t.add(std::move(move));
 	}

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -107,14 +107,11 @@ public:
 	size_t numSolutions() const override;
 	void processSolutions(const SolutionProcessor &processor) const override;
 
-	/// container used to represent a serial solution
-	typedef std::vector<const SolutionBase*> solution_container;
-
 protected:
 	/// called by a (direct) child when a new solution becomes available
 	void onNewSolution(const SolutionBase &s) override;
 
-	typedef std::function<void(const solution_container& trace,
+	typedef std::function<void(const SolutionSequence::container_type &trace,
 	                           double trace_accumulated_cost)> SolutionProcessor;
 
 	/// Traverse all solution pathes starting at start and going in given direction dir
@@ -123,7 +120,7 @@ protected:
 	/// the full trace (from start to end, but not including start) and its accumulated costs
 	template<Interface::Direction dir>
 	void traverse(const SolutionBase &start, const SolutionProcessor &cb,
-	              solution_container &trace, double trace_cost = 0);
+	              SolutionSequence::container_type &trace, double trace_cost = 0);
 
 protected:
 	SerialContainer(SerialContainerPrivate* impl);

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -136,27 +136,6 @@ protected:
 };
 PIMPL_FUNCTIONS(ContainerBase)
 
-/** Representation of a single, full solution path of a SerialContainer.
- *
- * A serial solution describes a full solution path through all children
- * of a SerialContainer. This is a vector (of children().size()) of pointers
- * to all solutions of the children. Hence, we don't need to copy those solutions. */
-class SerialSolution : public SolutionBase {
-public:
-	explicit SerialSolution(StagePrivate* creator, SerialContainer::solution_container&& subsolutions, double cost)
-	   : SolutionBase(creator, cost), subsolutions_(subsolutions)
-	{}
-	/// append all subsolutions to solution
-	void fillMessage(moveit_task_constructor_msgs::Solution &msg, Introspection *introspection) const override;
-
-	inline const InterfaceState* internalStart() const { return subsolutions_.front()->start(); }
-	inline const InterfaceState* internalEnd() const { return subsolutions_.back()->end(); }
-
-private:
-	/// series of sub solutions
-	SerialContainer::solution_container subsolutions_;
-};
-
 
 /* A solution of a SerialContainer needs to connect start to end via a full path.
  * The solution of a single child stage is usually disconnected to the container's start or end.
@@ -188,7 +167,7 @@ private:
 	                     InterfaceFlags accepted);
 
 	// set of all solutions
-	ordered<SerialSolution> solutions_;
+	ordered<SolutionSequence> solutions_;
 };
 PIMPL_FUNCTIONS(SerialContainer)
 

--- a/core/include/moveit/task_constructor/merge.h
+++ b/core/include/moveit/task_constructor/merge.h
@@ -46,6 +46,16 @@ namespace moveit { namespace task_constructor {
 /// create a new JointModelGroup comprising all joints of the given groups
 moveit::core::JointModelGroup* merge(const std::vector<const moveit::core::JointModelGroup*>& groups);
 
+/** find duplicate, non-fixed joints
+ *
+ * Merging is only allowed for disjoint joint sets. Fixed joints are tolerated.
+ * Assumes that \e joints is the the union of the joint sets of all \e groups (w/o duplicates).
+ * The list of duplicate joints is returned in \e duplicates and in \e names (as a comma-separated list) */
+bool findDuplicates(const std::vector<const moveit::core::JointModelGroup*>& groups,
+                    std::vector<const moveit::core::JointModel*> joints,
+                    std::vector<const moveit::core::JointModel*>& duplicates,
+                    std::string& names);
+
 /** merge all sub trajectories into a single RobotTrajectory for parallel execution
  *
  * As the RobotTrajectory maintains a pointer to the underlying JointModelGroup

--- a/core/include/moveit/task_constructor/merge.h
+++ b/core/include/moveit/task_constructor/merge.h
@@ -1,0 +1,59 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Luca Lach, Robert Haschke */
+
+#pragma once
+
+#include <moveit/task_constructor/storage.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_trajectory/robot_trajectory.h>
+
+namespace moveit { namespace task_constructor {
+
+
+/// create a new JointModelGroup comprising all joints of the given groups
+moveit::core::JointModelGroup* merge(const std::vector<const moveit::core::JointModelGroup*>& groups);
+
+/** merge all sub trajectories into a single RobotTrajectory for parallel execution
+ *
+ * As the RobotTrajectory maintains a pointer to the underlying JointModelGroup
+ * (to know about the involved joint names), a merged JointModelGroup needs to be passed
+ * or created on the fly. This JMG needs to stay alive during the lifetime of the trajectory.
+ * For now, only the trajectory path is considered. Timings, velocities, etc. are ignored.
+ */
+robot_trajectory::RobotTrajectoryPtr merge(const std::vector<robot_trajectory::RobotTrajectoryPtr>& sub_trajectories,
+                                           core::JointModelGroup*& merged_group);
+
+} }

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -346,10 +346,8 @@ public:
 	void reset() override;
 
 	virtual bool compute(const InterfaceState& from, const InterfaceState& to) = 0;
-	void connect(const InterfaceState& from, const InterfaceState& to,
-	             SubTrajectory&& trajectory);
-	void connect(const InterfaceState& from, const InterfaceState& to,
-	             SubTrajectory&& trajectory, double cost) {
+	void connect(const InterfaceState& from, const InterfaceState& to, SubTrajectory&& trajectory);
+	void connect(const InterfaceState& from, const InterfaceState& to, SubTrajectory&& trajectory, double cost) {
 		trajectory.setCost(cost);
 		connect(from, to, std::move(trajectory));
 	}

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -351,6 +351,8 @@ public:
 		trajectory.setCost(cost);
 		connect(from, to, std::move(trajectory));
 	}
+
+	void newSolution(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 };
 
 } }

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -339,6 +339,9 @@ protected:
 
 class ConnectingPrivate;
 class Connecting : public ComputeBase {
+protected:
+	virtual bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const;
+
 public:
 	PRIVATE_CLASS(Connecting)
 	Connecting(const std::string& name);

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -235,6 +235,10 @@ class ConnectingPrivate : public ComputeBasePrivate {
 			return x.first->priority() + x.second->priority() < y.first->priority() + y.second->priority();
 		}
 	};
+
+	template<Interface::Direction other>
+	inline StatePair make_pair(Interface::const_iterator first, Interface::const_iterator second);
+
 public:
 	inline ConnectingPrivate(Connecting *me, const std::string &name);
 
@@ -247,8 +251,8 @@ public:
 
 private:
 	// get informed when new start or end state becomes available
-	void newStartState(Interface::iterator it, bool updated);
-	void newEndState(Interface::iterator it, bool updated);
+	template<Interface::Direction other>
+	void newState(Interface::iterator it, bool updated);
 
 	// ordered list of pending state pairs
 	ordered<StatePair, StatePairLess> pending;

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -103,7 +103,7 @@ public:
 	inline void setIntrospection(Introspection* introspection) { introspection_ = introspection; }
 	void composePropertyErrorMsg(const std::string& name, std::ostream& os);
 
-	void newSolution(const SolutionBase &current);
+	void newSolution(SolutionBase& current);
 
 protected:
 	Stage* const me_; // associated/owning Stage instance

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -71,7 +71,14 @@ public:
 	void processFailures(const SolutionProcessor &processor) const override { return; }
 
 protected:
+	SolutionBase* storeSequential(const std::vector<robot_trajectory::RobotTrajectoryPtr>& sub_trajectories,
+	                              const std::vector<planning_scene::PlanningScenePtr>& intermediate_scenes);
+	robot_trajectory::RobotTrajectoryPtr merge(const std::vector<robot_trajectory::RobotTrajectoryPtr>& sub_trajectories,
+	                                           const std::vector<planning_scene::PlanningScenePtr>& intermediate_scenes);
+
+protected:
 	GroupPlannerVector planner_;
+	moveit::core::JointModelGroupPtr merged_jmg_;
 	std::list<SubTrajectory> subsolutions_;
 	std::list<SolutionSequence> solutions_;
 	std::list<InterfaceState> states_;

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -65,10 +65,9 @@ public:
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 	bool compute(const InterfaceState &from, const InterfaceState &to) override;
 
-	size_t numSolutions() const override { return solutions_.size(); }
-	size_t numFailures() const override { return 0; }
+	size_t numSolutions() const override;
 	void processSolutions(const SolutionProcessor &processor) const override;
-	void processFailures(const SolutionProcessor &processor) const override { return; }
+	void processFailures(const SolutionProcessor &processor) const override;
 
 protected:
 	SolutionBase* storeSequential(const std::vector<robot_trajectory::RobotTrajectoryPtr>& sub_trajectories,
@@ -79,6 +78,7 @@ protected:
 protected:
 	GroupPlannerVector planner_;
 	moveit::core::JointModelGroupPtr merged_jmg_;
+	// TODO: ComputeBase should handle any SolutionBase -> shared_ptr
 	std::list<SubTrajectory> subsolutions_;
 	std::list<SolutionSequence> solutions_;
 	std::list<InterfaceState> states_;

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -46,6 +46,9 @@
 namespace moveit { namespace task_constructor { namespace stages {
 
 class Connect : public Connecting {
+protected:
+	bool compatible(const InterfaceState &from_state, const InterfaceState &to_state) const override;
+
 public:
 	typedef std::vector<std::pair<std::string, solvers::PlannerInterfacePtr>> GroupPlannerVector;
 	Connect(std::string name, const GroupPlannerVector& planners);

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Authors: Michael Goerner, Robert Haschke
+/* Authors: Robert Haschke, Michael Goerner
    Desc:    Connect arbitrary states by motion planning
 */
 
@@ -47,7 +47,8 @@ namespace moveit { namespace task_constructor { namespace stages {
 
 class Connect : public Connecting {
 public:
-	Connect(std::string name, const solvers::PlannerInterfacePtr &planner);
+	typedef std::vector<std::pair<std::string, solvers::PlannerInterfacePtr>> GroupPlannerVector;
+	Connect(std::string name, const GroupPlannerVector& planners);
 
 	void setTimeout(const ros::Duration& timeout){
 		setProperty("timeout", timeout.toSec());
@@ -57,11 +58,20 @@ public:
 		setProperty("path_constraints", std::move(path_constraints));
 	}
 
-	void init(const moveit::core::RobotModelConstPtr& robot_model);
-	bool compute(const InterfaceState &from, const InterfaceState &to);
+	void reset() override;
+	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
+	bool compute(const InterfaceState &from, const InterfaceState &to) override;
+
+	size_t numSolutions() const override { return solutions_.size(); }
+	size_t numFailures() const override { return 0; }
+	void processSolutions(const SolutionProcessor &processor) const override;
+	void processFailures(const SolutionProcessor &processor) const override { return; }
 
 protected:
-	solvers::PlannerInterfacePtr planner_;
+	GroupPlannerVector planner_;
+	std::list<SubTrajectory> subsolutions_;
+	std::list<SolutionSequence> solutions_;
+	std::list<InterfaceState> states_;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/pick.h
+++ b/core/include/moveit/task_constructor/stages/pick.h
@@ -44,7 +44,6 @@ namespace moveit { namespace task_constructor {
 
 namespace solvers {
 MOVEIT_CLASS_FORWARD(CartesianPath)
-MOVEIT_CLASS_FORWARD(PipelinePlanner)
 }
 
 namespace stages {
@@ -63,7 +62,6 @@ namespace stages {
  */
 class Pick : public SerialContainer {
 	solvers::CartesianPathPtr cartesian_solver_;
-	solvers::PipelinePlannerPtr pipeline_solver_;
 	Stage* grasp_stage_ = nullptr;
 	Stage* approach_stage_ = nullptr;
 	Stage* lift_stage_ = nullptr;
@@ -81,7 +79,6 @@ public:
 	}
 
 	solvers::CartesianPathPtr cartesianSolver() { return cartesian_solver_; }
-	solvers::PipelinePlannerPtr pipelineSolver() { return pipeline_solver_; }
 
 	void setApproachMotion(const geometry_msgs::TwistStamped& motion,
 	                       double min_distance, double max_distance);

--- a/core/include/moveit/task_constructor/stages/simple_grasp.h
+++ b/core/include/moveit/task_constructor/stages/simple_grasp.h
@@ -46,18 +46,20 @@ namespace moveit { namespace task_constructor { namespace stages {
 
 class GenerateGraspPose;
 
-/** Simple Grasp Stage
+/** base class for simple grasping / ungrasping
  *
- * Given a named pre-grasp and grasp posture the stage generates
- * fully-qualified pre-grasp and grasp robot states, connected
- * by a grasping trajectory of the end-effector.
+ * Given a named pre-grasp and grasp posture the stage generates fully-qualified
+ * pre-grasp and grasp robot states, connected by a grasping trajectory of the end-effector.
+ *
+ * Grasping and UnGrasping only differs in the order of subtasks. Hence, the base class
+ * provides the common functionality for grasping (forward = true) and ungrasping (forward = false).
  */
-class SimpleGrasp : public SerialContainer {
+class SimpleGraspBase : public SerialContainer {
 	moveit::core::RobotModelConstPtr model_;
 	GenerateGraspPose* grasp_generator_ = nullptr;
 
 public:
-	SimpleGrasp(const std::string& name = "grasp");
+	SimpleGraspBase(const std::string& name, bool forward);
 
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 	void setMonitoredStage(Stage* monitored);
@@ -99,6 +101,20 @@ public:
 	void setTimeout(double timeout) {
 		properties().set("timeout", timeout);
 	}
+};
+
+
+/// specialization of SimpleGraspBase to realize grasping
+class SimpleGrasp : public SimpleGraspBase {
+public:
+	SimpleGrasp(const std::string& name = "grasp") : SimpleGraspBase(name, true) {}
+};
+
+
+/// specialization of SimpleGraspBase to realize ungrasping
+class SimpleUnGrasp : public SimpleGraspBase {
+public:
+	SimpleUnGrasp(const std::string& name = "ungrasp") : SimpleGraspBase(name, false) {}
 };
 
 } } }

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(${PROJECT_NAME}
 	${PROJECT_INCLUDE}/cost_queue.h
 	${PROJECT_INCLUDE}/introspection.h
 	${PROJECT_INCLUDE}/marker_tools.h
+	${PROJECT_INCLUDE}/merge.h
 	${PROJECT_INCLUDE}/properties.h
 	${PROJECT_INCLUDE}/stage.h
 	${PROJECT_INCLUDE}/stage_p.h
@@ -18,6 +19,7 @@ add_library(${PROJECT_NAME}
 	container.cpp
 	introspection.cpp
 	marker_tools.cpp
+	merge.cpp
 	properties.cpp
 	stage.cpp
 	storage.cpp

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -856,7 +856,6 @@ void ParallelContainerBase::spawn(InterfaceState &&state, SubTrajectory&& t)
 	auto impl = pimpl();
 	assert(impl->prevEnds() && impl->nextStarts());
 
-	t.setCreator(impl);
 	// store newly created solution (otherwise it's lost)
 	auto it = impl->created_solutions_.insert(impl->created_solutions_.end(), std::move(t));
 

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -283,18 +283,18 @@ std::ostream& operator<<(std::ostream& os, const ContainerBase& container) {
 struct SolutionCollector {
 	SolutionCollector(size_t max_depth) : max_depth(max_depth) {}
 
-	void operator()(const SerialContainer::solution_container& trace, double cost) {
+	void operator()(const SolutionSequence::container_type& trace, double cost) {
 		// traced path should not extend past container boundaries
 		assert(trace.size() <= max_depth);
 		solutions.emplace_back(std::make_pair(trace, cost));
 	}
 
-	typedef std::list<std::pair<SerialContainer::solution_container, double>> SolutionCostPairs;
+	typedef std::list<std::pair<SolutionSequence::container_type, double>> SolutionCostPairs;
 	SolutionCostPairs solutions;
 	const size_t max_depth;
 };
 
-void updateStateCosts(const SerialContainer::solution_container &partial_solution_path,
+void updateStateCosts(const SolutionSequence::container_type &partial_solution_path,
                       const InterfaceState::Priority &prio) {
 	for (const SolutionBase* solution : partial_solution_path) {
 		// here it suffices to update the start state, because the end state is the start state
@@ -322,7 +322,7 @@ void SerialContainer::onNewSolution(const SolutionBase &current)
 	assert(num_before < children.size());  // creator should be one of our children
 	num_after = children.size()-1 - num_before;
 
-	SerialContainer::solution_container trace; trace.reserve(children.size());
+	SolutionSequence::container_type trace; trace.reserve(children.size());
 
 	// find all incoming solution paths ending at current solution
 	SolutionCollector incoming(num_before);
@@ -333,8 +333,8 @@ void SerialContainer::onNewSolution(const SolutionBase &current)
 	traverse<Interface::FORWARD>(current, std::ref(outgoing), trace);
 
 	// collect (and sort) all solutions spanning from start to end of this container
-	ordered<SerialSolution> sorted;
-	SerialContainer::solution_container solution;
+	ordered<SolutionSequence> sorted;
+	SolutionSequence::container_type solution;
 	solution.reserve(children.size());
 	for (auto& in : incoming.solutions) {
 		for (auto& out : outgoing.solutions) {
@@ -352,7 +352,7 @@ void SerialContainer::onNewSolution(const SolutionBase &current)
 				// insert outgoing solutions in normal order
 				solution.insert(solution.end(), out.first.begin(), out.first.end());
 				// store solution in sorted list
-				sorted.insert(SerialSolution(impl, std::move(solution), prio.cost()));
+				sorted.insert(SolutionSequence(std::move(solution), prio.cost(), impl));
 			} else if (prio.depth() > 1) {
 				// update state priorities along the whole partial solution path
 				updateStateCosts(in.first, prio);
@@ -655,7 +655,7 @@ void SerialContainer::processSolutions(const ContainerBase::SolutionProcessor &p
 
 template <Interface::Direction dir>
 void SerialContainer::traverse(const SolutionBase &start, const SolutionProcessor &cb,
-                               solution_container &trace, double trace_cost)
+                               SolutionSequence::container_type &trace, double trace_cost)
 {
 	const InterfaceState::Solutions& solutions = start.trajectories<dir>();
 	if (solutions.empty())  // if we reached the end, call the callback
@@ -669,28 +669,6 @@ void SerialContainer::traverse(const SolutionBase &start, const SolutionProcesso
 		trace_cost -= successor->cost();
 		trace.pop_back();
 	}
-}
-
-void SerialSolution::fillMessage(moveit_task_constructor_msgs::Solution &msg,
-                                 Introspection* introspection) const
-{
-	moveit_task_constructor_msgs::SubSolution sub_msg;
-	sub_msg.id = introspection ? introspection->solutionId(*this) : 0;
-	sub_msg.cost = this->cost();
-
-	const Introspection *ci = introspection;
-	sub_msg.stage_id = ci ? ci->stageId(this->creator()->me()) : 0;
-
-	sub_msg.sub_solution_id.reserve(subsolutions_.size());
-	if (introspection) {
-		for (const SolutionBase* s : subsolutions_)
-			sub_msg.sub_solution_id.push_back(introspection->solutionId(*s));
-		msg.sub_solution.push_back(sub_msg);
-	}
-
-	msg.sub_trajectory.reserve(msg.sub_trajectory.size() + subsolutions_.size());
-	for (const SolutionBase* s : subsolutions_)
-		s->fillMessage(msg, introspection);
 }
 
 

--- a/core/src/merge.cpp
+++ b/core/src/merge.cpp
@@ -1,0 +1,133 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, Hamburg University
+ *  Copyright (c) 2017, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Luca Lach, Robert Haschke */
+
+#include <moveit/task_constructor/merge.h>
+
+namespace moveit { namespace task_constructor {
+
+moveit::core::JointModelGroup* merge(const std::vector<const moveit::core::JointModelGroup*>& groups)
+{
+	if (groups.size() <= 1)
+		throw std::runtime_error("Expected multiple groups");
+
+	const moveit::core::RobotModel* const robot_model = &groups[0]->getParentModel();
+
+	std::set<const moveit::core::JointModel*> jset;
+	std::vector<std::string> names;
+	for (const moveit::core::JointModelGroup* jmg : groups) {
+		// sanity check: all groups must share the same robot model
+		if (&jmg->getParentModel() != robot_model)
+			throw std::runtime_error("groups refer to different robot models");
+
+		const auto& joints = jmg->getJointModels();
+		jset.insert(joints.cbegin(), joints.cend());
+		names.push_back(jmg->getName());
+	}
+
+	std::vector<const moveit::core::JointModel*> joints(jset.cbegin(), jset.cend());
+	// attention: do not use getConfig()
+	return new moveit::core::JointModelGroup("", srdf::Model::Group(), joints, robot_model);
+}
+
+robot_trajectory::RobotTrajectoryPtr merge(const std::vector<robot_trajectory::RobotTrajectoryPtr>& sub_trajectories,
+                                           moveit::core::JointModelGroup*& merged_group)
+{
+	if (sub_trajectories.size() <= 1)
+		throw std::runtime_error("Expected multiple sub solutions");
+
+	const std::vector<const moveit::core::JointModel*> *merged_joints
+	      = merged_group ? &merged_group->getJointModels() : nullptr;
+	std::set<const moveit::core::JointModel*> jset;
+
+	// sanity checks: all sub solutions must share the same robot model and use disjoint joint sets
+	const moveit::core::RobotModelConstPtr& robot_model = sub_trajectories[0]->getRobotModel();
+	size_t max_num_joints = 0;  // maximum number of joints in sub groups
+	for (const robot_trajectory::RobotTrajectoryPtr& sub : sub_trajectories) {
+		if (sub->getRobotModel() != robot_model)
+			throw std::runtime_error("subsolutions refer to multiple robot models");
+
+		const moveit::core::JointModelGroup* jmg = sub->getGroup();
+		const auto& joints = jmg->getJointModels();
+		if (merged_joints) {  // validate that the joint model is known in merged_group
+			for (const moveit::core::JointModel* jm : joints) {
+				if (std::find(merged_joints->cbegin(), merged_joints->cend(), jm) == merged_joints->cend())
+					throw std::runtime_error("subsolutions refers to unknown joint: " + jm->getName());
+			}
+		}
+		max_num_joints = std::max(max_num_joints, joints.size());
+		size_t expected_size = jset.size() + joints.size();
+		jset.insert(joints.cbegin(), joints.cend());
+		if (jset.size() != expected_size)
+			throw std::runtime_error("joint sets of subsolutions are not disjoint");
+	}
+
+	// create merged_group if necessary
+	if (!merged_group) {
+		std::vector<const moveit::core::JointModel*> joints(jset.cbegin(), jset.cend());
+		merged_group = new moveit::core::JointModelGroup("", srdf::Model::Group(), joints, robot_model.get());
+	}
+
+	// do the actual trajectory merging
+	auto merged_traj = std::make_shared<robot_trajectory::RobotTrajectory>(robot_model, merged_group);
+	std::vector<double> values;
+	values.reserve(max_num_joints);
+
+	while (true) {
+		bool finished = true;
+		size_t index = merged_traj->getWayPointCount();
+		auto merged_state = index == 0 ? std::make_shared<robot_state::RobotState>(robot_model)
+		                               : std::make_shared<robot_state::RobotState>(merged_traj->getLastWayPoint());
+		for (const robot_trajectory::RobotTrajectoryPtr& sub : sub_trajectories) {
+			if (index >= sub->getWayPointCount())
+				continue;  // no more waypoints in this sub solution
+
+			finished = false;  // there was a waypoint, continue while loop
+			const robot_state::RobotState& sub_state = sub->getWayPoint(index);
+			sub_state.copyJointGroupPositions(sub->getGroup(), values);
+			merged_state->setJointGroupPositions(sub->getGroup(), values);
+		}
+		if (finished)
+			break;
+
+		// add waypoint without timing
+		merged_state->update();
+		merged_traj->addSuffixWayPoint(merged_state, 0.0);
+	}
+	return merged_traj;
+}
+
+} }

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -83,8 +83,10 @@ InterfaceFlags StagePrivate::interfaceFlags() const
 	return f;
 }
 
-void StagePrivate::newSolution(const SolutionBase &solution)
+void StagePrivate::newSolution(SolutionBase &solution)
 {
+	solution.setCreator(this);
+
 	if (introspection_)
 		introspection_->registerSolution(solution);
 
@@ -249,7 +251,6 @@ std::ostream& operator<<(std::ostream& os, const StagePrivate& impl) {
 }
 
 SubTrajectory& ComputeBasePrivate::addTrajectory(SubTrajectory&& trajectory) {
-	trajectory.setCreator(this);
 	if (!trajectory.isFailure()) {
 		return *solutions_.insert(std::move(trajectory));
 	} else if (me()->storeFailures()) {
@@ -653,8 +654,7 @@ void Connecting::reset()
 	ComputeBase::reset();
 }
 
-void Connecting::connect(const InterfaceState& from, const InterfaceState& to,
-                         SubTrajectory&& t) {
+void Connecting::connect(const InterfaceState& from, const InterfaceState& to, SubTrajectory&& t) {
 	auto impl = pimpl();
 	SubTrajectory& trajectory = impl->addTrajectory(std::move(t));
 	trajectory.setStartState(from);

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -655,11 +655,13 @@ void Connecting::reset()
 }
 
 void Connecting::connect(const InterfaceState& from, const InterfaceState& to, SubTrajectory&& t) {
-	auto impl = pimpl();
-	SubTrajectory& trajectory = impl->addTrajectory(std::move(t));
-	trajectory.setStartState(from);
-	trajectory.setEndState(to);
-	impl->newSolution(trajectory);
+	newSolution(from, to, pimpl()->addTrajectory(std::move(t)));
+}
+
+void Connecting::newSolution(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution) {
+	solution.setStartState(from);
+	solution.setEndState(to);
+	pimpl()->newSolution(solution);
 }
 
 std::ostream& operator<<(std::ostream& os, const Stage& stage) {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -38,11 +38,11 @@
 #include <moveit/task_constructor/stage_p.h>
 #include <moveit/task_constructor/container_p.h>
 #include <moveit/task_constructor/introspection.h>
+#include <moveit/planning_scene/planning_scene.h>
 #include <iostream>
 #include <iomanip>
 #include <ros/console.h>
 
-using namespace std::placeholders;
 namespace moveit { namespace task_constructor {
 
 void InitStageException::push_back(const Stage &stage, const std::string &msg)
@@ -310,14 +310,14 @@ void PropagatingEitherWayPrivate::initInterface(PropagatingEitherWay::Direction 
 {
 	if (dir & PropagatingEitherWay::FORWARD) {
 		if (!starts_)  // keep existing interface if possible
-			starts_.reset(new Interface(std::bind(&PropagatingEitherWayPrivate::dropFailedStarts, this, _1)));
+			starts_.reset(new Interface(std::bind(&PropagatingEitherWayPrivate::dropFailedStarts, this, std::placeholders::_1)));
 	} else {
 		starts_.reset();
 	}
 
 	if (dir & PropagatingEitherWay::BACKWARD) {
 		if (!ends_)  // keep existing interface if possible
-			ends_.reset(new Interface(std::bind(&PropagatingEitherWayPrivate::dropFailedEnds, this, _1)));
+			ends_.reset(new Interface(std::bind(&PropagatingEitherWayPrivate::dropFailedEnds, this, std::placeholders::_1)));
 	} else {
 		ends_.reset();
 	}
@@ -573,7 +573,7 @@ void MonitoringGenerator::init(const moveit::core::RobotModelConstPtr& robot_mod
 	if (!impl->monitored_)
 		throw InitStageException(*this, "no monitored stage defined");
 	if (!impl->registered_) {  // register only once
-		impl->cb_ = impl->monitored_->addSolutionCallback(std::bind(&MonitoringGenerator::onNewSolution, this, _1));
+		impl->cb_ = impl->monitored_->addSolutionCallback(std::bind(&MonitoringGenerator::onNewSolution, this, std::placeholders::_1));
 		impl->registered_ = true;
 	}
 }
@@ -582,15 +582,27 @@ void MonitoringGenerator::init(const moveit::core::RobotModelConstPtr& robot_mod
 ConnectingPrivate::ConnectingPrivate(Connecting *me, const std::string &name)
    : ComputeBasePrivate(me, name)
 {
-	starts_.reset(new Interface(std::bind(&ConnectingPrivate::newStartState, this, _1, _2)));
-	ends_.reset(new Interface(std::bind(&ConnectingPrivate::newEndState, this, _1, _2)));
+	starts_.reset(new Interface(std::bind(&ConnectingPrivate::newState<Interface::BACKWARD>, this, std::placeholders::_1, std::placeholders::_2)));
+	ends_.reset(new Interface(std::bind(&ConnectingPrivate::newState<Interface::FORWARD>, this, std::placeholders::_1, std::placeholders::_2)));
 }
 
 InterfaceFlags ConnectingPrivate::requiredInterface() const {
 	return InterfaceFlags(CONNECT);
 }
 
-void ConnectingPrivate::newStartState(Interface::iterator it, bool updated)
+template <>
+ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::BACKWARD>
+(Interface::const_iterator first, Interface::const_iterator second) {
+	return std::make_pair(first, second);
+}
+template <>
+ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>
+(Interface::const_iterator first, Interface::const_iterator second) {
+	return std::make_pair(second, first);
+}
+
+template <Interface::Direction other>
+void ConnectingPrivate::newState(Interface::iterator it, bool updated)
 {
 	// TODO: only consider interface states with priority depth > threshold
 	if (!std::isfinite(it->priority().cost())) {
@@ -603,30 +615,12 @@ void ConnectingPrivate::newStartState(Interface::iterator it, bool updated)
 		// many pairs might be affected: sort
 		pending.sort();
 	} else { // new state: insert all pairs with other interface
-		for (auto oit = ends_->begin(), oend = ends_->end(); oit != oend; ++oit) {
+		InterfacePtr other_interface = pullInterface(other);
+		for (auto oit = other_interface->begin(), oend = other_interface->end(); oit != oend; ++oit) {
 			if (!std::isfinite(oit->priority().cost()))
 				break;
-			pending.insert(std::make_pair(it, oit));
-		}
-	}
-}
-
-void ConnectingPrivate::newEndState(Interface::iterator it, bool updated)
-{
-	if (!std::isfinite(it->priority().cost())) {
-		// remove pending pairs, if cost updated to infinity
-		if (updated)
-			pending.remove_if([it](const StatePair& p) { return p.second == it; });
-		return;
-	}
-	if (updated) {
-		// many pairs might be affected: sort
-		pending.sort();
-	} else { // new state: insert all pairs with other interface
-		for (auto oit = starts_->begin(), oend = starts_->end(); oit != oend; ++oit) {
-			if (!std::isfinite(oit->priority().cost()))
-				break;
-			pending.insert(std::make_pair(oit, it));
+			if (static_cast<Connecting*>(me_)->compatible(*it, *oit))
+				pending.insert(make_pair<other>(it, oit));
 		}
 	}
 }
@@ -652,6 +646,30 @@ void Connecting::reset()
 {
 	pimpl()->pending.clear();
 	ComputeBase::reset();
+}
+
+/// compare consistency of planning scenes
+bool Connecting::compatible(const InterfaceState& from_state, const InterfaceState& to_state) const
+{
+	const planning_scene::PlanningSceneConstPtr& from = from_state.scene();
+	const planning_scene::PlanningSceneConstPtr& to = to_state.scene();
+
+	if (from->getWorld()->size() != to->getWorld()->size())
+		return false;  // different number of collision objects
+
+	// both scenes should have the same set of collision objects, at the same location
+	for (const auto& from_object_pair : *from->getWorld()) {
+		const collision_detection::World::ObjectPtr& from_object = from_object_pair.second;
+		const collision_detection::World::ObjectConstPtr& to_object = to->getWorld()->getObject(from_object_pair.first);
+		if (!to_object) return false;  // object missing
+		if (from_object->shape_poses_.size() != to_object->shape_poses_.size()) return false;  // shapes not matching
+
+		for (auto from_it = from_object->shape_poses_.cbegin(), from_end = from_object->shape_poses_.cend(),
+		     to_it = to_object->shape_poses_.cbegin(); from_it != from_end; ++from_it, ++to_it)
+			if (!from_it->matrix().array().isApprox(to_it->matrix().array()))
+				return false;  // transforms do not match
+	}
+	return true;
 }
 
 void Connecting::connect(const InterfaceState& from, const InterfaceState& to, SubTrajectory&& t) {

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -225,8 +225,31 @@ robot_trajectory::RobotTrajectoryPtr Connect::merge(const std::vector<robot_traj
 	return trajectory;
 }
 
+size_t Connect::numSolutions() const
+{
+	return solutions_.size() + Connecting::numSolutions();
+}
+
 void Connect::processSolutions(const Stage::SolutionProcessor& processor) const
 {
+	// TODO: This is not nice, but necessary to process simple SubTrajectory + SolutionSequence
+	for (const auto& s : solutions_) {
+		if (s.isFailure()) continue;
+		if (!processor(s))
+			break;
+	}
+	Connecting::processSolutions(processor);
+}
+
+void Connect::processFailures(const Stage::SolutionProcessor &processor) const
+{
+	// TODO: This is not nice, but necessary to process simple SubTrajectory + SolutionSequence
+	for (const auto& s : solutions_) {
+		if (!s.isFailure()) continue;
+		if (!processor(s))
+			break;
+	}
+	Connecting::processFailures(processor);
 }
 
 } } }

--- a/core/src/stages/pick.cpp
+++ b/core/src/stages/pick.cpp
@@ -1,13 +1,9 @@
 #include <moveit/task_constructor/stages/pick.h>
 
 #include <moveit/task_constructor/solvers/cartesian_path.h>
-#include <moveit/task_constructor/solvers/pipeline_planner.h>
 
 #include <moveit/task_constructor/container.h>
-#include <moveit/task_constructor/stages/move_to.h>
 #include <moveit/task_constructor/stages/move_relative.h>
-#include <moveit/task_constructor/stages/connect.h>
-#include <moveit/task_constructor/stages/modify_planning_scene.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 
@@ -26,24 +22,6 @@ Pick::Pick(Stage::pointer&& grasp_stage, const std::string& name)
 	p.declare<std::string>("eef_parent_group", "JMG of eef's parent");
 
 	cartesian_solver_ = std::make_shared<solvers::CartesianPath>();
-	pipeline_solver_ = std::make_shared<solvers::PipelinePlanner>();
-	pipeline_solver_->setTimeout(8.0);
-	pipeline_solver_->setPlannerId("RRTConnectkConfigDefault");
-
-	{
-		auto move = std::make_unique<MoveTo>("open gripper", pipeline_solver_);
-		PropertyMap& p = move->properties();
-		p.property("group").configureInitFrom(Stage::PARENT, "eef_group");
-		move->setGoal("open");  // TODO: retrieve from grasp stage
-		insert(std::move(move));
-	}
-
-	{
-		auto move = std::make_unique<Connect>("move to object", pipeline_solver_);
-		PropertyMap& p = move->properties();
-		p.property("group").configureInitFrom(Stage::PARENT, "eef_parent_group");
-		insert(std::move(move));
-	}
 
 	{
 		auto approach = std::make_unique<MoveRelative>("approach object", cartesian_solver_);


### PR DESCRIPTION
As already announced, this is my attempt to generalize the `connect` stage. So far, it was not possible to connect two states that differed w.r.t. multiple joint model groups. For example, for grasping, both the gripper and arm groups have changed for the _pregrasp pose_ compared to the _initial_ pose.
The new connect stage allows to specify an (ordered) vector of `JMGs` and associated planners to resolve differences.

This PR also removes `connect` from the `pick` stage. `connect` is considered as a generator of the transit motion only and should not be part of a functional container.

Finally, I implemented releasing and placing as _inversions_ of grasping and picking, using the same base classes for each pair. An example of usage is provided in [`mtc_demos`](https://github.com/ubi-agni/mtc_demos/blob/master/src/yumi.cpp).

I also implemented merging of trajectories. Here I faced some unexpected issues: MoveIt! doesn't nicely support creating of arbitrary RobotTrajectories - they are always bound to a JMG. Hence, I had to create a JMG on-the-fly.