### PR TITLE
MoveTo: set goals form RobotState msg & introduced named_joint_pose property

### DIFF
--- a/core/include/moveit/task_constructor/stages/move_to.h
+++ b/core/include/moveit/task_constructor/stages/move_to.h
@@ -61,8 +61,10 @@ public:
 	void setGoal(const geometry_msgs::PoseStamped& pose);
 	/// move link to given point, keeping current orientation
 	void setGoal(const geometry_msgs::PointStamped& point);
-	/// move joint model group to given named pose
-	void setGoal(const std::string& joint_pose);
+    /// move joint model group to given named pose
+    void setGoal(const std::string& joint_pose);
+    /// move joints specified in msg to their target values
+    void setGoal(const moveit_msgs::RobotState& robot_state);
 
 	void setPathConstraints(moveit_msgs::Constraints path_constraints){
 		setProperty("path_constraints", std::move(path_constraints));

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -94,6 +94,14 @@ public:
 			                this->cost() + other.cost());
 		}
 		inline bool operator<(const Priority& other) const {
+			/* infinite cost should always be last */
+			if (std::isinf(this->cost()) && std::isinf(other.cost()))
+				return this->depth() > other.depth();
+			else if (std::isinf(this->cost()))
+				return false;
+			else if (std::isinf(other.cost()))
+				return true;
+
 			if (this->depth() == other.depth())
 				return this->cost() < other.cost();
 			else
@@ -155,7 +163,7 @@ public:
 	/// remove a state from the interface and return it as a one-element list
 	container_type remove(iterator it);
 
-	/// update state's priority if new priority is smaller and call notify_
+	/// update state's priority if new priority is smaller or became infeasible and call notify_
 	void updatePriority(InterfaceState *state, const InterfaceState::Priority &priority);
 
 private:

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -176,7 +176,12 @@ bool Connect::compute(const InterfaceState &from, const InterfaceState &to) {
 		// mark solution as failure
 		solution->setCost(std::numeric_limits<double>::infinity());
 	} else {
-		robot_trajectory::RobotTrajectoryPtr t = merge(sub_trajectories, intermediate_scenes, from.scene()->getCurrentState());
+		robot_trajectory::RobotTrajectoryConstPtr t = nullptr;
+		if(sub_trajectories.size() >= 2)
+			t = merge(sub_trajectories, intermediate_scenes, from.scene()->getCurrentState());
+		else
+			t = sub_trajectories[0];
+
 		if (t) {
 			connect(from, to, SubTrajectory(t));
 			return true;

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -158,7 +158,7 @@ bool Connect::compute(const InterfaceState &from, const InterfaceState &to) {
 		end->getCurrentStateNonConst().setJointGroupPositions(jmg, positions);
 
 		robot_trajectory::RobotTrajectoryPtr trajectory;
-		if (!pair.second->plan(start, to.scene(), jmg, timeout, trajectory, path_constraints))
+		if (!pair.second->plan(start, end, jmg, timeout, trajectory, path_constraints))
 			break;
 
 		sub_trajectories.push_back(trajectory);

--- a/core/src/stages/simple_grasp.cpp
+++ b/core/src/stages/simple_grasp.cpp
@@ -94,7 +94,7 @@ SimpleGraspBase::SimpleGraspBase(const std::string& name, bool forward)
 			return boost::any(jmg->getName());
 		});
 		insert(std::move(move), insertion_position);
-		exposePropertyOfChildAs(insertion_position, "joint_pose", forward ? "grasp" : "pregrasp");
+        exposePropertyOfChildAs(insertion_position, "named_joint_pose", forward ? "grasp" : "pregrasp");
 	}
 	{
 		auto attach = std::make_unique<ModifyPlanningScene>(forward ? "attach object" : "detach object");

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -106,11 +106,13 @@ Interface::container_type Interface::remove(iterator it)
 
 void Interface::updatePriority(InterfaceState *state, const InterfaceState::Priority& priority)
 {
-	if (priority < state->priority()) {
+	double old_cost = state->priority_.cost();
+	if (priority < state->priority() || std::isinf(priority.cost())) {
 		auto it = std::find_if(begin(), end(), [state](const InterfaceState& other) { return state == &other; });
 		// state should be part of the interface
 		assert(it != end());
 		state->priority_ = priority;
+		update(it);
 		if (notify_) notify_(it, true);
 	}
 }


### PR DESCRIPTION
MoveTos property "joint_pose" now takes a RobotState message instead of named joint pose.
The property "named_joint_pose" replaces the old usage of "joint_pose".

Also, in MoveTo::init, a named joint pose is converted into a RobotState message.