### PR TITLE
cleanup PlannerInterface

### DIFF
--- a/core/include/moveit/task_constructor/solvers/cartesian_path.h
+++ b/core/include/moveit/task_constructor/solvers/cartesian_path.h
@@ -47,9 +47,6 @@ class CartesianPath : public PlannerInterface {
 public:
 	CartesianPath();
 
-	void setGroup(const std::string &group) { setProperty("group", group); }
-	void setTimeout(double timeout) { setProperty("timeout", timeout); }
-
 	void setStepSize(double step_size) { setProperty("step_size", step_size); }
 	void setJumpThreshold(double jump_threshold) { setProperty("jump_threshold", jump_threshold); }
 	void setMinFraction(double min_fraction) { setProperty("min_fraction", min_fraction); }

--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -52,9 +52,7 @@ class PipelinePlanner : public PlannerInterface {
 public:
 	PipelinePlanner();
 
-	void setGroup(const std::string &group) { setProperty("group", group); }
 	void setPlannerId(const std::string &planner) { setProperty("planner", planner); }
-	void setTimeout(double timeout) { setProperty("timeout", timeout); }
 
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 

--- a/core/include/moveit/task_constructor/solvers/planner_interface.h
+++ b/core/include/moveit/task_constructor/solvers/planner_interface.h
@@ -63,7 +63,8 @@ class PlannerInterface {
 	PropertyMap properties_;
 
 public:
-	PlannerInterface() {}
+	PlannerInterface();
+	virtual ~PlannerInterface() {}
 
 	PropertyMap& properties() { return properties_; }
 	const PropertyMap& properties() const { return properties_; }

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(${PROJECT_NAME}
 	storage.cpp
 	task.cpp
 
+	solvers/planner_interface.cpp
 	solvers/cartesian_path.cpp
 	solvers/pipeline_planner.cpp
 	solvers/joint_interpolation.cpp

--- a/core/src/solvers/cartesian_path.cpp
+++ b/core/src/solvers/cartesian_path.cpp
@@ -48,8 +48,6 @@ CartesianPath::CartesianPath()
 	p.declare<double>("step_size", 0.01, "step size between consecutive waypoints");
 	p.declare<double>("jump_threshold", 1.5, "acceptable fraction of mean joint motion per step");
 	p.declare<double>("min_fraction", 1.0, "fraction of motion required for success");
-	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
-	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
 }
 
 void CartesianPath::init(const core::RobotModelConstPtr &robot_model)

--- a/core/src/solvers/joint_interpolation.cpp
+++ b/core/src/solvers/joint_interpolation.cpp
@@ -46,8 +46,6 @@ JointInterpolationPlanner::JointInterpolationPlanner()
 {
 	auto& p = properties();
 	p.declare<double>("max_step", 0.1, "max joint step");
-	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
-	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
 }
 
 void JointInterpolationPlanner::init(const core::RobotModelConstPtr &robot_model)

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -52,8 +52,6 @@ PipelinePlanner::PipelinePlanner()
 	p.declare<std::string>("planner", "", "planner id");
 
 	p.declare<uint>("num_planning_attempts", 1u, "number of planning attempts");
-	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
-	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
 	p.declare<moveit_msgs::WorkspaceParameters>("workspace_parameters", moveit_msgs::WorkspaceParameters(), "allowed workspace of mobile base?");
 
 	p.declare<double>("goal_joint_tolerance", 1e-4, "tolerance for reaching joint goals");

--- a/core/src/solvers/planner_interface.cpp
+++ b/core/src/solvers/planner_interface.cpp
@@ -33,39 +33,18 @@
  *********************************************************************/
 
 /* Authors: Robert Haschke
-   Desc:    plan using MoveIt's PlanningPipeline
+   Desc:    Planner Interface: implementation details shared across different planners
 */
 
-#pragma once
-
 #include <moveit/task_constructor/solvers/planner_interface.h>
-#include <moveit/macros/class_forward.h>
 
 namespace moveit { namespace task_constructor { namespace solvers {
 
-MOVEIT_CLASS_FORWARD(JointInterpolationPlanner)
-
-/** Use MoveIt's PlanningPipeline to plan a trajectory between to scenes */
-class JointInterpolationPlanner : public PlannerInterface {
-public:
-    JointInterpolationPlanner();
-
-	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-
-	bool plan(const planning_scene::PlanningSceneConstPtr& from,
-	          const planning_scene::PlanningSceneConstPtr& to,
-	          const core::JointModelGroup *jmg,
-	          double timeout,
-	          robot_trajectory::RobotTrajectoryPtr& result,
-	          const moveit_msgs::Constraints& path_constraints= moveit_msgs::Constraints()) override;
-
-	bool plan(const planning_scene::PlanningSceneConstPtr& from,
-	          const moveit::core::LinkModel &link,
-	          const Eigen::Affine3d& target,
-	          const core::JointModelGroup *jmg,
-	          double timeout,
-	          robot_trajectory::RobotTrajectoryPtr& result,
-	          const moveit_msgs::Constraints& path_constraints= moveit_msgs::Constraints()) override;
-};
+PlannerInterface::PlannerInterface()
+{
+	auto& p = properties();
+	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
+	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
+}
 
 } } }

--- a/core/src/stages/simple_grasp.cpp
+++ b/core/src/stages/simple_grasp.cpp
@@ -99,7 +99,6 @@ void SimpleGraspBase::setup(std::unique_ptr<Stage>&& generator, bool forward)
 	}
 	{
 		auto pipeline = std::make_shared<solvers::PipelinePlanner>();
-		pipeline->setTimeout(8.0);
 		pipeline->setPlannerId("RRTConnectkConfigDefault");
 
 		auto move = new MoveTo(forward ? "close gripper" : "open gripper", pipeline);

--- a/core/test/pick_pa10.cpp
+++ b/core/test/pick_pa10.cpp
@@ -44,7 +44,6 @@ TEST(PA10, pick) {
 	t.setProperty("gripper", std::string("left_hand"));
 
 	auto pipeline = std::make_shared<solvers::PipelinePlanner>();
-	pipeline->setTimeout(8.0);
 	pipeline->setPlannerId("RRTConnectkConfigDefault");
 	auto cartesian = std::make_shared<solvers::CartesianPath>();
 

--- a/core/test/pick_pr2.cpp
+++ b/core/test/pick_pr2.cpp
@@ -40,7 +40,6 @@ TEST(PR2, pick) {
 
 	// planner used for connect
 	auto pipeline = std::make_shared<solvers::PipelinePlanner>();
-	pipeline->setTimeout(8.0);
 	pipeline->setPlannerId("RRTConnectkConfigDefault");
 	// connect to pick
 	stages::Connect::GroupPlannerVector planners = {{"left_arm", pipeline}, {"left_gripper", pipeline}};

--- a/core/test/pick_ur5.cpp
+++ b/core/test/pick_ur5.cpp
@@ -42,7 +42,6 @@ TEST(UR5, pick) {
 
 	// planner used for connect
 	auto pipeline = std::make_shared<solvers::PipelinePlanner>();
-	pipeline->setTimeout(8.0);
 	pipeline->setPlannerId("RRTConnectkConfigDefault");
 	// connect to pick
 	stages::Connect::GroupPlannerVector planners = {{"arm", pipeline}, {"gripper", pipeline}};


### PR DESCRIPTION
- remove `group` + `timeout` properties: they are passed as arguments to plan()
- move `max_velocity_scaling_factor`, `max_acceleration_scaling_factor` to `PlannerInterface` base class