### PR TITLE
Remaining commits of #69

### DIFF
--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <moveit/task_constructor/solvers/planner_interface.h>
+#include <moveit_msgs/MotionPlanRequest.h>
 #include <moveit/macros/class_forward.h>
 
 namespace planning_pipeline {
@@ -70,6 +71,12 @@ public:
 	          double timeout,
 	          robot_trajectory::RobotTrajectoryPtr& result,
 	          const moveit_msgs::Constraints& path_constraints= moveit_msgs::Constraints()) override;
+
+protected:
+	void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req,
+	                           const PropertyMap& p,
+	                           const moveit::core::JointModelGroup *jmg,
+	                           double timeout);
 
 protected:
 	planning_pipeline::PlanningPipelinePtr planner_;

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -40,7 +40,6 @@
 #include <moveit/task_constructor/task.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_pipeline/planning_pipeline.h>
-#include <moveit_msgs/MotionPlanRequest.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <eigen_conversions/eigen_msg.h>
 
@@ -67,15 +66,12 @@ PipelinePlanner::PipelinePlanner()
 void PipelinePlanner::init(const core::RobotModelConstPtr &robot_model)
 {
 	planner_ = Task::createPlanner(robot_model);
-
-	planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
-	planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
 }
 
-void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req,
-                           const PropertyMap& p,
-                           const moveit::core::JointModelGroup *jmg,
-                           double timeout)
+void PipelinePlanner::initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req,
+                                            const PropertyMap& p,
+                                            const moveit::core::JointModelGroup *jmg,
+                                            double timeout)
 {
 	req.group_name = jmg->getName();
 	req.planner_id = p.get<std::string>("planner");
@@ -86,6 +82,9 @@ void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req,
 	req.max_velocity_scaling_factor = p.get<double>("max_velocity_scaling_factor");
 	req.max_acceleration_scaling_factor = p.get<double>("max_acceleration_scaling_factor");
 	req.workspace_parameters = p.get<moveit_msgs::WorkspaceParameters>("workspace_parameters");
+
+	planner_->displayComputedMotionPlans(p.get<bool>("display_motion_plans"));
+	planner_->publishReceivedRequests(p.get<bool>("publish_planning_requests"));
 }
 
 bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& from,


### PR DESCRIPTION
This one needs discussion.
Moving the configuration of motion plan and request publishers from `init()` to `plan()` causes issues if you want to use multiple planning pipelines.
I don't remember the details anymore, but maybe it's not possible to create multiple publishers on the same topic within the same node?