### PR TITLE
inf cost states always go last

### DIFF
--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -94,6 +94,14 @@ public:
 			                this->cost() + other.cost());
 		}
 		inline bool operator<(const Priority& other) const {
+			/* infinite cost should always be last */
+			if (std::isinf(this->cost()) && std::isinf(other.cost()))
+				return this->depth() > other.depth();
+			else if (std::isinf(this->cost()))
+				return false;
+			else if (std::isinf(other.cost()))
+				return true;
+
 			if (this->depth() == other.depth())
 				return this->cost() < other.cost();
 			else
@@ -155,7 +163,7 @@ public:
 	/// remove a state from the interface and return it as a one-element list
 	container_type remove(iterator it);
 
-	/// update state's priority if new priority is smaller and call notify_
+	/// update state's priority if new priority is smaller or became infeasible and call notify_
 	void updatePriority(InterfaceState *state, const InterfaceState::Priority &priority);
 
 private:

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -93,20 +93,7 @@ public:
 			return Priority(this->depth() + other.depth(),
 			                this->cost() + other.cost());
 		}
-		inline bool operator<(const Priority& other) const {
-			/* infinite cost should always be last */
-			if (std::isinf(this->cost()) && std::isinf(other.cost()))
-				return this->depth() > other.depth();
-			else if (std::isinf(this->cost()))
-				return false;
-			else if (std::isinf(other.cost()))
-				return true;
-
-			if (this->depth() == other.depth())
-				return this->cost() < other.cost();
-			else
-				return this->depth() > other.depth();
-		}
+		bool operator<(const Priority& other) const;
 	};
 	typedef std::deque<SolutionBase*> Solutions;
 

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -150,7 +150,7 @@ public:
 	/// remove a state from the interface and return it as a one-element list
 	container_type remove(iterator it);
 
-	/// update state's priority if new priority is smaller or became infeasible and call notify_
+	/// update state's priority (and call notify_ if it really has changed)
 	void updatePriority(InterfaceState *state, const InterfaceState::Priority &priority);
 
 private:

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -106,11 +106,13 @@ Interface::container_type Interface::remove(iterator it)
 
 void Interface::updatePriority(InterfaceState *state, const InterfaceState::Priority& priority)
 {
-	if (priority < state->priority()) {
+	double old_cost = state->priority_.cost();
+	if (priority < state->priority() || std::isinf(priority.cost())) {
 		auto it = std::find_if(begin(), end(), [state](const InterfaceState& other) { return state == &other; });
 		// state should be part of the interface
 		assert(it != end());
 		state->priority_ = priority;
+		update(it);
 		if (notify_) notify_(it, true);
 	}
 }

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -55,6 +55,23 @@ InterfaceState::InterfaceState(const InterfaceState &other)
 {
 }
 
+
+bool InterfaceState::Priority::operator<(const InterfaceState::Priority& other) const {
+	// infinite costs go always last
+	if (std::isinf(this->cost()) && std::isinf(other.cost()))
+		return this->depth() > other.depth();
+	else if (std::isinf(this->cost()))
+		return false;
+	else if (std::isinf(other.cost()))
+		return true;
+
+	if (this->depth() == other.depth())
+		return this->cost() < other.cost();
+	else
+		return this->depth() > other.depth();
+}
+
+
 Interface::Interface(const Interface::NotifyFunction &notify)
    : notify_(notify)
 {}

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -123,8 +123,7 @@ Interface::container_type Interface::remove(iterator it)
 
 void Interface::updatePriority(InterfaceState *state, const InterfaceState::Priority& priority)
 {
-	double old_cost = state->priority_.cost();
-	if (priority < state->priority() || std::isinf(priority.cost())) {
+	if (priority != state->priority()) {
 		auto it = std::find_if(begin(), end(), [state](const InterfaceState& other) { return state == &other; });
 		// state should be part of the interface
 		assert(it != end());

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -20,4 +20,7 @@ if (CATKIN_ENABLE_TESTING)
 
 	catkin_add_gtest(${PROJECT_NAME}-test-cost_queue test_cost_queue.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-cost_queue ${PROJECT_NAME} gtest_main)
+
+	catkin_add_gtest(${PROJECT_NAME}-test-interface_state test_interface_state.cpp)
+	target_link_libraries(${PROJECT_NAME}-test-interface_state ${PROJECT_NAME} gtest_main)
 endif()

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -1,0 +1,19 @@
+#include <list>
+#include <moveit/task_constructor/storage.h>
+#include <gtest/gtest.h>
+
+using namespace moveit::task_constructor;
+TEST(InterfaceStatePriority, compare) {
+	typedef InterfaceState::Priority Prio;
+	const double inf = std::numeric_limits<double>::infinity();
+
+	EXPECT_TRUE(Prio(0, 0) == Prio(0, 0));
+	EXPECT_TRUE(Prio(0, inf) == Prio(0, inf));
+
+	EXPECT_TRUE(Prio(1, 0) < Prio(0, 0)); // higher depth is smaller
+	EXPECT_TRUE(Prio(1, inf) < Prio(0, inf));
+
+	EXPECT_TRUE(Prio(0, 0) < Prio(0, 1)); // higher cost is larger
+	EXPECT_TRUE(Prio(0, 0) < Prio(0, inf));
+	EXPECT_TRUE(Prio(0, inf) > Prio(0, 0));
+}


### PR DESCRIPTION
This PR was originally proposed by @v4hn. 
Also update sorted interface when state becomes inf or get's new cost.