### PR TITLE
expose typed setters in Cartesian solver

### DIFF
--- a/core/include/moveit/task_constructor/solvers/cartesian_path.h
+++ b/core/include/moveit/task_constructor/solvers/cartesian_path.h
@@ -50,6 +50,13 @@ public:
 	void setGroup(const std::string &group) { setProperty("group", group); }
 	void setTimeout(double timeout) { setProperty("timeout", timeout); }
 
+	void setStepSize(double step_size) { setProperty("step_size", step_size); }
+	void setJumpThreshold(double jump_threshold) { setProperty("jump_threshold", jump_threshold); }
+	void setMinFraction(double min_fraction) { setProperty("min_fraction", min_fraction); }
+
+	void setMaxVelocityScaling(double factor) { setProperty("max_velocity_scaling_factor", factor); }
+	void setMaxAccelerationScaling(double factor) { setProperty("max_acceleration_scaling_factor", factor); }
+
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 
 	bool plan(const planning_scene::PlanningSceneConstPtr from,


### PR DESCRIPTION
It would be nice to have some automated way to add them via C++1x magic,
but I'm not aware of something like that at the moment.