### PR TITLE
MoveRelative: introduced joint space goals

### DIFF
--- a/core/include/moveit/task_constructor/properties.h
+++ b/core/include/moveit/task_constructor/properties.h
@@ -271,5 +271,19 @@ public:
 template <>
 void PropertyMap::set<boost::any>(const std::string& name, const boost::any& value);
 
+// provide a serialization method for std::map
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::map<std::string, T>& m) {
+    os << "{";
+    bool first = true;
+    for (const auto& pair : m) {
+        if (!first)
+            os << ", ";
+        os << pair.first << " : " << pair.second;
+        first = false;
+    }
+    os << "}";
+}
+
 } // namespace task_constructor
 } // namespace moveit

--- a/core/include/moveit/task_constructor/stages/move_relative.h
+++ b/core/include/moveit/task_constructor/stages/move_relative.h
@@ -63,6 +63,8 @@ public:
 	void setMaxDistance(double distance);
 	void setMinMaxDistance(double min_distance, double max_distance);
 
+    void setRelativeJointSpaceGoal(const std::map<std::string, double>& goal);
+
 	void setPathConstraints(moveit_msgs::Constraints path_constraints){
 		setProperty("path_constraints", std::move(path_constraints));
 	}
@@ -78,6 +80,7 @@ protected:
 
 protected:
 	solvers::PlannerInterfacePtr planner_;
+    bool joint_space_goal_ = false;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/pick.h
+++ b/core/include/moveit/task_constructor/stages/pick.h
@@ -88,6 +88,8 @@ public:
 	                        double min_distance, double max_distance);
 	void setLiftPlace(const geometry_msgs::TwistStamped& motion,
 	                  double min_distance, double max_distance);
+
+    void setRelativeJointSpaceGoal(const std::map<std::string, double>& relative_joint_space_goal);
 };
 
 
@@ -107,6 +109,10 @@ public:
 	                   double min_distance, double max_distance) {
 		setLiftPlace(motion, min_distance, max_distance);
 	}
