### PR TITLE
rviz: property visualization

### DIFF
--- a/core/include/moveit/task_constructor/properties.h
+++ b/core/include/moveit/task_constructor/properties.h
@@ -78,6 +78,9 @@ class Property {
 public:
 	typedef boost::typeindex::type_info type_info;
 
+	/// Construct a property holding a any value
+	Property();
+
 	/// base class for Property exceptions
 	class error;
 	/// exception thrown when accessing an undeclared property

--- a/core/include/moveit/task_constructor/properties.h
+++ b/core/include/moveit/task_constructor/properties.h
@@ -70,11 +70,14 @@ boost::any fromName(const PropertyMap& other, const std::string& other_name);
 class Property {
 	friend class PropertyMap;
 
-	typedef decltype(std::declval<boost::any>().type()) type_index;
 	/// typed constructor is only accessible via PropertyMap
-	Property(const type_index &type_index, const std::string &description, const boost::any &default_value);
+	Property(const boost::typeindex::type_info& type_info,
+	         const std::string &description,
+	         const boost::any &default_value);
 
 public:
+	typedef boost::typeindex::type_info type_info;
+
 	/// base class for Property exceptions
 	class error;
 	/// exception thrown when accessing an undeclared property
@@ -115,7 +118,7 @@ public:
 	void setDescription(const std::string& desc) { description_ = desc; }
 
 	/// get typename
-	static std::string typeName(const std::type_index& type_index);
+	static std::string typeName(const type_info& type_info);
 	std::string typeName() const;
 
 	/// return true, if property initialized from given SourceId
@@ -127,7 +130,7 @@ public:
 
 private:
 	std::string description_;
-	type_index type_index_;
+	const type_info& type_info_;
 	boost::any default_;
 	boost::any value_;
 
@@ -282,7 +285,7 @@ class PropertyMap
 	typedef std::map<std::string, Property>::const_iterator const_iterator;
 
 	/// implementation of declare methods
-	Property& declare(const std::string& name, const Property::type_index& type_index,
+	Property& declare(const std::string& name, const Property::type_info& type_info,
 	                  const std::string& description, const boost::any& default_value);
 public:
 	/// declare a property for future use
@@ -294,7 +297,7 @@ public:
 	/// declare a property with default value
 	template<typename T>
 	Property& declare(const std::string& name, const T& default_value,
-	             const std::string& description = "") {
+	                  const std::string& description = "") {
 		PropertySerializer<T>();  // register serializer/deserializer
 		return declare(name, typeid(T), description, default_value);
 	}

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -227,6 +227,7 @@ moveit_task_constructor_msgs::TaskDescription& Introspection::fillTaskDescriptio
 			moveit_task_constructor_msgs::Property p;
 			p.name = pair.first;
 			p.description = pair.second.description();
+			p.type = pair.second.typeName();
 			p.value = pair.second.serialize();
 			desc.properties.push_back(p);
 		}

--- a/core/src/properties.cpp
+++ b/core/src/properties.cpp
@@ -127,6 +127,10 @@ Property::Property(const type_info& type_info, const std::string& description, c
 	reset();
 }
 
+Property::Property() : Property(typeid(boost::any), "", boost::any())
+{
+}
+
 void Property::setValue(const boost::any &value) {
 	setCurrentValue(value);
 	default_ = value_;

--- a/core/src/properties.cpp
+++ b/core/src/properties.cpp
@@ -159,7 +159,7 @@ std::string Property::serialize(const boost::any& value)
 
 boost::any Property::deserialize(const std::string& type_name, const std::string& wire)
 {
-	if (wire.empty())
+	if (type_name != Property::typeName(typeid(std::string)) && wire.empty())
 		return boost::any();
 	else
 		return registry_singleton_.entry(type_name).deserialize_(wire);

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -53,6 +53,9 @@ MoveRelative::MoveRelative(const std::string& name, const solvers::PlannerInterf
 	p.declare<geometry_msgs::PoseStamped>("ik_frame", "frame to be moved in Cartesian direction");
 
 	p.declare<boost::any>("direction", "motion specification");
+	// register actual types
+	PropertySerializer<geometry_msgs::TwistStamped>();
+	PropertySerializer<geometry_msgs::Vector3Stamped>();
 	p.declare<double>("min_distance", -1.0, "minimum distance to move");
 	p.declare<double>("max_distance", 0.0, "maximum distance to move");
 

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -53,6 +53,11 @@ MoveTo::MoveTo(const std::string& name, const solvers::PlannerInterfacePtr& plan
 	p.declare<std::string>("group", "name of planning group");
 	p.declare<geometry_msgs::PoseStamped>("ik_frame", "frame to be moved towards goal pose");
 	p.declare<boost::any>("goal", "goal specification");
+	// register actual types
+	PropertySerializer<std::string>();
+	PropertySerializer<moveit_msgs::RobotState>();
+	PropertySerializer<geometry_msgs::PointStamped>();
+	PropertySerializer<geometry_msgs::PoseStamped>();
 
 	p.declare<moveit_msgs::Constraints>("path_constraints", moveit_msgs::Constraints(),
 	                                    "constraints to maintain during trajectory");

--- a/core/test/test_properties.cpp
+++ b/core/test/test_properties.cpp
@@ -27,12 +27,11 @@ TEST(Property, directset) {
 	PropertyMap props;
 	props.set("int1", 1);
 	EXPECT_EQ(props.get<int>("int1"), 1);
-	EXPECT_STREQ(props.property("int1").serialize().c_str(), "1");
+	EXPECT_EQ(props.property("int1").serialize(), "1");
 
 	props.set("int2", boost::any(2));
 	EXPECT_EQ(props.get<int>("int2"), 2);
-	// cannot serialize, because directly set
-	EXPECT_STREQ(props.property("int2").serialize().c_str(), "");
+	EXPECT_EQ(props.property("int2").serialize(), "2");
 }
 
 TEST(Property, redeclare) {
@@ -85,6 +84,15 @@ TEST(Property, anytype) {
 
 	props.set("any", std::string("foo"));
 	EXPECT_EQ(props.get<std::string>("any"), "foo");
+}
+
+TEST(Property, serialize_basic) {
+	EXPECT_TRUE(hasSerialize<int>::value);
+	EXPECT_TRUE(hasDeserialize<int>::value);
+	EXPECT_TRUE(hasSerialize<double>::value);
+	EXPECT_TRUE(hasDeserialize<double>::value);
+	EXPECT_TRUE(hasSerialize<std::string>::value);
+	EXPECT_TRUE(hasDeserialize<std::string>::value);
 }
 
 TEST(Property, serialize) {

--- a/msgs/msg/Property.msg
+++ b/msgs/msg/Property.msg
@@ -1,3 +1,4 @@
 string name
 string description
+string type
 string value

--- a/visualization/motion_planning_tasks/properties/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/properties/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES
 )
 
 include(FindPkgConfig)
-pkg_check_modules(YAML yaml-cpp>=0.5)
+pkg_check_modules(YAML yaml-0.1)
 if (YAML_FOUND)
 	# Only cmake > 3.12 provides XXX_LINK_LIBRARIES. Find the absolute path manually
 	find_library(YAML_LIBRARIES ${YAML_LIBRARIES} PATHS ${YAML_LIBRARY_DIRS})

--- a/visualization/motion_planning_tasks/properties/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/properties/CMakeLists.txt
@@ -3,14 +3,24 @@ set(MOVEIT_LIB_NAME motion_planning_tasks_properties)
 set(SOURCES
 	property_factory.cpp
 )
+
+include(FindPkgConfig)
+pkg_check_modules(YAML yaml-cpp>=0.5)
+if (YAML_FOUND)
+	# Only cmake > 3.12 provides XXX_LINK_LIBRARIES. Find the absolute path manually
+	find_library(YAML_LIBRARIES ${YAML_LIBRARIES} PATHS ${YAML_LIBRARY_DIRS})
+	list(APPEND SOURCES property_from_yaml.cpp)
+	add_definitions(-DHAVE_YAML)
+endif()
+
 add_library(${MOVEIT_LIB_NAME} SHARED ${SOURCES})
 
 target_link_libraries(${MOVEIT_LIB_NAME}
-	${QT_LIBRARIES}
+	${QT_LIBRARIES} ${YAML_LIBRARIES}
 )
 target_include_directories(${MOVEIT_LIB_NAME}
 	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-	PRIVATE ${catkin_INCLUDE_DIRS}
+	PRIVATE ${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS}
 )
 
 install(TARGETS ${MOVEIT_LIB_NAME}

--- a/visualization/motion_planning_tasks/properties/property_factory.cpp
+++ b/visualization/motion_planning_tasks/properties/property_factory.cpp
@@ -81,6 +81,21 @@ rviz::Property* PropertyFactory::create(const std::string& prop_name, Property* 
 	return it->second(QString::fromStdString(prop_name), prop);
 }
 
+rviz::Property* PropertyFactory::create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const
+{
+	if (old) {  // reuse existing Property?
+		old->setDescription(QString::fromStdString(p.description));
+		old->setValue(QString::fromStdString(p.value));
+		return old;
+	} else {  // create new Property?
+		rviz::Property *result = new rviz::StringProperty(QString::fromStdString(p.name),
+		                                                  QString::fromStdString(p.value),
+		                                                  QString::fromStdString(p.description));
+		result->setReadOnly(true);
+		return result;
+	}
+}
+
 rviz::PropertyTreeModel* createPropertyTreeModel(PropertyMap& properties, QObject* parent) {
 	PropertyFactory& factory = PropertyFactory::instance();
 

--- a/visualization/motion_planning_tasks/properties/property_factory.cpp
+++ b/visualization/motion_planning_tasks/properties/property_factory.cpp
@@ -106,21 +106,6 @@ rviz::Property* PropertyFactory::create(const std::string& prop_name, mtc::Prope
 	return it->second(QString::fromStdString(prop_name), prop, scene, display_context);
 }
 
-rviz::Property* PropertyFactory::create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const
-{
-	if (old) {  // reuse existing Property?
-		old->setDescription(QString::fromStdString(p.description));
-		old->setValue(QString::fromStdString(p.value));
-		return old;
-	} else {  // create new Property?
-		rviz::Property *result = new rviz::StringProperty(QString::fromStdString(p.name),
-		                                                  QString::fromStdString(p.value),
-		                                                  QString::fromStdString(p.description));
-		result->setReadOnly(true);
-		return result;
-	}
-}
-
 rviz::PropertyTreeModel* PropertyFactory::createPropertyTreeModel(moveit::task_constructor::Stage& stage,
                                                                   const planning_scene::PlanningScene* scene,
                                                                   rviz::DisplayContext* display_context)

--- a/visualization/motion_planning_tasks/properties/property_factory.cpp
+++ b/visualization/motion_planning_tasks/properties/property_factory.cpp
@@ -102,7 +102,8 @@ rviz::Property* PropertyFactory::create(const std::string& prop_name, mtc::Prope
                                         rviz::DisplayContext* display_context) const
 {
 	auto it = property_registry_.find(prop.typeName());
-	if (it == property_registry_.end()) return nullptr;
+	if (it == property_registry_.end())
+		return createDefault(prop_name, prop.typeName(), prop.description(), prop.serialize());
 	return it->second(QString::fromStdString(prop_name), prop, scene, display_context);
 }
 
@@ -148,6 +149,24 @@ void PropertyFactory::addRemainingProperties(rviz::Property* root, mtc::Property
 	// just to see something, when no properties are defined
 	if (root->numChildren() == 0)
 		new rviz::Property("no properties", QVariant(), QString(), root);
+}
+
+rviz::Property* PropertyFactory::createDefault(const std::string& name, const std::string& type,
+                                               const std::string& description, const std::string& value,
+                                               rviz::Property* old)
+{
+	if (old) {  // reuse existing Property?
+		assert(old->getNameStd() == name);
+		old->setDescription(QString::fromStdString(description));
+		old->setValue(QString::fromStdString(value));
+		return old;
+	} else {  // create new Property?
+		rviz::Property *result = new rviz::StringProperty(QString::fromStdString(name),
+		                                                  QString::fromStdString(value),
+		                                                  QString::fromStdString(description));
+		result->setReadOnly(true);
+		return result;
+	}
 }
 
 }

--- a/visualization/motion_planning_tasks/properties/property_factory.cpp
+++ b/visualization/motion_planning_tasks/properties/property_factory.cpp
@@ -151,6 +151,7 @@ void PropertyFactory::addRemainingProperties(rviz::Property* root, mtc::Property
 		new rviz::Property("no properties", QVariant(), QString(), root);
 }
 
+#ifndef HAVE_YAML
 rviz::Property* PropertyFactory::createDefault(const std::string& name, const std::string& type,
                                                const std::string& description, const std::string& value,
                                                rviz::Property* old)
@@ -168,5 +169,6 @@ rviz::Property* PropertyFactory::createDefault(const std::string& name, const st
 		return result;
 	}
 }
+#endif
 
 }

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -48,6 +48,10 @@
 namespace rviz {
 class Property;
 class PropertyTreeModel;
+class DisplayContext;
+}
+namespace planning_scene {
+class PlanningScene;
 }
 namespace moveit { namespace task_constructor {
 class Stage;
@@ -60,8 +64,12 @@ class PropertyFactory
 public:
 	static PropertyFactory& instance();
 
-	typedef std::function<rviz::Property*(const QString& name, moveit::task_constructor::Property&)> PropertyFactoryFunction;
-	typedef std::function<rviz::PropertyTreeModel*(moveit::task_constructor::PropertyMap&)> TreeFactoryFunction;
+	typedef std::function<rviz::Property*(const QString& name, moveit::task_constructor::Property&,
+	                                      const planning_scene::PlanningScene* scene,
+	                                      rviz::DisplayContext* display_context)> PropertyFactoryFunction;
+	typedef std::function<rviz::PropertyTreeModel*(moveit::task_constructor::PropertyMap&,
+	                                               const planning_scene::PlanningScene* scene,
+	                                               rviz::DisplayContext* display_context)> TreeFactoryFunction;
 
 	/// register a factory function for type T
 	template <typename T>
@@ -75,18 +83,25 @@ public:
 	inline void registerStage(const TreeFactoryFunction& f) { registerStage(typeid(T), f); }
 
 	/// create rviz::Property for given MTC Property
-	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property &prop) const;
+	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property &prop,
+	                       const planning_scene::PlanningScene*scene, rviz::DisplayContext *display_context) const;
 	/// create rviz::Property for given MTC property message
 	rviz::Property* create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const;
 
 	/// create PropertyTreeModel for given Stage
-	rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::Stage &stage);
+	rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::Stage &stage,
+	                                                 const planning_scene::PlanningScene* scene,
+	                                                 rviz::DisplayContext* display_context);
 
 	/// turn a PropertyMap into an rviz::PropertyTreeModel
-	rviz::PropertyTreeModel* defaultPropertyTreeModel(moveit::task_constructor::PropertyMap &properties);
+	rviz::PropertyTreeModel* defaultPropertyTreeModel(moveit::task_constructor::PropertyMap &properties,
+	                                                  const planning_scene::PlanningScene* scene,
+	                                                  rviz::DisplayContext* display_context);
 
 	/// add all properties from map that are not yet in root
-	void addRemainingProperties(rviz::Property *root, moveit::task_constructor::PropertyMap &properties);
+	void addRemainingProperties(rviz::Property *root, moveit::task_constructor::PropertyMap &properties,
+	                            const planning_scene::PlanningScene* scene,
+	                            rviz::DisplayContext* display_context);
 
 private:
 	std::map<std::string, PropertyFactoryFunction> property_registry_;

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -41,6 +41,7 @@
 #include <map>
 #include <functional>
 #include <typeindex>
+#include <moveit_task_constructor_msgs/Property.h>
 
 namespace rviz {
 class Property;
@@ -62,10 +63,12 @@ public:
 
 	/// register a new factory function for type T
 	template <typename T>
-	void registerType(const FactoryFunction& f) { registerType(std::type_index(typeid(T)).name(), f); }
+	void registerType(const FactoryFunction& f) { registerType(typeid(T).name(), f); }
 
-	/// retrieve rviz property for given task_constructor property
+	/// create rviz::Property for given MTC Property
 	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property *prop) const;
+	/// create rviz::Property for given MTC property message
+	rviz::Property* create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const;
 
 private:
 	std::map<std::string, FactoryFunction> registry_;

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -41,16 +41,14 @@
 #include <map>
 #include <functional>
 #include <typeindex>
+
+#include <moveit/task_constructor/properties.h>
 #include <moveit_task_constructor_msgs/Property.h>
 
 namespace rviz {
 class Property;
 class PropertyTreeModel;
 }
-namespace moveit { namespace task_constructor {
-class Property;
-class PropertyMap;
-} }
 
 namespace moveit_rviz_plugin {
 
@@ -59,14 +57,17 @@ class PropertyFactory
 public:
 	static PropertyFactory& instance();
 
-	typedef std::function<rviz::Property*(const QString& name, moveit::task_constructor::Property*)> FactoryFunction;
+	typedef std::function<rviz::Property*(const QString& name, moveit::task_constructor::Property&)> FactoryFunction;
 
 	/// register a new factory function for type T
 	template <typename T>
-	void registerType(const FactoryFunction& f) { registerType(typeid(T).name(), f); }
+	inline void registerType(const FactoryFunction& f) {
+		moveit::task_constructor::PropertySerializer<T>();  // register serializer
+		registerType(moveit::task_constructor::Property::typeName(typeid(T)), f);
+	}
 
 	/// create rviz::Property for given MTC Property
-	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property *prop) const;
+	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property &prop) const;
 	/// create rviz::Property for given MTC property message
 	rviz::Property* create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const;
 
@@ -82,6 +83,6 @@ private:
 };
 
 /// turn a PropertyMap into an rviz::PropertyTreeModel
-rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::PropertyMap &properties, QObject *parent = nullptr);
+rviz::PropertyTreeModel* defaultPropertyTreeModel(moveit::task_constructor::PropertyMap &properties, QObject *parent = nullptr);
 
 }

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -43,7 +43,6 @@
 #include <typeindex>
 
 #include <moveit/task_constructor/properties.h>
