### PR TITLE
improve error msg for mismatching container/child interfaces

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -10,5 +10,5 @@
     version: master
 - git:
     local-name: mtc_pour
-    uri: https://github.com/TAMS-Group/mtc_pour.git
+    uri: https://github.com/rhaschke/mtc_pour.git
     version: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,15 @@ notifications:
       - rhaschke@techfak.uni-bielefeld.de
       - me@v4hn.de
 env:
+  global:
+    - ROS_DISTRO=melodic
+    - ROS_REPO=ros
+    - UPSTREAM_WORKSPACE=.rosinstall
   matrix:
-    - ROS_DISTRO=kinetic  ROS_REPO=ros               UPSTREAM_WORKSPACE=.rosinstall
-    - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed  UPSTREAM_WORKSPACE=.rosinstall
-    - ROS_DISTRO=melodic  ROS_REPO=ros               UPSTREAM_WORKSPACE=.rosinstall
-    - ROS_DISTRO=melodic  ROS_REPO=ros-shadow-fixed  UPSTREAM_WORKSPACE=.rosinstall
+    - ROS_DISTRO=melodic
 
 before_script:
-  - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+  - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci
 
 script:
   - .moveit_ci/travis.sh

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# moveit_task_constructor
-An approach to forward multi-step manipulation planning
+# MoveIt! Task Constructor Framework
 
-**The framework is currently under development. The API is unstable and incomplete.**
+The Task Constructor framework provides a flexible and transparent way to define and plan actions that consist of *multiple interdependent* subtasks.
+It draws on the planning capabilities of [MoveIt!](https://moveit.ros.org/) to solve individual subproblems in black-box *planning stages*.
+A common interface, based on MoveIt's PlanningScene is used to pass solution hypotheses between stages.
+The framework enables the hierarchical organization of basic stages using *containers*, allowing for sequential as well as parallel compositions.
+For more details, please refer to the associated [ICRA 2019 publication](https://pub.uni-bielefeld.de/download/2918864/2933599/paper.pdf).
 
-**Feedback is very welcome.**
+**The framework is still under development. The API is unstable and incomplete.**
 
-This project enables the user to specify and plan *complex manipulation actions* in terms of successive *planning stages*.
-
-Individual stages compute robot trajectories relative to their expected start *or end*.
-The resulting planning pipeline, i.e. Task, extends different candidate trajectories from key states (Generator stages)
-until it generated feasible trajectories that extend through all stages.
+**Feedback and contributions are very welcome.**
 
 The current aim is to replace MoveIt's old pick&place pipeline and provide a *transparent mechanism* to enable and debug complex motion sequences.
+
+The software repository is compatible to MoveIt's Melodic branch, which also works on Kinetic (when compiled from source).

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(moveit_task_constructor_core)
 
+find_package(Boost REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
 	eigen_conversions
 	geometry_msgs

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -364,4 +364,6 @@ protected:
 	}
 };
 
+const char* flowSymbol(moveit::task_constructor::InterfaceFlags f);
+
 } }

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -349,6 +349,15 @@ const char* direction(const StagePrivate& stage) {
 	return "<-";
 }
 
+const char* flowSymbol(moveit::task_constructor::InterfaceFlags f) {
+	if (f == InterfaceFlags(CONNECT)) return "∞";
+	if (f == InterfaceFlags(PROPAGATE_FORWARDS)) return "↓";
+	if (f == InterfaceFlags(PROPAGATE_BACKWARDS)) return "↑";
+	if (f == PROPAGATE_BOTHWAYS) return "⇅";
+	if (f == InterfaceFlags(GENERATE)) return "↕";
+	return "?";
+}
+
 std::ostream& operator<<(std::ostream& os, const StagePrivate& impl) {
 	// starts
 	for (const InterfaceConstPtr& i : {impl.prevEnds(), impl.starts()}) {

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -176,6 +176,7 @@ void Task::add(Stage::pointer &&stage) {
 
 void Task::clear()
 {
+	reset();
 	stages()->clear();
 }
 


### PR DESCRIPTION
Addresses #67 by augmenting the error message with the corresponding flow symbol used in rviz.
In order to fix the broken Travis, I had to add some more commits meanwhile. Please fast-forward for merging.