### PR TITLE
fix broken rvalue-forward & SerialContainer assert

### DIFF
--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -300,7 +300,7 @@ public:
 	   : SolutionBase()
 	{}
 	SolutionSequence(container_type&& subsolutions, double cost = 0.0, StagePrivate* creator = nullptr)
-	   : SolutionBase(creator, cost), subsolutions_(subsolutions)
+	   : SolutionBase(creator, cost), subsolutions_(std::move(subsolutions))
 	{}
 
 	void push_back(const SolutionBase& solution);


### PR DESCRIPTION
Release mode builds previously produced broken solutions with too many entries,
debug build triggered the assert

container.cpp:334: assert(solution.empty())

The standard guarantees std::vector(&&a) leaves a.empty() == true,
so the logic there is fine as long as subsolutions is actually
used for move-construction.