### PR TITLE
visualization improvements

### DIFF
--- a/core/include/moveit/task_constructor/introspection.h
+++ b/core/include/moveit/task_constructor/introspection.h
@@ -106,6 +106,8 @@ private:
 	void fillSolution(moveit_task_constructor_msgs::Solution &msg, const SolutionBase &s);
 	/// retrieve or set id of given stage
 	uint32_t stageId(const moveit::task_constructor::Stage * const s);
+	/// retrieve solution with given id
+	const SolutionBase* solutionFromId(uint id) const;
 };
 
 } }

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -164,14 +164,20 @@ void Introspection::publishAllSolutions(bool wait)
 	};
 }
 
+const SolutionBase* Introspection::solutionFromId(uint id) const {
+	auto it = impl->id_solution_bimap_.left.find(id);
+	if (it == impl->id_solution_bimap_.left.end())
+		return nullptr;
+	return it->second;
+}
+
 bool Introspection::getSolution(moveit_task_constructor_msgs::GetSolution::Request  &req,
                                 moveit_task_constructor_msgs::GetSolution::Response &res)
 {
-	auto it = impl->id_solution_bimap_.left.find(req.solution_id);
-	if (it == impl->id_solution_bimap_.left.end())
-		return false;
+	const SolutionBase* solution = solutionFromId(req.solution_id);
+	if (!solution) return false;
 
-	fillSolution(res.solution, *it->second);
+	fillSolution(res.solution, *solution);
 	return true;
 }
 

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -94,21 +94,16 @@ TaskDisplay::TaskDisplay() : Display()
 
 TaskDisplay::~TaskDisplay()
 {
-	if (context_) TaskPanel::decUseCount();
+	if (context_) TaskPanel::decDisplayCount();
 }
 
 void TaskDisplay::onInitialize()
 {
 	Display::onInitialize();
 	trajectory_visual_->onInitialize(scene_node_, context_);
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	// displays are loaded before panels, hence wait a little bit for the panel to be loaded
-	QTimer::singleShot(1000, [this](){ TaskPanel::incUseCount(context_->getWindowManager()); });
-#else
-	// Qt4 doesn't support lambdas: directly instantiate panel instance
-	TaskPanel::incUseCount(context_->getWindowManager());
-#endif
+	// create a new TaskPanel by default
+	// by post-poning this to main loop, we can ensure that rviz has loaded everything before
+	mainloop_jobs_.addJob([this]() { TaskPanel::incDisplayCount(context_->getWindowManager()); });
 }
 
 void TaskDisplay::loadRobotModel()

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -91,6 +91,7 @@ TaskPanel::TaskPanel(QWidget* parent)
 	d->settings_widget = new TaskSettings(this);
 	layout()->addWidget(d->tasks_widget);
 	layout()->addWidget(d->settings_widget);
+	connect(d->tasks_widget, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
 
 	connect(d->button_show_stage_dock_widget, SIGNAL(clicked()), this, SLOT(showStageDockWidget()));
 	connect(d->button_show_settings, SIGNAL(toggled(bool)), d->settings_widget, SLOT(setVisible(bool)));
@@ -245,6 +246,13 @@ TaskView::TaskView(QWidget *parent)
 	        this, SLOT(onCurrentStageChanged(QModelIndex,QModelIndex)));
 
 	onCurrentStageChanged(d->tasks_view->currentIndex(), QModelIndex());
+
+	// propagate infos about config changes
+	connect(d_ptr->tasks_property_splitter, SIGNAL(splitterMoved(int,int)),this, SIGNAL(configChanged()));
+	connect(d_ptr->tasks_solutions_splitter, SIGNAL(splitterMoved(int,int)), this, SIGNAL(configChanged()));
+	connect(d_ptr->tasks_view->header(), SIGNAL(sectionResized(int,int,int)), this, SIGNAL(configChanged()));
+	connect(d_ptr->solutions_view->header(), SIGNAL(sectionResized(int,int,int)), this, SIGNAL(configChanged()));
+	connect(d_ptr->solutions_view->header(), SIGNAL(sortIndicatorChanged(int,Qt::SortOrder)), this, SIGNAL(configChanged()));
 }
 
 TaskView::~TaskView()

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -51,6 +51,7 @@
 #include <rviz/display_group.h>
 #include <rviz/visualization_manager.h>
 #include <rviz/window_manager_interface.h>
