### PR TITLE
PropertyMap::exposeTo fix: use other_name as new name for property

### DIFF
--- a/core/src/properties.cpp
+++ b/core/src/properties.cpp
@@ -140,7 +140,7 @@ void PropertyMap::exposeTo(PropertyMap& other, const std::set<std::string> &prop
 void PropertyMap::exposeTo(PropertyMap& other, const std::string& name, const std::string& other_name)
 {
 	const Property& p = property(name);
-	other.declare(name, p.type_index_, p.description_, p.default_, p.serialize_);
+    other.declare(other_name, p.type_index_, p.description_, p.default_, p.serialize_);
 }
 
 void PropertyMap::configureInitFrom(Property::SourceId source, const std::set<std::string> &properties)


### PR DESCRIPTION
PropertyMap::exposeTo is given the parameter other_name which should be the new name of the exposed property, but the old name was used instead.