+
+    void setRelativeJointSpaceLiftGoal(const std::map<std::string, double>& relative_joint_space_goal) {
+        setRelativeJointSpaceGoal(relative_joint_space_goal);
+    }
 };
 
 

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -94,6 +94,14 @@ public:
 			                this->cost() + other.cost());
 		}
 		inline bool operator<(const Priority& other) const {
+			/* infinite cost should always be last */
+			if (std::isinf(this->cost()) && std::isinf(other.cost()))
+				return this->depth() > other.depth();
+			else if (std::isinf(this->cost()))
+				return false;
+			else if (std::isinf(other.cost()))
+				return true;
+
 			if (this->depth() == other.depth())
 				return this->cost() < other.cost();
 			else
@@ -155,7 +163,7 @@ public:
 	/// remove a state from the interface and return it as a one-element list
 	container_type remove(iterator it);
 
-	/// update state's priority if new priority is smaller and call notify_
+	/// update state's priority if new priority is smaller or became infeasible and call notify_
 	void updatePriority(InterfaceState *state, const InterfaceState::Priority &priority);
 
 private:

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -176,7 +176,12 @@ bool Connect::compute(const InterfaceState &from, const InterfaceState &to) {
 		// mark solution as failure
 		solution->setCost(std::numeric_limits<double>::infinity());
 	} else {
-		robot_trajectory::RobotTrajectoryPtr t = merge(sub_trajectories, intermediate_scenes, from.scene()->getCurrentState());
+		robot_trajectory::RobotTrajectoryConstPtr t = nullptr;
+		if(sub_trajectories.size() >= 2)
+			t = merge(sub_trajectories, intermediate_scenes, from.scene()->getCurrentState());
+		else
+			t = sub_trajectories[0];
+
 		if (t) {
 			connect(from, to, SubTrajectory(t));
 			return true;

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -158,7 +158,7 @@ bool Connect::compute(const InterfaceState &from, const InterfaceState &to) {
 		end->getCurrentStateNonConst().setJointGroupPositions(jmg, positions);
 
 		robot_trajectory::RobotTrajectoryPtr trajectory;
-		if (!pair.second->plan(start, to.scene(), jmg, timeout, trajectory, path_constraints))
+		if (!pair.second->plan(start, end, jmg, timeout, trajectory, path_constraints))
 			break;
 
 		sub_trajectories.push_back(trajectory);

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -57,9 +57,14 @@ MoveRelative::MoveRelative(const std::string& name, const solvers::PlannerInterf
 
 	p.declare<geometry_msgs::TwistStamped>("twist", "Cartesian twist transform");
 	p.declare<geometry_msgs::Vector3Stamped>("direction", "Cartesian translation direction");
+    p.declare<std::map<std::string, double>>("relative_joint_space_goal", "Relative joint space goal");
 
 	p.declare<moveit_msgs::Constraints>("path_constraints", moveit_msgs::Constraints(),
 	                                    "constraints to maintain during trajectory");
+}
+
+void MoveRelative::setRelativeJointSpaceGoal(const std::map<std::string, double>& goal){
+    setProperty("relative_joint_space_goal", goal);
 }
 
 void MoveRelative::setGroup(const std::string& group){
@@ -114,7 +119,7 @@ bool MoveRelative::compute(const InterfaceState &state, planning_scene::Planning
 	}
 
 	// only allow single target
-	size_t count_goals = props.countDefined({"twist", "direction"});
+    size_t count_goals = props.countDefined({"twist", "direction", "relative_joint_space_goal"});
 	if (count_goals != 1) {
         if (count_goals == 0) ROS_WARN("MoveRelative: no goal defined");
         else ROS_WARN("MoveRelative: cannot plan to multiple goals");
@@ -206,9 +211,35 @@ bool MoveRelative::compute(const InterfaceState &state, planning_scene::Planning
 		target_eigen.translation() += linear;
 	}
 
-	robot_trajectory::RobotTrajectoryPtr robot_trajectory;
-	bool success = planner_->plan(state.scene(), *link, target_eigen, jmg, timeout, robot_trajectory,
-	                              props.get<moveit_msgs::Constraints>("path_constraints"));
+    goal = props.get("relative_joint_space_goal");
+    if (!goal.empty()) {
+
+        const auto &start_state = scene->getCurrentState();
+        auto& current_state = scene->getCurrentStateNonConst();
+        joint_space_goal_ = true;
+
+        const std::map<std::string, double>& relative_joint_position_map = boost::any_cast<std::map<std::string, double>>(goal);
+
+        for (auto j : relative_joint_position_map) {
+            double new_pos = (start_state.getVariablePosition(j.first) + j.second);
+            current_state.setVariablePosition(j.first, new_pos);
+
+            auto jm = scene->getRobotModel()->getJointModel(j.first);
+            current_state.enforceBounds(jm);
+            current_state.update(true);
+        }
+    }
+
+    robot_trajectory::RobotTrajectoryPtr robot_trajectory;
+    bool success = false;
+
+    if (joint_space_goal_) {
+        success = planner_->plan(state.scene(), scene, jmg, timeout, robot_trajectory,
+                                 props.get<moveit_msgs::Constraints>("path_constraints"));
+    } else {
+        success = planner_->plan(state.scene(), *link, target_eigen, jmg, timeout, robot_trajectory,
+                                      props.get<moveit_msgs::Constraints>("path_constraints"));
+    }
 
 	// min_distance reached?
 	if (min_distance > 0.0) {

--- a/core/src/stages/pick.cpp
+++ b/core/src/stages/pick.cpp
@@ -83,4 +83,10 @@ void PickPlaceBase::setLiftPlace(const geometry_msgs::TwistStamped& motion, doub
 	p.set("max_distance", max_distance);
 }
 
+void PickPlaceBase::setRelativeJointSpaceGoal(const std::map<std::string, double>& relative_joint_space_goal)
+{
+    auto& p = lift_stage_->properties();
+    p.set("relative_joint_space_goal", relative_joint_space_goal);
+}
+
 } } }

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -106,11 +106,13 @@ Interface::container_type Interface::remove(iterator it)
 
 void Interface::updatePriority(InterfaceState *state, const InterfaceState::Priority& priority)
 {
-	if (priority < state->priority()) {
+	double old_cost = state->priority_.cost();
+	if (priority < state->priority() || std::isinf(priority.cost())) {
 		auto it = std::find_if(begin(), end(), [state](const InterfaceState& other) { return state == &other; });
 		// state should be part of the interface
 		assert(it != end());
 		state->priority_ = priority;
+		update(it);
 		if (notify_) notify_(it, true);
 	}
 }


### PR DESCRIPTION
A std::map<std::string, double> can be set as a goal for MoveRelative, where the map consists of
<joint_name, offset> pairs. Based on the joint offsets, a RobotState is constructed wrt joint limits.