### PR TITLE
keep RobotModelLoader around

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -51,6 +51,10 @@ namespace moveit { namespace core {
 	MOVEIT_CLASS_FORWARD(RobotState)
 }}
 
+namespace robot_model_loader {
+	MOVEIT_CLASS_FORWARD(RobotModelLoader)
+}
+
 namespace moveit { namespace task_constructor {
 
 MOVEIT_CLASS_FORWARD(Stage)
@@ -137,6 +141,7 @@ protected:
 
 private:
 	std::string id_;
+	robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
 	moveit::core::RobotModelConstPtr robot_model_;
 
 	// introspection and monitoring

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -109,8 +109,8 @@ void Task::setRobotModel(const core::RobotModelConstPtr& robot_model)
 }
 
 void Task::loadRobotModel(const std::string& robot_description) {
-	robot_model_loader::RobotModelLoader rml(robot_description);
-	setRobotModel(rml.getModel());
+	robot_model_loader_ = std::make_shared<robot_model_loader::RobotModelLoader>(robot_description);
+	setRobotModel(robot_model_loader_->getModel());
 	if (!robot_model_)
 		throw Exception("Task failed to construct RobotModel");
 }


### PR DESCRIPTION
Otherwise the robot_model_ does not remain valid and the kinematic plugins might not be around anymore until the model is loaded again by a different RML.