-#include <moveit_task_constructor_msgs/Property.h>
 
 namespace rviz {
 class Property;
@@ -59,6 +58,16 @@ class Stage;
 
 namespace moveit_rviz_plugin {
 
+/** Registry for rviz::Property and rviz::PropertyTreeModel creator functions.
+ *
+ *  To inspect (and edit) properties of stages, our MTC properties are converted to rviz properties,
+ *  which are finally shown in an rviz::PropertyTree.
+ *  To allow customization of property display, one can register creator functions for individual
+ *  properties as well as creator functions for a complete stage. The latter allows to fully customize
+ *  the display of stage properties, e.g. hiding specific properties, or returning a subclassed
+ *  PropertyTreeModel with modified behaviour. By default, defaultPropertyTreeModel() creates an rviz
+ *  property for each MTC property.
+ */
 class PropertyFactory
 {
 public:
@@ -75,7 +84,7 @@ public:
 	template <typename T>
 	inline void registerType(const PropertyFactoryFunction& f) {
 		moveit::task_constructor::PropertySerializer<T>();  // register serializer
-		registerType(moveit::task_constructor::Property::typeName(typeid(T)), f);
+		registerType(moveit::task_constructor::PropertySerializer<T>::typeName(), f);
 	}
 
 	/// register a factory function for stage T
@@ -84,9 +93,7 @@ public:
 
 	/// create rviz::Property for given MTC Property
 	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property &prop,
-	                       const planning_scene::PlanningScene*scene, rviz::DisplayContext *display_context) const;
-	/// create rviz::Property for given MTC property message
-	rviz::Property* create(const moveit_task_constructor_msgs::Property& p, rviz::Property* old) const;
+	                       const planning_scene::PlanningScene *scene, rviz::DisplayContext *display_context) const;
 
 	/// create PropertyTreeModel for given Stage
 	rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::Stage &stage,

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -94,6 +94,10 @@ public:
 	/// create rviz::Property for given MTC Property
 	rviz::Property* create(const std::string &prop_name, moveit::task_constructor::Property &prop,
 	                       const planning_scene::PlanningScene *scene, rviz::DisplayContext *display_context) const;
+	/// create rviz::Property for property of given name, type, description, and value
+	static rviz::Property* createDefault(const std::string& name, const std::string& type,
+	                                     const std::string& description, const std::string& value,
+	                                     rviz::Property* old=nullptr);
 
 	/// create PropertyTreeModel for given Stage
 	rviz::PropertyTreeModel* createPropertyTreeModel(moveit::task_constructor::Stage &stage,

--- a/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
+++ b/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
@@ -41,76 +41,153 @@
 
 namespace mtc = ::moveit::task_constructor;
 
-namespace moveit_rviz_plugin {
-
 /** Implement PropertyFactory::createDefault(), creating an rviz::Property (tree)
  *  from a YAML-serialized string.
  *  As we cannot know the required data type for a field from YAML parsing,
  *  we only distinguish numbers (FloatProperty) and all other YAML scalars (StringProperty).
  */
-#if 0
+
+namespace {
+
+// Event-based YAML parser, creating an rviz::Property tree
+// https://www.wpsoftware.net/andrew/pages/libyaml.html
+class Parser {
+public:
+	static const int YAML_ERROR_EVENT = 255;
+
+	Parser(const std::string& value);
+	~Parser();
+
+	rviz::Property* process(const QString& name, const QString& description, rviz::Property *old) const;
+	static rviz::Property* createScalar(const QString& name, const QString& description,
+	                                    const QByteArray& value, rviz::Property *old);
+
+private:
+	// return true if there was no error so far
+	bool noError() const { return parser_.error == YAML_NO_ERROR; }
+	// parse a single event and return it's type, YAML_ERROR_EVENT on parsing error
+	int parse(yaml_event_t& event) const;
+	// process events: scalar, start mapping, start sequence
+	rviz::Property *process(const yaml_event_t &event, const QString &name, const QString &description, rviz::Property *old) const;
+
+	inline static QByteArray byteArray(const yaml_event_t& event) {
+		assert(event.type == YAML_SCALAR_EVENT);
+		return QByteArray::fromRawData(reinterpret_cast<const char*>(event.data.scalar.value),
+		                               event.data.scalar.length);
+	}
+	// Try to set value of existing rviz::Property (expecting matching types). Return false on error.
+	static bool setValue(rviz::Property *old, const QByteArray &value);
+
+	static rviz::Property *createParent(const QString &name, const QString &description, rviz::Property *old);
+	rviz::Property* processMapping(const QString& name, const QString& description, rviz::Property *old) const;
+	rviz::Property* processSequence(const QString& name, const QString& description, rviz::Property *old) const;
+
+private:
+	mutable yaml_parser_t parser_;
+};
+
+Parser::Parser(const std::string &value) {
+	yaml_parser_initialize(&parser_);
+	yaml_parser_set_input_string(&parser_, reinterpret_cast<const yaml_char_t*>(value.c_str()), value.size());
+}
+
+Parser::~Parser() {
+	yaml_parser_delete(&parser_);
+}
+
+int Parser::parse(yaml_event_t &event) const {
+	if (!yaml_parser_parse(&parser_, &event)) {
+		yaml_event_delete(&event);
+		return YAML_ERROR_EVENT;
+	}
+	return event.type;
+}
+
+// main processing function
+rviz::Property *Parser::process(const QString &name, const QString &description, rviz::Property *old) const {
+	bool stop = false;
+	while (!stop) {
+		yaml_event_t event;
+		switch (parse(event)) {
+		case YAML_ERROR_EVENT: return Parser::createScalar(name, description, "YAML error", old);
+		case YAML_STREAM_END_EVENT:
+			stop = true;
+			break;
+
+		case YAML_SEQUENCE_START_EVENT:
+		case YAML_MAPPING_START_EVENT:
+		case YAML_SCALAR_EVENT:
+			return process(event, name, description, old);
+
+		default: break;
+		}
+	}
+	// if we get here, there was no content in the yaml stream
+	return createScalar(name, description, "undefined", old);
+}
+
+// default processing for scalar, start mapping, start sequence events
+rviz::Property* Parser::process(const yaml_event_t& event,
+                                const QString& name, const QString& description, rviz::Property *old) const {
+	switch (event.type) {
+	case YAML_SEQUENCE_START_EVENT: return processSequence(name, description, old);
+	case YAML_MAPPING_START_EVENT: return processMapping(name, description, old);
+	case YAML_SCALAR_EVENT: return createScalar(name, description, byteArray(event), old);
+	}
+	assert(false);  // should not be reached
+}
+
 // Try to set numeric or arbitrary scalar value from YAML node. Needs to match old's type.
-void setScalarValue(rviz::Property* old, const YAML::Node& node)
+bool Parser::setValue(rviz::Property* old, const QByteArray& value)
 {
 	if (rviz::FloatProperty* p = dynamic_cast<rviz::FloatProperty*>(old)) {
-		// value should be a number. If not throws YAML::BadConversion
-		p->setValue(node.as<double>());
-		return;
+		bool ok = true;
+		double v = value.toDouble(&ok);
+		if (ok) p->setValue(v);
+		return ok;
 	}
 	if (rviz::StringProperty* p = dynamic_cast<rviz::StringProperty*>(old)) {
 		// value should be an arbitrary string. If not throws YAML::BadConversion
-		p->setValue(QString::fromStdString(node.as<std::string>()));
-		return;
+		p->setValue(value);
+		return true;
 	}
-	throw YAML::BadConversion();
+	return false;
 }
 
 // Update existing old rviz:Property or create a new one from scalar YAML node
-rviz::Property* createFromScalar(const QString& name, const QString& description,
-                                 const YAML::Node& node, rviz::Property* old)
+rviz::Property *Parser::createScalar(const QString &name, const QString &description,
+                                     const QByteArray &value, rviz::Property *old)
 {
-	while (old) {  // reuse existing Property?
-		try {
-			// try to update value, expecting matching rviz::Property
-			setScalarValue(old, node);
-			// only if setScalarValue succeeded, also update the rest
-			old->setName(name);
-			old->setDescription(description);
-			return old;
-		} catch (const YAML::BadConversion&) {
-			break;  // on error, break from loop and create a new property
-		}
+	// try to update value, expecting matching rviz::Property
+	if (old && setValue(old, value)) {
+		// only if setValue succeeded, also update the rest
+		old->setName(name);
+		old->setDescription(description);
+		return old;
 	}
 
-	// if value is a number, create a FloatProperty
-	try { return new rviz::FloatProperty(name, node.as<double>(), description); }
-	catch (const YAML::BadConversion&) {}
+	bool ok = true;
+	double v = value.toDouble(&ok);
+	if (ok) // if value is a number, create a FloatProperty
+		old = new rviz::FloatProperty(name, v, description);
+	else // otherwise create a StringProperty
+		old = new rviz::StringProperty(name, value, description);
 
-	// otherwise create a StringProperty
-	return new rviz::StringProperty(name, QString::fromStdString(node.as<std::string>()), description);
+	old->setReadOnly(true);
+	return old;
 }
-
-// Create a scalar YAML node with given content value
-YAML::Node dummyNode(const std::string& content) {
-	YAML::Node dummy;
-	dummy=content;
-	return dummy;
-}
-
-// forward declaration
-rviz::Property* createFromNode(const QString& name, const QString& description,
-                               const YAML::Node& node, rviz::Property* old);
 
 // Reuse old property (or create new one) as parent for a sequence or map
-rviz::Property* createParent(const QString& name, const QString& description, rviz::Property* old)
+rviz::Property* Parser::createParent(const QString& name, const QString& description, rviz::Property* old)
 {
 	// don't reuse float or string properties (they are for scalars)
 	if (dynamic_cast<rviz::FloatProperty*>(old) ||
 	    dynamic_cast<rviz::StringProperty*>(old))
 		old = nullptr;
-	if (!old)
-		old = new rviz::Property(name, description);
-	else {
+	if (!old) {
+		old = new rviz::Property(name, QVariant(), description);
+		old->setReadOnly(true);
+	} else {
 		old->setName(name);
 		old->setDescription(description);
 	}
@@ -118,31 +195,58 @@ rviz::Property* createParent(const QString& name, const QString& description, rv
 }
 
 // Hierarchically create property from YAML map node
-rviz::Property* createFromMap(const QString& name, const QString& description,
-                              const YAML::Node& node, rviz::Property* root)
+rviz::Property* Parser::processMapping(const QString& name, const QString& description, rviz::Property* root) const
 {
 	root = createParent(name, description, root);
 	int index = 0;  // current child index in root
-	for(YAML::const_iterator it=node.begin(); it!=node.end(); ++it) {
-		QString child_name = QString::fromStdString(it->first.as<std::string>());
-		int num = root->numChildren();
-		// find first child with name >= it->name
-		int next = index;
-		while (next < num && root->childAt(next)->getName() < child_name)
-			++next;
-		// and remove all children in range [index, next) at once
-		root->removeChildren(index, next-index);
-		num = root->numChildren();
+	bool stop = false;
+	while (!stop && noError()) {  // parse all map items
+		yaml_event_t event;
+		switch (parse(event)) {  // parse key
+		case YAML_MAPPING_END_EVENT:  // all fine, reached end of mapping
+			stop = true;
+			break;
 
-		// if names differ, insert a new child, otherwise reuse existing
-		rviz::Property *old_child = index < num ? root->childAt(index) : nullptr;
-		if (old_child && old_child->getName() != child_name)
-			old_child = nullptr;
+		case YAML_SCALAR_EVENT: { // key
+			QByteArray key = byteArray(event);
+			int num = root->numChildren();
+			// find first child with name >= it->name
+			int next = index;
+			while (next < num && root->childAt(next)->getName() < key)
+				++next;
+			// and remove all children in range [index, next) at once
+			root->removeChildren(index, next-index);
+			num = root->numChildren();
 
-		rviz::Property *new_child = createFromNode(child_name, "", it->second, old_child);
-		if (new_child != old_child)
-			root->addChild(new_child, index);
-		++index;
+			// if names differ, insert a new child, otherwise reuse existing
+			rviz::Property *old_child = index < num ? root->childAt(index) : nullptr;
+			if (old_child && old_child->getName() != key)
+				old_child = nullptr;
+
+			rviz::Property *new_child = nullptr;
+			switch (parse(event)) { // parse value
+			case YAML_MAPPING_START_EVENT:
+			case YAML_SEQUENCE_START_EVENT:
+			case YAML_SCALAR_EVENT:
+				new_child = process(event, key, "", old_child);
+				break;
+			default:  // all other events are an error
+				new_child = createScalar(key, "", parser_.problem, old_child);
+				root->setValue("YAML error");
+				break;
+			}
+
+			if (new_child != old_child)
+				root->addChild(new_child, index);
+			++index;
+			break;
+		}
+
+		default:  // unexpected event
+			root->setValue("YAML error");
+			stop = true;
+			break;
+		}
 	}
 	// remove remaining children
 	root->removeChildren(index, root->numChildren()-index);
@@ -150,42 +254,44 @@ rviz::Property* createFromMap(const QString& name, const QString& description,
 }
 
 // Hierarchically create property from YAML sequence node. Items are named [#].
-rviz::Property* createFromSequence(const QString& name, const QString& description,
-                                   const YAML::Node& node, rviz::Property* root)
+rviz::Property* Parser::processSequence(const QString& name, const QString& description, rviz::Property* root) const
 {
 	root = createParent(name, description, root);
 	int index = 0;  // current child index in root
-	for (YAML::const_iterator it=node.begin(); it != node.end(); ++it) {
-		rviz::Property *old_child = root->childAt(index);  // nullptr for invalid index
-		rviz::Property *new_child = createFromNode(QString("[%1]").arg(index), "", *it, old_child);
-		if (new_child != old_child)
-			root->addChild(new_child, index);
-		if (++index >= 10)
-			break; // limit number of entries
+	bool stop = false;
+	while (!stop && noError()) {  // parse all map items
+		yaml_event_t event;
+		switch (parse(event)) {
+		case YAML_SEQUENCE_END_EVENT:  // all fine, reached end of sequence
+			stop = true;
+			break;
+
+		case YAML_MAPPING_START_EVENT:
+		case YAML_SEQUENCE_START_EVENT:
+		case YAML_SCALAR_EVENT: {
+			rviz::Property *old_child = root->childAt(index);  // nullptr for invalid index
+			rviz::Property *new_child = process(event, 	QString("[%1]").arg(index), "", old_child);
+			if (new_child != old_child)
+				root->addChild(new_child, index);
+			if (++index >= 10)
+				stop = true;  // limit number of shown entries
+			break;
+		}
+
+		default:  // unexpected event
+			root->setValue("YAML error");
+			stop = true;
+			break;
+		}
 	}
 	// remove remaining children
 	root->removeChildren(index, root->numChildren()-index);
 	return root;
 }
 
-// Create a property from any YAML node.
-rviz::Property* createFromNode(const QString& name, const QString& description,
-                              const YAML::Node& node, rviz::Property* old)
-{
-	rviz::Property* result = nullptr;
-	switch(node.Type()) {
-	case YAML::NodeType::Scalar: result = createFromScalar(name, description, node, old); break;
-	case YAML::NodeType::Sequence: result = createFromSequence(name, description, node, old); break;
-	case YAML::NodeType::Map: result = createFromMap(name, description, node, old); break;
-	case YAML::NodeType::Null: result = createFromScalar(name, description, dummyNode("undefined"), old); break;
-	default: result = createFromScalar(name, description, dummyNode("unknown YAML node"), old); break;
-	}
-	result->setReadOnly(true);
-	return result;
 }
-#endif
 
-inline std::string indent(unsigned int depth) { return std::string(2*depth, ' '); }
+namespace moveit_rviz_plugin {
 
 rviz::Property* PropertyFactory::createDefault(const std::string& name, const std::string& type,
                                                const std::string& description, const std::string& value,
@@ -193,46 +299,8 @@ rviz::Property* PropertyFactory::createDefault(const std::string& name, const st
 {
 	QString qname = QString::fromStdString(name);
 	QString qdesc = QString::fromStdString(description);
-
-	yaml_parser_t parser;
-	yaml_parser_initialize(&parser);
-	yaml_parser_set_input_string(&parser, reinterpret_cast<const yaml_char_t*>(value.c_str()), value.size());
-	try {
-		unsigned int depth=0;
-		bool proceed = true;
-		while (proceed) {
-			yaml_event_t event;
-			if (!yaml_parser_parse(&parser, &event)) {
-				yaml_event_delete(&event);
-				throw std::runtime_error(parser.problem);
-				break;
-			}
-
-			switch(event.type)
-			{
-			case YAML_NO_EVENT: std::cout << indent(depth) << "No event!" << std::endl; break;
-			/* Stream start/end */
-			case YAML_STREAM_START_EVENT: std::cout << indent(depth++) << "STREAM START" << std::endl; break;
-			case YAML_STREAM_END_EVENT:   std::cout << indent(--depth) << "STREAM END" << std::endl;   break;
-			/* Block delimeters */
-			case YAML_DOCUMENT_START_EVENT: std::cout << indent(depth++) << "Start Document" << std::endl; break;
-			case YAML_DOCUMENT_END_EVENT:   std::cout << indent(--depth) << "End Document" << std::endl;   break;
-			case YAML_SEQUENCE_START_EVENT: std::cout << indent(depth++) << "Start Sequence" << std::endl; break;
-			case YAML_SEQUENCE_END_EVENT:   std::cout << indent(--depth) << "End Sequence" << std::endl;   break;
-			case YAML_MAPPING_START_EVENT:  std::cout << indent(depth++) << "Start Mapping" << std::endl;  break;
-			case YAML_MAPPING_END_EVENT:    std::cout << indent(--depth) << "End Mapping" << std::endl;    break;
-			/* Data */
-			case YAML_ALIAS_EVENT:  std::cout << indent(depth) << "alias anchor=" << event.data.alias.anchor << std::endl; break;
-			case YAML_SCALAR_EVENT: std::cout << indent(depth) << "scalar: " << event.data.scalar.value << std::endl; break;
-			}
-			proceed = event.type != YAML_STREAM_END_EVENT;
-			yaml_event_delete(&event);
-		}
-		return nullptr;
-	} catch (const std::exception &e) {
-		std::cout << e.what() << std::endl;
-		return nullptr;
-	}
+	Parser parser(value);
+	return parser.process(qname, qdesc, old);
 }
 
 }

--- a/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
+++ b/visualization/motion_planning_tasks/properties/property_from_yaml.cpp
@@ -1,0 +1,200 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Robert Haschke */
+
+#include "property_factory.h"
+#include <yaml-cpp/yaml.h>
+#include <rviz/properties/string_property.h>
+#include <rviz/properties/float_property.h>
+
+namespace mtc = ::moveit::task_constructor;
+
+namespace moveit_rviz_plugin {
+
+/** Implement PropertyFactory::createDefault(), creating an rviz::Property (tree)
+ *  from a YAML-serialized string.
+ *  As we cannot know the required data type for a field from YAML parsing,
+ *  we only distinguish numbers (FloatProperty) and all other YAML scalars (StringProperty).
+ */
+
+// Try to set numeric or arbitrary scalar value from YAML node. Needs to match old's type.
+void setScalarValue(rviz::Property* old, const YAML::Node& node)
+{
+	if (rviz::FloatProperty* p = dynamic_cast<rviz::FloatProperty*>(old)) {
+		// value should be a number. If not throws YAML::BadConversion
+		p->setValue(node.as<double>());
+		return;
+	}
+	if (rviz::StringProperty* p = dynamic_cast<rviz::StringProperty*>(old)) {
+		// value should be an arbitrary string. If not throws YAML::BadConversion
+		p->setValue(QString::fromStdString(node.as<std::string>()));
+		return;
+	}
+	throw YAML::BadConversion();
+}
+
+// Update existing old rviz:Property or create a new one from scalar YAML node
+rviz::Property* createFromScalar(const QString& name, const QString& description,
+                                 const YAML::Node& node, rviz::Property* old)
+{
+	while (old) {  // reuse existing Property?
+		try {
+			// try to update value, expecting matching rviz::Property
+			setScalarValue(old, node);
+			// only if setScalarValue succeeded, also update the rest
+			old->setName(name);
+			old->setDescription(description);
+			return old;
+		} catch (const YAML::BadConversion&) {
+			break;  // on error, break from loop and create a new property
+		}
+	}
+
+	// if value is a number, create a FloatProperty
+	try { return new rviz::FloatProperty(name, node.as<double>(), description); }
+	catch (const YAML::BadConversion&) {}
+
+	// otherwise create a StringProperty
+	return new rviz::StringProperty(name, QString::fromStdString(node.as<std::string>()), description);
+}
+
+// Create a scalar YAML node with given content value
+YAML::Node dummyNode(const std::string& content) {
+	YAML::Node dummy;
+	dummy=content;
+	return dummy;
+}
+
+// forward declaration
+rviz::Property* createFromNode(const QString& name, const QString& description,
+                               const YAML::Node& node, rviz::Property* old);
+
+// Reuse old property (or create new one) as parent for a sequence or map
+rviz::Property* createParent(const QString& name, const QString& description, rviz::Property* old)
+{
+	// don't reuse float or string properties (they are for scalars)
+	if (dynamic_cast<rviz::FloatProperty*>(old) ||
+	    dynamic_cast<rviz::StringProperty*>(old))
+		old = nullptr;
+	if (!old)
+		old = new rviz::Property(name, description);
+	else {
+		old->setName(name);
+		old->setDescription(description);
+	}
+	return old;
+}
+
+// Hierarchically create property from YAML map node
+rviz::Property* createFromMap(const QString& name, const QString& description,
+                              const YAML::Node& node, rviz::Property* root)
+{
+	root = createParent(name, description, root);
+	int index = 0;  // current child index in root
+	for(YAML::const_iterator it=node.begin(); it!=node.end(); ++it) {
+		QString child_name = QString::fromStdString(it->first.as<std::string>());
+		int num = root->numChildren();
+		// find first child with name >= it->name
+		int next = index;
+		while (next < num && root->childAt(next)->getName() < child_name)
+			++next;
+		// and remove all children in range [index, next) at once
+		root->removeChildren(index, next-index);
+		num = root->numChildren();
+
+		// if names differ, insert a new child, otherwise reuse existing
+		rviz::Property *old_child = index < num ? root->childAt(index) : nullptr;
+		if (old_child && old_child->getName() != child_name)
+			old_child = nullptr;
+
+		rviz::Property *new_child = createFromNode(child_name, "", it->second, old_child);
+		if (new_child != old_child)
+			root->addChild(new_child, index);
+		++index;
+	}
+	// remove remaining children
+	root->removeChildren(index, root->numChildren()-index);
+	return root;
+}
+
+// Hierarchically create property from YAML sequence node. Items are named [#].
+rviz::Property* createFromSequence(const QString& name, const QString& description,
+                                   const YAML::Node& node, rviz::Property* root)
+{
+	root = createParent(name, description, root);
+	int index = 0;  // current child index in root
+	for (YAML::const_iterator it=node.begin(); it != node.end(); ++it) {
+		rviz::Property *old_child = root->childAt(index);  // nullptr for invalid index
+		rviz::Property *new_child = createFromNode(QString("[%1]").arg(index), "", *it, old_child);
+		if (new_child != old_child)
+			root->addChild(new_child, index);
+		if (++index >= 10)
+			break; // limit number of entries
+	}
+	// remove remaining children
+	root->removeChildren(index, root->numChildren()-index);
+	return root;
+}
+
+// Create a property from any YAML node.
+rviz::Property* createFromNode(const QString& name, const QString& description,
+                              const YAML::Node& node, rviz::Property* old)
+{
+	rviz::Property* result = nullptr;
+	switch(node.Type()) {
+	case YAML::NodeType::Scalar: result = createFromScalar(name, description, node, old); break;
+	case YAML::NodeType::Sequence: result = createFromSequence(name, description, node, old); break;
+	case YAML::NodeType::Map: result = createFromMap(name, description, node, old); break;
+	case YAML::NodeType::Null: result = createFromScalar(name, description, dummyNode("undefined"), old); break;
+	default: result = createFromScalar(name, description, dummyNode("unknown YAML node"), old); break;
+	}
+	result->setReadOnly(true);
+	return result;
+}
+
+rviz::Property* PropertyFactory::createDefault(const std::string& name, const std::string& type,
+                                               const std::string& description, const std::string& value,
+                                               rviz::Property* old)
+{
+	QString qname = QString::fromStdString(name);
+	QString qdesc = QString::fromStdString(description);
+	try {
+		return createFromNode(qname, qdesc, YAML::Load(value), old);
+	} catch (const std::exception &e) {
+		return createFromNode(qname, qdesc, dummyNode("YAML parse error"), old);
+	}
+}
+
+}

--- a/visualization/motion_planning_tasks/src/factory_model.h
+++ b/visualization/motion_planning_tasks/src/factory_model.h
@@ -41,6 +41,9 @@
 
 namespace moveit_rviz_plugin {
 
+/** Provide a tree model listing all available plugins from the rviz::Factory
+ *  grouped by package name
+ */
 class FactoryModel : public QStandardItemModel
 {
 	QString mime_type_;

--- a/visualization/motion_planning_tasks/src/local_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/local_task_model.cpp
@@ -245,8 +245,10 @@ rviz::PropertyTreeModel* LocalTaskModel::getPropertyModel(const QModelIndex &ind
 	Node *n = node(index);
 	if (!n) return nullptr;
 	auto it_inserted = properties_.insert(std::make_pair(n, nullptr));
+	// TODO: We might need custom factory methods to create PropertyTreeModels
+	// that are specifically tailored to a Stage class.
 	if (it_inserted.second)  // newly inserted, create new model
-		it_inserted.first->second = createPropertyTreeModel(n->me()->properties(), this);
+		it_inserted.first->second = defaultPropertyTreeModel(n->me()->properties(), this);
 	return it_inserted.first->second;
 }
 

--- a/visualization/motion_planning_tasks/src/local_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/local_task_model.cpp
@@ -38,6 +38,7 @@
 #include "factory_model.h"
 #include "properties/property_factory.h"
 #include <moveit/task_constructor/container_p.h>
+#include <rviz/properties/property_tree_model.h>
 
 #include <ros/console.h>
 
@@ -247,8 +248,10 @@ rviz::PropertyTreeModel* LocalTaskModel::getPropertyModel(const QModelIndex &ind
 	auto it_inserted = properties_.insert(std::make_pair(n, nullptr));
 	// TODO: We might need custom factory methods to create PropertyTreeModels
 	// that are specifically tailored to a Stage class.
-	if (it_inserted.second)  // newly inserted, create new model
-		it_inserted.first->second = defaultPropertyTreeModel(n->me()->properties(), this);
+	if (it_inserted.second) {  // newly inserted, create new model
+		it_inserted.first->second = PropertyFactory::instance().createPropertyTreeModel(*n->me());
+		it_inserted.first->second->setParent(this);
+	}
 	return it_inserted.first->second;
 }
 

--- a/visualization/motion_planning_tasks/src/local_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/local_task_model.cpp
@@ -80,10 +80,8 @@ QModelIndex LocalTaskModel::index(Node *n) const
 
 LocalTaskModel::LocalTaskModel(ContainerBase::pointer &&container, const planning_scene::PlanningSceneConstPtr& scene,
                                rviz::DisplayContext* display_context, QObject* parent)
-   : BaseTaskModel(parent)
+   : BaseTaskModel(scene, display_context, parent)
    , Task("", std::move(container))
-   , scene_(scene)
-   , display_context_(display_context)
 {
 	root_ = pimpl();
 	flags_ |= LOCAL_MODEL;

--- a/visualization/motion_planning_tasks/src/local_task_model.h
+++ b/visualization/motion_planning_tasks/src/local_task_model.h
@@ -49,14 +49,17 @@ class LocalTaskModel
 	typedef moveit::task_constructor::StagePrivate Node;
 	Node *root_;
 	StageFactoryPtr stage_factory_;
+	planning_scene::PlanningSceneConstPtr scene_;
+	rviz::DisplayContext* display_context_;
+
 	std::map<Node*, rviz::PropertyTreeModel*> properties_;
 
 	inline Node* node(const QModelIndex &index) const;
 	QModelIndex index(Node *n) const;
 
 public:
-	LocalTaskModel(QObject *parent = nullptr);
-	LocalTaskModel(ContainerBase::pointer &&container, QObject *parent = nullptr);
+	LocalTaskModel(ContainerBase::pointer &&container, const planning_scene::PlanningSceneConstPtr &scene,
+	               rviz::DisplayContext* display_context, QObject *parent = nullptr);
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
 	QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;

--- a/visualization/motion_planning_tasks/src/local_task_model.h
+++ b/visualization/motion_planning_tasks/src/local_task_model.h
@@ -49,9 +49,6 @@ class LocalTaskModel
 	typedef moveit::task_constructor::StagePrivate Node;
 	Node *root_;
 	StageFactoryPtr stage_factory_;
-	planning_scene::PlanningSceneConstPtr scene_;
-	rviz::DisplayContext* display_context_;
-
 	std::map<Node*, rviz::PropertyTreeModel*> properties_;
 
 	inline Node* node(const QModelIndex &index) const;

--- a/visualization/motion_planning_tasks/src/pluginlib_factory.h
+++ b/visualization/motion_planning_tasks/src/pluginlib_factory.h
@@ -54,6 +54,9 @@
 
 namespace moveit_rviz_plugin {
 
+/** Templated factory to create objects of a given pluginlib base class type.
+ *  This is a slightly modified version of rviz::PluginlibFactory, providing a custom mime type.
+ */
 template<class Type>
 class PluginlibFactory: public rviz::Factory
 {
@@ -177,9 +180,8 @@ public:
    * @param error_return If non-NULL and there is an error, *error_return is set to a description of the problem.
    * @return A new instance of the class identified by class_id, or NULL if there was an error.
    *
-   * If makeRaw() returns NULL and error_return is not NULL,
-   * *error_return will be set.  On success, *error_return will not be
-   * changed. */
+   * If makeRaw() returns NULL and error_return is not NULL, *error_return will be set.
+   * On success, *error_return will not be changed. */
   virtual Type* makeRaw( const QString& class_id, QString* error_return = NULL )
     {
       typename QHash<QString, BuiltInClassRecord>::const_iterator iter = built_ins_.find( class_id );

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -129,7 +129,7 @@ RemoteTaskModel::Node::createProperty(const moveit_task_constructor_msgs::Proper
 	auto& factory = PropertyFactory::instance();
 	// try to deserialize from msg (using registered functions)
 	boost::any value = Property::deserialize(prop.type, prop.value);
-	if (!value.empty()) {
+	if (!value.empty()) {  // if successful, create rviz::Property from mtc::Property using factory methods
 		auto it = properties_.insert(std::make_pair(prop.name, Property())).first;
 		it->second.setDescription(prop.description);
 		it->second.setValue(value);
@@ -140,17 +140,8 @@ RemoteTaskModel::Node::createProperty(const moveit_task_constructor_msgs::Proper
 			properties_.erase(it);
 	}
 
-	if (old) {  // reuse existing Property?
-		old->setDescription(QString::fromStdString(prop.description));
-		old->setValue(QString::fromStdString(prop.value));
-		return old;
-	} else {  // create new Property?
-		rviz::Property *result = new rviz::StringProperty(QString::fromStdString(prop.name),
-		                                                  QString::fromStdString(prop.value),
-		                                                  QString::fromStdString(prop.description));
-		result->setReadOnly(true);
-		return result;
-	}
+	// otherwise create default, read-only rviz::Property by parsing serialized YAML
+	return factory.createDefault(prop.name, prop.type, prop.description, prop.value, old);
 }
 
 // return Node* corresponding to index

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -134,7 +134,7 @@ RemoteTaskModel::Node::createProperty(const moveit_task_constructor_msgs::Proper
 		it->second.setDescription(prop.description);
 		it->second.setValue(value);
 		if (rviz::Property* rviz_prop = factory.create(prop.name, it->second, scene_.get(), display_context_)) {
-			// rviz_prop->setReadOnly(true);
+			rviz_prop->setReadOnly(true);
 			return rviz_prop;
 		} else
 			properties_.erase(it);

--- a/visualization/motion_planning_tasks/src/remote_task_model.h
+++ b/visualization/motion_planning_tasks/src/remote_task_model.h
@@ -54,7 +54,6 @@ class RemoteTaskModel : public BaseTaskModel {
 	Q_OBJECT
 	struct Node;
 	Node* const root_;
-	planning_scene::PlanningSceneConstPtr scene_;
 	ros::ServiceClient* get_solution_client_ = nullptr;
 
 	std::map<uint32_t, Node*> id_to_stage_;
@@ -67,7 +66,7 @@ class RemoteTaskModel : public BaseTaskModel {
 	inline RemoteSolutionModel* getSolutionModel(uint32_t stage_id) const;
 
 public:
-	RemoteTaskModel(const planning_scene::PlanningSceneConstPtr &scene, QObject *parent = nullptr);
+	RemoteTaskModel(const planning_scene::PlanningSceneConstPtr &scene, rviz::DisplayContext *display_context, QObject *parent = nullptr);
 	~RemoteTaskModel();
 
 	void setSolutionClient(ros::ServiceClient *client);

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -101,6 +101,7 @@ void TaskDisplay::onInitialize()
 {
 	Display::onInitialize();
 	trajectory_visual_->onInitialize(scene_node_, context_);
+	task_list_model_->setDisplayContext(context_);
 	// create a new TaskPanel by default
 	// by post-poning this to main loop, we can ensure that rviz has loaded everything before
 	mainloop_jobs_.addJob([this]() { TaskPanel::incDisplayCount(context_->getWindowManager()); });

--- a/visualization/motion_planning_tasks/src/task_list_model.cpp
+++ b/visualization/motion_planning_tasks/src/task_list_model.cpp
@@ -275,7 +275,7 @@ void TaskListModel::processTaskDescriptionMessage(const std::string& id,
 		}
 	} else if (created) { // create new task model, if ID was not known before
 		// the model is managed by this instance via Qt's parent-child mechanism
-		remote_task = new RemoteTaskModel(scene_, this);
+		remote_task = new RemoteTaskModel(scene_, display_context_, this);
 		remote_task->setSolutionClient(get_solution_client_);
 
 		// HACK: always use the last created model as active

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -70,6 +70,8 @@ class BaseTaskModel : public QAbstractItemModel {
 	Q_OBJECT
 protected:
 	unsigned int flags_ = 0;
+	planning_scene::PlanningSceneConstPtr scene_;
+	rviz::DisplayContext* display_context_;
 
 public:
 	enum TaskModelFlag {
@@ -79,7 +81,10 @@ public:
 		IS_RUNNING     = 0x08,
 	};
 
-	BaseTaskModel(QObject *parent = nullptr) : QAbstractItemModel(parent) {}
+	BaseTaskModel(const planning_scene::PlanningSceneConstPtr &scene,
+	              rviz::DisplayContext* display_context, QObject *parent = nullptr)
+	    : QAbstractItemModel(parent), scene_(scene), display_context_(display_context)
+	{}
 
 	int columnCount(const QModelIndex &parent = QModelIndex()) const override { return 3; }
 	QVariant headerData(int section, Qt::Orientation orientation, int role) const override;

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -330,7 +330,7 @@ void TaskView::addTask()
 	bool is_top_level = !current.parent().isValid();
 
 	TaskListModel* task_list_model = d_ptr->getTaskListModel(current).first;
-	task_list_model->insertModel(new LocalTaskModel(task_list_model), is_top_level ? -1 : current.row());
+	task_list_model->insertModel(task_list_model->createLocalTaskModel(), is_top_level ? -1 : current.row());
 
 	// select and edit newly inserted model
 	if (is_top_level) current = current.model()->index(task_list_model->rowCount()-1, 0, current);

--- a/visualization/motion_planning_tasks/test/test_task_model.cpp
+++ b/visualization/motion_planning_tasks/test/test_task_model.cpp
@@ -169,11 +169,13 @@ TEST_F(TaskListModelTest, localTaskModel) {
 	ros::init(argc, &argv, "testLocalTaskModel");
 
 	children = 3;
-	moveit_rviz_plugin::LocalTaskModel m;
+	const char* task_name = "task pipeline";
+	moveit_rviz_plugin::LocalTaskModel m(std::make_unique<SerialContainer>(task_name),
+	                                     planning_scene::PlanningSceneConstPtr(), nullptr);
 	for (int i = 0; i != children; ++i)
 		m.add(std::make_unique<stages::CurrentState>(std::to_string(i)));
 
-	{ SCOPED_TRACE("localTaskModel"); validate(m, {"task pipeline"}); }
+	{ SCOPED_TRACE("localTaskModel"); validate(m, {task_name}); }
 }
 
 TEST_F(TaskListModelTest, noChildren) {


### PR DESCRIPTION
First attempt to display mtc properties in rviz. For each stage, a separate `rviz::PropertyTreeModel` is maintained. It's possible to register custom `rviz::Property` factory functions with the `PropertyFactory`.
These custom properties might allow nice editing, e.g. using interactive markers to configure a `StampedPose`.
A generic creator function, creates an rviz::Property tree from serialized YAML. Streaming a ROS type, generates YAML-like text. Unfortunately it's not perfect YAML (in contract to Python). For example, sequences as in [`moveit_msgs/Constraints`](http://docs.ros.org/melodic/api/moveit_msgs/html/msg/Constraints.html) are not correctly handled.

An alternative implementation would have used [ros-type-introspection](http://wiki.ros.org/ros_type_introspection). However, ros-type-introspection requires access to the full message description (as provided by ros topics). Otherwise one cannot ensure that the correct message description is used to decode the serialized, binary buffer.
The parser cannot (efficiently) handle ROS types in a recursive fashion. All message descriptions need to be self-contained. This could be handled by also publishing all used message descriptions in the [`TaskDescription`](https://github.com/ros-planning/moveit_task_constructor/blob/master/msgs/msg/TaskDescription.msg) msg.
Finally, [ros-type-introspection cannot write back changes](https://github.com/facontidavide/ros_type_introspection/issues/28). It's a read-only inspection tool.
In contrast, any parsed `rviz::Property` tree can be serialized to YAML easily. Using Python, we can also parse YAML into a ROS msg type again... Later!