+#include <rviz/visualization_frame.h>
 #include <rviz/panel_dock_widget.h>
 #include <ros/console.h>
 #include <QPointer>
@@ -75,6 +76,12 @@ rviz::PanelDockWidget* getStageDockWidget(rviz::WindowManagerInterface* mgr) {
 }
 
 
+// TaskPanel singleton
+static QPointer<TaskPanel> singleton_;
+// count active TaskDisplays
+static uint display_count_ = 0;
+
+
 TaskPanel::TaskPanel(QWidget* parent)
   : rviz::Panel(parent), d_ptr(new TaskPanelPrivate(this))
 {
@@ -90,14 +97,8 @@ TaskPanel::TaskPanel(QWidget* parent)
 	d->settings_widget->setVisible(d->button_show_settings->isChecked());
 
 	// if still undefined, this becomes the global instance
-	if (TaskPanelPrivate::global_instance_.isNull()) {
-		TaskPanelPrivate::global_instance_ = this;
-		// If an explicitly created instance is explicitly destroyed, we don't notice.
-		// If there there were displays "using" it, global_use_count_ is still greater zero.
-		if (TaskPanelPrivate::global_use_count_ > 0);  // In this case, don't increment use count
-		else
-			++TaskPanelPrivate::global_use_count_; // otherwise increment use count for explicitly created instance
-	}
+	if (singleton_.isNull())
+		singleton_ = this;
 }
 
 TaskPanel::~TaskPanel()
@@ -105,26 +106,23 @@ TaskPanel::~TaskPanel()
 	delete d_ptr;
 }
 
-QPointer<TaskPanel> TaskPanelPrivate::global_instance_;
-uint TaskPanelPrivate::global_use_count_ = 0;
-
-void TaskPanel::incUseCount(rviz::WindowManagerInterface* window_manager)
+void TaskPanel::incDisplayCount(rviz::WindowManagerInterface* window_manager)
 {
-	++TaskPanelPrivate::global_use_count_;
-	if (TaskPanelPrivate::global_instance_ || !window_manager)
+	++display_count_;
+
+	rviz::VisualizationFrame* vis_frame = dynamic_cast<rviz::VisualizationFrame*>(window_manager);
+	if (singleton_ || !vis_frame)
 		return; // already define, nothing to do
 
-	--TaskPanelPrivate::global_use_count_; // counteract ++ in constructor
-	TaskPanelPrivate::global_instance_ = new TaskPanel(window_manager->getParentWindow());
-	TaskPanelPrivate::global_instance_->d_ptr->window_manager_ = window_manager;
-	window_manager->addPane("Motion Planning Tasks", TaskPanelPrivate::global_instance_);
+	window_manager->addPane("Motion Planning Tasks", new TaskPanel());
+	singleton_->initialize(vis_frame->getManager());
 }
 
-void TaskPanel::decUseCount()
+void TaskPanel::decDisplayCount()
 {
-	Q_ASSERT(TaskPanelPrivate::global_use_count_ > 0);
-	if (--TaskPanelPrivate::global_use_count_ == 0 && TaskPanelPrivate::global_instance_)
-		TaskPanelPrivate::global_instance_->deleteLater();
+	Q_ASSERT(display_count_ > 0);
+	if (--display_count_ == 0 && singleton_)
+		singleton_->deleteLater();
 }
 
 TaskPanelPrivate::TaskPanelPrivate(TaskPanel *q_ptr)

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -101,6 +101,9 @@ public:
 	void save(rviz::Config config);
 	void load(const rviz::Config& config);
 
