### PR TITLE
use correct frame in pick

### DIFF
--- a/core/src/stages/pick.cpp
+++ b/core/src/stages/pick.cpp
@@ -30,7 +30,7 @@ PickPlaceBase::PickPlaceBase(Stage::pointer&& grasp_stage, const std::string& na
 		if (frame.empty())
 			return boost::any();
 
-		pose.header.frame_id = boost::any_cast<std::string>("eef_frame");
+		pose.header.frame_id = boost::any_cast<std::string>(frame);
 		pose.pose.orientation.w = 1.0;
 		return pose;
 	};


### PR DESCRIPTION
boost on ubuntu 14.04 failed to compile this and it looks
like this is a typo anyway.