+Q_SIGNALS:
+	void configChanged();
+
 public Q_SLOTS:
 	void addTask();
 

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -70,13 +70,13 @@ public:
 	TaskPanel(QWidget* parent = 0);
 	~TaskPanel();
 
-	/** Increment/decrement use count for global task panel instance.
+	/** Increment/decrement use count of singleton TaskPanel instance.
 	 *
 	 * If not yet done, an instance is created. If use count drops to zero,
 	 * the global instance is destroyed.
 	 */
-	static void incUseCount(rviz::WindowManagerInterface *window_manager);
-	static void decUseCount();
+	static void incDisplayCount(rviz::WindowManagerInterface *window_manager);
+	static void decDisplayCount();
 
 	void onInitialize() override;
 	void load(const rviz::Config& config) override;

--- a/visualization/motion_planning_tasks/src/task_panel_p.h
+++ b/visualization/motion_planning_tasks/src/task_panel_p.h
@@ -62,8 +62,6 @@ public:
 	TaskSettings* settings_widget;
 
 	rviz::WindowManagerInterface* window_manager_;
-	static QPointer<TaskPanel> global_instance_;
-	static uint global_use_count_;
 };
 
 

--- a/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
@@ -99,7 +99,7 @@ public:
 
 	float getWayPointDurationFromPrevious(const IndexPair& idx_pair) const;
 	float getWayPointDurationFromPrevious(size_t index) const {
-		if (index >= steps_) return 0.0;
+		if (index >= steps_) return 0.1;  // display time of last waypoint before switching to final scene
 		return getWayPointDurationFromPrevious(indexPair(index));
 	}
 	const moveit::core::RobotStatePtr& getWayPointPtr(const IndexPair& idx_pair) const;

--- a/visualization/visualization_tools/src/task_solution_visualization.cpp
+++ b/visualization/visualization_tools/src/task_solution_visualization.cpp
@@ -419,7 +419,6 @@ void TaskSolutionVisualization::update(float wall_dt, float ros_dt)
   } else if (current_state_ < max_state_index)
     animating_ = true;  // auto-activate animation if slider_panel_ is hidden
 
-  QString msg = "no change";
   if (animating_ && current_state_ == previous_state) {
     // auto-advance current_state_ based on time progress
     current_state_time_ += wall_dt;
@@ -429,7 +428,6 @@ void TaskSolutionVisualization::update(float wall_dt, float ros_dt)
       current_state_ = 0;
       current_state_time_ = 0.0;
       trail_scene_node_->setVisible(false);
-      msg = "restart";
     } else if (tm < 0.0) {  // using realtime: skip to next waypoint based on elapsed display time
       while (current_state_ < max_state_index &&
              (tm = displaying_solution_->getWayPointDurationFromPrevious(current_state_ + 1)) < current_state_time_) {
@@ -439,11 +437,9 @@ void TaskSolutionVisualization::update(float wall_dt, float ros_dt)
     } else if (current_state_time_ > tm) {  // fixed display time per state
         ++current_state_;
       current_state_time_ = 0.0;
-      msg = "progress";
     }
   } else if (current_state_ != previous_state) {  // current_state_ changed from slider
     current_state_time_ = 0.0;
-    msg = "slider";
   }
 
   if ((waypoint_count > 0 && current_state_ >= max_state_index) ||


### PR DESCRIPTION
This contains a series of little bug fixes to rviz visualization.
Particularly, `TaskPanel` settings are all saved now.
Unfortunately, due to a bug in rviz (addressed in https://github.com/ros-visualization/rviz/pull/1303),
programmatically created panels cannot save their settings. If the rviz patch is merged, I have one more commit to actually use the new feature.
As a workaround for now, one first needs to create a new task panel **before** creating any task display using rviz' create panel mechanism. The created panel will save it's settings and serve as the singleton instance.