### PR TITLE
fast-forward master

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -147,8 +147,8 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		// define individual variable for use in closure below
 		const std::string description = std::to_string(i+1) + "/"
 		                                + std::to_string(solution.sub_trajectory.size())
-		                                + " - subsolution " + std::to_string(sub_traj.id)
-		                                + " of stage " + std::to_string(sub_traj.stage_id);
+		                                + " - subsolution " + std::to_string(sub_traj.info.id)
+		                                + " of stage " + std::to_string(sub_traj.info.stage_id);
 
 		exec_traj.description_ = description;
 

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -64,8 +64,6 @@ public:
 
 	void reset() override;
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-	/// validate connectivity of children (after init() was done)
-	virtual void validateConnectivity() const;
 
 	virtual bool canCompute() const = 0;
 	virtual void compute() = 0;
@@ -88,9 +86,6 @@ public:
 	SerialContainer(const std::string& name = "serial container");
 
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-
-	/// validate connectivity of children (after init() was done)
-	void validateConnectivity() const override;
 
 	bool canCompute() const override;
 	void compute() override;
@@ -131,9 +126,6 @@ public:
 	ParallelContainerBase(const std::string &name);
 
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-
-	/// validate connectivity of children (after init() was done)
-	void validateConnectivity() const override;
 
 protected:
 	ParallelContainerBase(ParallelContainerBasePrivate* impl);

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -97,6 +97,8 @@ public:
 		return const_cast<const ContainerBasePrivate*>(this)->traverseStages(const_processor, cur_depth, max_depth);
 	}
 
+	void validateConnectivity() const override;
+
 	// forward these methods to the public interface for containers
 	bool canCompute() const override;
 	void compute() override;
@@ -162,6 +164,8 @@ public:
 
 	// called by parent asking for pruning of this' interface
 	void pruneInterface(InterfaceFlags accepted) override;
+	// validate connectivity of chain
+	void validateConnectivity() const override;
 
 private:
 	// connect cur stage to its predecessor and successor
@@ -213,6 +217,8 @@ public:
 
 	// called by parent asking for pruning of this' interface
 	void pruneInterface(InterfaceFlags accepted) override;
+
+	void validateConnectivity() const override;
 
 private:
 	/// callback for new externally received states

--- a/core/include/moveit/task_constructor/properties.h
+++ b/core/include/moveit/task_constructor/properties.h
@@ -106,6 +106,7 @@ public:
 
 	/// get current value (or default if not defined)
 	inline const boost::any& value() const { return value_.empty() ? default_ : value_; }
+	inline boost::any& value() { return value_.empty() ? default_ : value_; }
 	/// get default value
 	const boost::any& defaultValue() const { return default_; }
 

--- a/core/include/moveit/task_constructor/properties.h
+++ b/core/include/moveit/task_constructor/properties.h
@@ -65,7 +65,7 @@ boost::any fromName(const PropertyMap& other, const std::string& other_name);
  *
  * Setting the value via setValue() updates both, the current value and the default value.
  * Using reset() the default value can be restored.
- * Using setCurrentValue() only updates the current value, allowing for later reset to the original default.
+ * setCurrentValue() and setDefaultValue() only set the specific value.
  */
 class Property {
 	friend class PropertyMap;
@@ -97,6 +97,7 @@ public:
 	/// set current value and default value
 	void setValue(const boost::any& value);
 	void setCurrentValue(const boost::any& value);
+	void setDefaultValue(const boost::any& value);
 
 	/// reset to default value (which can be empty)
 	void reset();
@@ -275,6 +276,7 @@ public:
 	/// declare given property name as other_name in other PropertyMap
 	void exposeTo(PropertyMap& other, const std::string& name, const std::string& other_name) const;
 
+	/// check whether given property is declared
 	bool hasProperty(const std::string &name) const;
 
 	/// get the property with given name, throws Property::undeclared for unknown name

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -56,17 +56,26 @@ class StagePrivate {
 	friend std::ostream& operator<<(std::ostream& os, const StagePrivate& stage);
 
 public:
-	// container type used to store children
+	/// container type used to store children
 	typedef std::list<Stage::pointer> container_type;
 	StagePrivate(Stage* me, const std::string& name);
 	virtual ~StagePrivate() = default;
 
+	/// actually configured interface of this stage (only valid after init())
 	InterfaceFlags interfaceFlags() const;
-	// retrieve description of the interface required by this stage
-	// if this is unknown (because interface is auto-detected from context), return 0
+
+	/** Interface required by this stage
+	 *
+	 * If the interface is unknown (because it is auto-detected from context), return 0 */
 	virtual InterfaceFlags requiredInterface() const = 0;
-	// prune interface to the given propagation direction
+
+	/** Prune interface to comply with the given propagation direction
+	 *
+	 * PropagatingEitherWay uses this in restrictDirection() */
 	virtual void pruneInterface(InterfaceFlags accepted) {}
+
+	/// validate connectivity of children (after init() was done)
+	virtual void validateConnectivity() const;
 
 	virtual bool canCompute() const = 0;
 	virtual void compute() = 0;
@@ -173,6 +182,8 @@ public:
 	void initInterface(PropagatingEitherWay::Direction dir);
 	// prune interface to the given propagation direction
 	void pruneInterface(InterfaceFlags accepted) override;
+	// validate that we can propagate in one direction at least
+	void validateConnectivity() const override;
 
 	bool canCompute() const override;
 	void compute() override;

--- a/core/include/moveit/task_constructor/stages/compute_ik.h
+++ b/core/include/moveit/task_constructor/stages/compute_ik.h
@@ -69,6 +69,10 @@ public:
 	void init(const core::RobotModelConstPtr &robot_model);
 	void onNewSolution(const SolutionBase &s) override;
 
+	bool canCompute() const override;
+
+	void compute() override;
+
 	void setEndEffector(const std::string& eef) {
 		setProperty("eef", eef);
 	}
@@ -107,6 +111,9 @@ public:
 	void setMinSolutionDistance(double distance) {
 		setProperty("min_solution_distance", distance);
 	}
+
+protected:
+	std::queue<const SolutionBase*> targets_;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/compute_ik.h
+++ b/core/include/moveit/task_constructor/stages/compute_ik.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <moveit/task_constructor/container.h>
+#include <moveit/task_constructor/cost_queue.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <Eigen/Geometry>
 
@@ -66,7 +67,8 @@ class ComputeIK : public WrapperBase {
 public:
 	ComputeIK(const std::string &name, Stage::pointer &&child = Stage::pointer());
 
-	void init(const core::RobotModelConstPtr &robot_model);
+	void reset() override;
+	void init(const core::RobotModelConstPtr &robot_model) override;
 	void onNewSolution(const SolutionBase &s) override;
 
 	bool canCompute() const override;
@@ -113,7 +115,7 @@ public:
 	}
 
 protected:
-	std::queue<const SolutionBase*> targets_;
+	ordered<const SolutionBase*> upstream_solutions_;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/stages/generate_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_pose.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/cost_queue.h>
 #include <geometry_msgs/PoseStamped.h>
 
 namespace moveit { namespace task_constructor { namespace stages {
@@ -57,8 +58,7 @@ public:
 
 protected:
 	void onNewSolution(const SolutionBase& s) override;
-
-	std::deque<planning_scene::PlanningScenePtr> scenes_;
+	ordered<const SolutionBase*> upstream_solutions_;
 };
 
 } } }

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -134,17 +134,9 @@ private:
 	Interface* owner_ = nullptr;  // allow update of priority
 };
 
-
-/// compare InterfaceState* by value
-struct InterfaceStateLess {
-	inline bool operator()(const InterfaceState* x, const InterfaceState* y) const {
-		return *x < *y;
-	}
-};
-
 /** Interface provides a cost-sorted list of InterfaceStates available as input for a stage. */
-class Interface : public ordered<InterfaceState*, InterfaceStateLess> {
-	typedef ordered<InterfaceState*, InterfaceStateLess> base_type;
+class Interface : public ordered<InterfaceState*> {
+	typedef ordered<InterfaceState*> base_type;
 
 public:
 	// iterators providing convinient access to stored InterfaceState

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -229,6 +229,8 @@ public:
 	/// append this solution to Solution msg
 	virtual void fillMessage(moveit_task_constructor_msgs::Solution &solution,
 	                         Introspection* introspection = nullptr) const = 0;
+	void fillInfo(moveit_task_constructor_msgs::SolutionInfo& info,
+	              Introspection* introspection = nullptr) const;
 
 	/// order solutions by their cost
 	bool operator<(const SolutionBase& other) const {

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -1092,7 +1092,8 @@ void MergerPrivate::merge(const ChildSolutionList& sub_solutions,
 		// TODO: directly skip failures in mergeAnyCombination() or even earlier
 		if (sub->isFailure())
 			return;
-		sub_trajectories.push_back(sub->trajectory());
+		if (sub->trajectory())
+			sub_trajectories.push_back(sub->trajectory());
 	}
 
 	moveit::core::JointModelGroup *jmg = jmg_merged_.get();

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -35,6 +35,7 @@
 /* Authors: Robert Haschke */
 
 #include <moveit/task_constructor/container_p.h>
+#include <moveit/task_constructor/introspection.h>
 #include <moveit/task_constructor/merge.h>
 #include <moveit/planning_scene/planning_scene.h>
 
@@ -640,6 +641,12 @@ void WrappedSolution::fillMessage(moveit_task_constructor_msgs::Solution &soluti
                                   Introspection *introspection) const
 {
 	wrapped_->fillMessage(solution, introspection);
+
+	// prepend this solutions info as a SubSolution msg
+	moveit_task_constructor_msgs::SubSolution sub_msg;
+	SolutionBase::fillInfo(sub_msg.info, introspection);
+	sub_msg.sub_solution_id.push_back(introspection ? introspection->solutionId(*wrapped_) : 0);
+	solution.sub_solution.insert(solution.sub_solution.begin(), std::move(sub_msg));
 }
 
 ParallelContainerBasePrivate::ParallelContainerBasePrivate(ParallelContainerBase *me, const std::string &name)

--- a/core/src/properties.cpp
+++ b/core/src/properties.cpp
@@ -142,6 +142,14 @@ void Property::setCurrentValue(const boost::any &value)
 	initialized_from_ = 1; // manually initialized TODO: use enums
 }
 
+void Property::setDefaultValue(const boost::any& value)
+{
+	if (!value.empty() && type_info_ != typeid(boost::any) && value.type() != type_info_)
+		throw Property::type_error(value.type().name(), type_info_.name());
+
+	default_ = value;
+}
+
 void Property::reset()
 {
 	if (initialized_from_ == 0)  // TODO: use enum

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -313,11 +313,11 @@ void ComputeIK::compute()
 		marker.color.a *= 0.5;
 		failure_markers.push_back(marker);
 	};
-	const auto& link_to_visualize = moveit::core::RobotModel::getRigidlyConnectedParentLinkModel(link)
+	const auto& links_to_visualize = moveit::core::RobotModel::getRigidlyConnectedParentLinkModel(link)
 	                                ->getParentJointModel()->getDescendantLinkModels();
 	if (colliding) {
 		SubTrajectory solution;
-		generateCollisionMarkers(sandbox_state, appender, link_to_visualize);
+		generateCollisionMarkers(sandbox_state, appender, links_to_visualize);
 		std::copy(failure_markers.begin(), failure_markers.end(), std::back_inserter(solution.markers()));
 		solution.markAsFailure();
 		// TODO: visualize collisions
@@ -325,7 +325,7 @@ void ComputeIK::compute()
 		spawn(InterfaceState(sandbox_scene), std::move(solution));
 		return;
 	} else
-		generateVisualMarkers(sandbox_state, appender, link_to_visualize);
+		generateVisualMarkers(sandbox_state, appender, links_to_visualize);
 
 
 	// determine joint values of robot pose to compare IK solution with for costs

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -54,7 +54,6 @@ namespace moveit { namespace task_constructor { namespace stages {
 ComputeIK::ComputeIK(const std::string &name, Stage::pointer &&child)
    : WrapperBase(name, std::move(child))
 {
-	setTimeout(1.0);
 	auto& p = properties();
 	p.declare<std::string>("eef", "name of end-effector group");
 	p.declare<std::string>("group", "name of active group (derived from eef if not provided)");
@@ -254,6 +253,7 @@ void ComputeIK::compute()
 		ROS_WARN_STREAM_NAMED("ComputeIK", "Neither eef nor group are well defined");
 		return;
 	}
+	properties().property("timeout").setDefaultValue(jmg->getDefaultIKTimeout());
 
 	// extract target_pose
 	geometry_msgs::PoseStamped target_pose_msg = props.get<geometry_msgs::PoseStamped>("target_pose");

--- a/core/src/stages/generate_pose.cpp
+++ b/core/src/stages/generate_pose.cpp
@@ -51,25 +51,25 @@ GeneratePose::GeneratePose(const std::string& name)
 
 void GeneratePose::reset()
 {
+	upstream_solutions_.clear();
 	MonitoringGenerator::reset();
-	scenes_.clear();
 }
 
 void GeneratePose::onNewSolution(const SolutionBase& s)
 {
-	scenes_.push_back(s.end()->scene()->diff());
+	// It's safe to store a pointer to this solution, as the generating stage stores it
+	upstream_solutions_.push(&s);
 }
 
 bool GeneratePose::canCompute() const {
-	return scenes_.size() > 0;
+	return upstream_solutions_.size() > 0;
 }
 
 void GeneratePose::compute() {
-	if (scenes_.empty())
+	if (upstream_solutions_.empty())
 		return;
-	planning_scene::PlanningScenePtr scene = scenes_[0];
-	scenes_.pop_front();
 
+	planning_scene::PlanningScenePtr scene = upstream_solutions_.pop()->end()->scene()->diff();
 	geometry_msgs::PoseStamped target_pose = properties().get<geometry_msgs::PoseStamped>("pose");
 	if (target_pose.header.frame_id.empty())
 		target_pose.header.frame_id = scene->getPlanningFrame();

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -47,8 +47,8 @@ MoveRelative::MoveRelative(const std::string& name, const solvers::PlannerInterf
    : PropagatingEitherWay(name)
    , planner_(planner)
 {
-	setTimeout(10.0);
 	auto& p = properties();
+	p.property("timeout").setDefaultValue(1.0);
 	p.declare<std::string>("group", "name of planning group");
 	p.declare<geometry_msgs::PoseStamped>("ik_frame", "frame to be moved in Cartesian direction");
 

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -48,8 +48,8 @@ MoveTo::MoveTo(const std::string& name, const solvers::PlannerInterfacePtr& plan
    : PropagatingEitherWay(name)
    , planner_(planner)
 {
-	setTimeout(10.0);
 	auto& p = properties();
+	p.property("timeout").setDefaultValue(1.0);
 	p.declare<std::string>("group", "name of planning group");
 	p.declare<geometry_msgs::PoseStamped>("ik_frame", "frame to be moved towards goal pose");
 	p.declare<boost::any>("goal", "goal specification");

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -237,7 +237,7 @@ void Task::init()
 	// task expects its wrapped child to push to both ends, this triggers interface resolution
 	stages()->pimpl()->pruneInterface(InterfaceFlags({GENERATE}));
 	// and *finally* validate connectivity
-	stages()->validateConnectivity();
+	stages()->pimpl()->validateConnectivity();
 
 	// provide introspection instance to all stages
 	impl->setIntrospection(introspection_.get());

--- a/core/test/test_cost_queue.cpp
+++ b/core/test/test_cost_queue.cpp
@@ -1,6 +1,100 @@
 #include <list>
+#include <memory>
 #include <moveit/task_constructor/cost_queue.h>
+#include <moveit/task_constructor/storage.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
+
+namespace mtc = moveit::task_constructor;
+
+// type-trait functions for OrderedTest<T>
+template <typename T> T create(int cost);
+template <> int create(int cost) { return cost; }
+template <> int* create(int cost) { return new int(cost); }
+template <> mtc::SolutionBasePtr create(int cost) {
+	mtc::SolutionBasePtr s = std::make_shared<mtc::SubTrajectory>();
+	s->setCost(cost);
+	return s;
+}
+template <> mtc::SolutionBaseConstPtr create(int cost) {
+	return create<mtc::SolutionBasePtr>(cost);
+}
+
+template <typename T> int value(const T& item);
+template <> int value(const int& item) { return item; }
+template <> int value(int* const& item) { return *item; }
+template <> int value(const mtc::SolutionBasePtr& item) { return item->cost(); }
+template <> int value(const mtc::SolutionBaseConstPtr& item) { return item->cost(); }
+
+template <typename T>
+class ValueOrPointeeLessTest : public ::testing::Test {
+protected:
+	bool less(int lhs, int rhs) {
+		ValueOrPointeeLess<T> comp;
+		return comp(create<T>(lhs), create<T>(rhs));
+	}
+};
+// set of template types to test for
+typedef ::testing::Types<int, int*, mtc::SolutionBasePtr, mtc::SolutionBaseConstPtr> TypeInstances;
+TYPED_TEST_CASE(ValueOrPointeeLessTest, TypeInstances);
+TYPED_TEST(ValueOrPointeeLessTest, less) {
+	EXPECT_TRUE(this->less(2, 3));
+	EXPECT_FALSE(this->less(1, 1));
+	EXPECT_FALSE(this->less(2, 1));
+}
+
+template <typename T>
+class OrderedTest : public ::testing::Test, public ordered<T> {
+protected:
+	void pushAndValidate(int cost, const std::vector<int>& expected) {
+		this->insert(create<T>(cost));
+
+		std::vector<int> actual;
+		std::transform(this->c.begin(), this->c.end(), std::back_inserter(actual),
+		               [](const T& item) -> int { return value<T>(item); });
+
+		EXPECT_THAT(actual, ::testing::ElementsAreArray(expected));
+	}
+	void validatePop() {
+		std::vector<int> expected;
+		std::vector<int> actual;
+		std::transform(this->c.begin(), this->c.end(), std::back_inserter(expected),
+		               [](const T& item) -> int { return value<T>(item); });
+
+		while(!this->empty())
+			actual.push_back(value<T>(this->pop()));
+
+		EXPECT_THAT(actual, ::testing::ElementsAreArray(expected));
+		EXPECT_TRUE(this->empty());
+	}
+};
+
+
+#define pushAndValidate(cost, ...) { \
+	SCOPED_TRACE("pushAndValidate(" #cost ", " #__VA_ARGS__ ")"); \
+	this->pushAndValidate(cost, __VA_ARGS__); \
+}
+TYPED_TEST_CASE(OrderedTest, TypeInstances);
+TYPED_TEST(OrderedTest, sorting) {
+	pushAndValidate(2, {2});
+	pushAndValidate(1, {1,2});
+	pushAndValidate(3, {1,2,3});
+	this->validatePop();
+
+	pushAndValidate(1, {1});
+	pushAndValidate(2, {1,2});
+	pushAndValidate(3, {1,2,3});
+	pushAndValidate(4, {1,2,3,4});
+	pushAndValidate(5, {1,2,3,4,5});
+	this->validatePop();
+
+	pushAndValidate(5, {5});
+	pushAndValidate(4, {4,5});
+	pushAndValidate(3, {3,4,5});
+	pushAndValidate(1, {1,3,4,5});
+	pushAndValidate(2, {1,2,3,4,5});
+	this->validatePop();
+}
 
 template<typename ValueType, typename CostType>
 std::ostream& operator<<(std::ostream &os, const cost_ordered<ValueType, CostType> &queue) {

--- a/core/test/test_stage.cpp
+++ b/core/test/test_stage.cpp
@@ -10,9 +10,10 @@
 #include <gtest/gtest.h>
 
 using namespace moveit::task_constructor;
+using namespace planning_scene;
 
 class GeneratorMockup : public Generator {
-	planning_scene::PlanningScenePtr ps;
+	PlanningScenePtr ps;
 	InterfacePtr prev;
 	InterfacePtr next;
 
@@ -25,7 +26,7 @@ public:
 	}
 
 	void init(const moveit::core::RobotModelConstPtr &robot_model) {
-		ps.reset((new planning_scene::PlanningScene(robot_model)));
+		ps.reset((new PlanningScene(robot_model)));
 	}
 
 	bool canCompute() const override { return true; }
@@ -34,6 +35,12 @@ public:
 		state.properties().set("target_pose", geometry_msgs::PoseStamped());
 		spawn(std::move(state), 0.0);
 	}
+};
+
+class ConnectMockup : public Connecting {
+public:
+	using Connecting::compatible;
+	void compute(const InterfaceState& from, const InterfaceState& to) override {}
 };
 
 TEST(Stage, registerCallbacks) {
@@ -97,4 +104,76 @@ TEST(ModifyPlanningScene, allowCollisions) {
 
 	s->allowCollisions("foo", std::vector<const char*>{"bar", "boom"}, true);
 	s->allowCollisions("foo", std::set<const char*>{"ab", "abc"}, false);
+}
+
+void spawnObject(PlanningScene& scene, const std::string& name, int type,
+                 const std::vector<double>& pos = {0,0,0}) {
+	moveit_msgs::CollisionObject o;
+	o.id= name;
+	o.header.frame_id= scene.getPlanningFrame();
+	o.primitive_poses.resize(1);
+	o.primitive_poses[0].position.x = pos[0];
+	o.primitive_poses[0].position.y = pos[1];
+	o.primitive_poses[0].position.z = pos[2];
+	o.primitive_poses[0].orientation.w = 1.0;
+
+	o.primitives.resize(1);
+	o.primitives[0].type= type;
+
+	switch (type) {
+	case shape_msgs::SolidPrimitive::CYLINDER:
+		o.primitives[0].dimensions = {0.1, 0.02};
+		break;
+	case shape_msgs::SolidPrimitive::BOX:
+		o.primitives[0].dimensions = {0.1, 0.2, 0.3};
+		break;
+	case shape_msgs::SolidPrimitive::SPHERE:
+		o.primitives[0].dimensions = {0.05};
+		break;
+	}
+	scene.processCollisionObjectMsg(o);
+}
+
+void attachObject(PlanningScene& scene,
+                  const std::string& object, const std::string& link, bool attach)
+{
+	moveit_msgs::AttachedCollisionObject obj;
+	obj.link_name = link;
+	obj.object.operation = attach ? (int8_t) moveit_msgs::CollisionObject::ADD
+	                              : (int8_t) moveit_msgs::CollisionObject::REMOVE;
+	obj.object.id = object;
+	scene.processAttachedCollisionObjectMsg(obj);
+}
+
+TEST(Connect, compatible) {
+	ConnectMockup connect;
+	auto scene = std::make_shared<PlanningScene>(getModel());
+	auto& state = scene->getCurrentStateNonConst();
+	state.setToDefaultValues();
+	spawnObject(*scene, "object", shape_msgs::SolidPrimitive::CYLINDER);
+	state.update();
+
+	auto other = scene->diff();
+	EXPECT_TRUE(connect.compatible(scene, other)) << "identical scenes";
+
+	spawnObject(*other, "object", shape_msgs::SolidPrimitive::BOX);
+	// EXPECT_FALSE(connect.compatible(scene, other)) << "different shapes";
+
+	spawnObject(*other, "object", shape_msgs::SolidPrimitive::CYLINDER, {0.1,0,0});
+	EXPECT_FALSE(connect.compatible(scene, other)) << "different pose";
+
+	spawnObject(*other, "object", shape_msgs::SolidPrimitive::CYLINDER);
+	EXPECT_TRUE(connect.compatible(scene, other)) << "same objects";
+
+	// attached objects
+	other = scene->diff();
+	attachObject(*scene, "object", "base_link", true);
+	EXPECT_FALSE(connect.compatible(scene, other)) << "detached and attached object";
+
+	other = scene->diff();
+	EXPECT_TRUE(connect.compatible(scene, other)) << "identical scenes, attached object";
+
+	spawnObject(*other, "object", shape_msgs::SolidPrimitive::CYLINDER, {0.1,0,0});
+	attachObject(*other, "object", "base_link", true);
+	EXPECT_FALSE(connect.compatible(scene, other)) << "different pose";
 }

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 add_message_files(DIRECTORY msg FILES
 	Property.msg
 	Solution.msg
+	SolutionInfo.msg
 	StageDescription.msg
 	StageStatistics.msg
 	SubSolution.msg

--- a/msgs/msg/SolutionInfo.msg
+++ b/msgs/msg/SolutionInfo.msg
@@ -1,0 +1,14 @@
+# unique id within task
+uint32 id
+
+# associated cost
+float32 cost
+
+# associated comment, usually providing failure hint
+string comment
+
+# id of stage that created this trajectory
+uint32 stage_id
+
+# markers, e.g. providing additional hints or illustrating failure
+visualization_msgs/Marker[] markers

--- a/msgs/msg/SubSolution.msg
+++ b/msgs/msg/SubSolution.msg
@@ -1,11 +1,5 @@
-# unique id within task
-uint32 id
-
-# associated cost
-float32 cost
-
-# id of stage that created this trajectory
-uint32 stage_id
+# generic solution information
+SolutionInfo info
 
 # IDs of subsolutions
 uint32[] sub_solution_id

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -1,19 +1,8 @@
-# unique id within task
-uint32 id
-
-# associated cost
-float32 cost
-
-# associated comment, usually providing failure hint
-string comment
-
-# id of stage that created this trajectory
-uint32 stage_id
+# generic solution information
+SolutionInfo info
 
 # trajectory
 moveit_msgs/RobotTrajectory trajectory
-# markers, e.g. providing additional hints or illustrating failure
-visualization_msgs/Marker[] markers
 
 # planning scene of end state as diff w.r.t. start state
 moveit_msgs/PlanningScene scene_diff

--- a/rviz_marker_tools/src/marker_creation.cpp
+++ b/rviz_marker_tools/src/marker_creation.cpp
@@ -104,16 +104,18 @@ std_msgs::ColorRGBA &setColor(std_msgs::ColorRGBA &color, Color color_id, double
 	return color;
 }
 
+// interpolate between start and end with fraction in range from 0..1
 double interpolate(double start, double end, double fraction) {
-	return start * fraction + end * (1.0 - fraction);
+	return start * (1.0 - fraction) + end * fraction;
 }
 
 std_msgs::ColorRGBA& interpolate(std_msgs::ColorRGBA& color, const std_msgs::ColorRGBA& other, double fraction) {
 	if (fraction < 0.0) fraction = 0.0;
 	if (fraction > 1.0) fraction = 1.0;
-	color.r += interpolate(other.r-color.r, other.r, fraction);
-	color.g += interpolate(other.g-color.g, other.g, fraction);
-	color.b += interpolate(other.b-color.b, other.b, fraction);
+	color.r = interpolate(color.r, other.r, fraction);
+	color.g = interpolate(color.g, other.g, fraction);
+	color.b = interpolate(color.b, other.b, fraction);
+	color.a = interpolate(color.a, other.a, fraction);
 	return color;
 }
 

--- a/visualization/motion_planning_tasks/src/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MOVEIT_LIB_NAME motion_planning_tasks_rviz_plugin)
 qt_wrap_ui(UIC_FILES
 	task_panel.ui
 	task_view.ui
-	task_settings.ui
+	global_settings.ui
 )
 
 add_library(${MOVEIT_LIB_NAME}

--- a/visualization/motion_planning_tasks/src/global_settings.ui
+++ b/visualization/motion_planning_tasks/src/global_settings.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>moveit_rviz_plugin::TaskSettings</class>
- <widget class="QWidget" name="moveit_rviz_plugin::TaskSettings">
+ <class>moveit_rviz_plugin::GlobalSettingsWidget</class>
+ <widget class="QWidget" name="moveit_rviz_plugin::GlobalSettingsWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -27,7 +27,7 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QVBoxLayout" name="tab_settings_layout">
+    <layout class="QVBoxLayout" name="layout">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -44,14 +44,14 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QLabel" name="settings_view_label">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Settings</string>
+        <string>Global Settings</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="rviz::PropertyTreeWidget" name="settings_view"/>
+      <widget class="rviz::PropertyTreeWidget" name="view"/>
      </item>
     </layout>
    </item>

--- a/visualization/motion_planning_tasks/src/remote_task_model.h
+++ b/visualization/motion_planning_tasks/src/remote_task_model.h
@@ -64,6 +64,7 @@ class RemoteTaskModel : public BaseTaskModel {
 
 	Node* node(uint32_t stage_id) const;
 	inline RemoteSolutionModel* getSolutionModel(uint32_t stage_id) const;
+	void setSolutionData(const moveit_task_constructor_msgs::SolutionInfo &info);
 
 public:
 	RemoteTaskModel(const planning_scene::PlanningSceneConstPtr &scene, rviz::DisplayContext *display_context, QObject *parent = nullptr);

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -42,9 +42,12 @@
 #include <moveit/macros/class_forward.h>
 #include <QModelIndex>
 class QItemSelection;
+class QIcon;
 
 namespace rviz {
 class WindowManagerInterface;
+class Property;
+class EnumProperty;
 }
 
 namespace moveit_rviz_plugin {
@@ -53,12 +56,22 @@ class TaskSolutionVisualization;
 MOVEIT_CLASS_FORWARD(TaskListModel)
 MOVEIT_CLASS_FORWARD(TaskPanel)
 
-/** The TaskPanel displays information about manipulation tasks in the system.
- *
- *  Subscribing to task_monitoring and task_solution topics, it collects information
- *  about running tasks and their solutions and allows to inspect both,
- *  successful solutions and failed solution attempts.
- */
+
+/// Base class for all sub panels within the Task Panel
+class SubPanel : public QWidget {
+	Q_OBJECT
+public:
+	SubPanel(QWidget* parent = nullptr) : QWidget(parent) {}
+
+	virtual void save(rviz::Config config) {}
+	virtual void load(const rviz::Config& config) {}
+
+Q_SIGNALS:
+	void configChanged();
+};
+
+
+/** The TaskPanel is the central panel of this plugin, collecting various sub panels. */
 class TaskPanelPrivate;
 class TaskPanel: public rviz::Panel
 {
@@ -69,6 +82,9 @@ class TaskPanel: public rviz::Panel
 public:
 	TaskPanel(QWidget* parent = 0);
 	~TaskPanel();
+
+	/// add a new sub panel widget
+	void addSubPanel(SubPanel* w, const QString &title, const QIcon &icon);
 
 	/** Increment/decrement use count of singleton TaskPanel instance.
 	 *
@@ -88,21 +104,29 @@ protected Q_SLOTS:
 
 
 class MetaTaskListModel;
+/** TaskView displays all known tasks.
+ *
+ *  Subscribing to task_monitoring and task_solution topics, it collects information
+ *  about running tasks and their solutions and allows to inspect both,
+ *  successful solutions and failed solution attempts.
+*/
 class TaskViewPrivate;
-class TaskView : public QWidget {
+class TaskView : public SubPanel {
 	Q_OBJECT
 	Q_DECLARE_PRIVATE(TaskView)
 	TaskViewPrivate *d_ptr;
 
+protected:
+	// configuration settings
+	enum TaskExpand { EXPAND_TOP=1, EXPAND_ALL, EXPAND_NONE };
+	rviz::EnumProperty* initial_task_expand;
+
 public:
-	TaskView(QWidget* parent = 0);
+	TaskView(TaskPanel* parent, rviz::Property* root);
 	~TaskView();
 
-	void save(rviz::Config config);
-	void load(const rviz::Config& config);
-
-Q_SIGNALS:
-	void configChanged();
+	void save(rviz::Config config) override;
+	void load(const rviz::Config& config) override;
 
 public Q_SLOTS:
 	void addTask();
@@ -115,15 +139,18 @@ protected Q_SLOTS:
 };
 
 
-class TaskSettingsPrivate;
-class TaskSettings : public QWidget {
+class GlobalSettingsWidgetPrivate;
+class GlobalSettingsWidget : public SubPanel {
 	Q_OBJECT
-	Q_DECLARE_PRIVATE(TaskSettings)
-	TaskSettingsPrivate *d_ptr;
+	Q_DECLARE_PRIVATE(GlobalSettingsWidget)
+	GlobalSettingsWidgetPrivate *d_ptr;
 
 public:
-	TaskSettings(QWidget* parent = 0);
-	~TaskSettings();
+	GlobalSettingsWidget(TaskPanel* parent, rviz::Property* root);
+	~GlobalSettingsWidget();
+
+	void save(rviz::Config config) override;
+	void load(const rviz::Config &config) override;
 };
 
 }

--- a/visualization/motion_planning_tasks/src/task_panel.ui
+++ b/visualization/motion_planning_tasks/src/task_panel.ui
@@ -27,23 +27,9 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="tool_buttons_layout">
      <item>
-      <widget class="QToolButton" name="button_show_settings">
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/icons/settings.png</normaloff>:/icons/settings.png</iconset>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="spacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -67,6 +53,9 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
   </layout>
  </widget>

--- a/visualization/motion_planning_tasks/src/task_panel_p.h
+++ b/visualization/motion_planning_tasks/src/task_panel_p.h
@@ -41,7 +41,7 @@
 #include "task_panel.h"
 #include "ui_task_panel.h"
 #include "ui_task_view.h"
-#include "ui_task_settings.h"
+#include "ui_global_settings.h"
 
 #include <rviz/panel.h>
 #include <rviz/properties/property_tree_model.h>
@@ -58,8 +58,8 @@ public:
 	TaskPanelPrivate(TaskPanel *q_ptr);
 
 	TaskPanel* q_ptr;
-	TaskView* tasks_widget;
-	TaskSettings* settings_widget;
+	QButtonGroup* tool_buttons_group;
+	rviz::Property* property_root;
 
 	rviz::WindowManagerInterface* window_manager_;
 };
@@ -85,11 +85,12 @@ public:
 };
 
 
-class TaskSettingsPrivate : public Ui_TaskSettings {
+class GlobalSettingsWidgetPrivate : public Ui_GlobalSettingsWidget {
 public:
-	TaskSettingsPrivate(TaskSettings *q_ptr);
+	GlobalSettingsWidgetPrivate(GlobalSettingsWidget *q_ptr, rviz::Property *root);
 
-	TaskSettings *q_ptr;
+	GlobalSettingsWidget *q_ptr;
+	rviz::PropertyTreeModel *properties;
 };
 
 }

--- a/visualization/motion_planning_tasks/test/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/test/CMakeLists.txt
@@ -10,13 +10,11 @@ if (CATKIN_ENABLE_TESTING)
 	target_link_libraries(${PROJECT_NAME}-test-merge-models
 		motion_planning_tasks_utils gtest_main)
 
+	catkin_add_gtest(${PROJECT_NAME}-test-solution-models test_solution_models.cpp)
+	target_link_libraries(${PROJECT_NAME}-test-solution-models
+		motion_planning_tasks_rviz_plugin gtest_main)
 
-	if(NOT "${rviz_QT_VERSION}" VERSION_LESS "5")
-		# This tests uses Qt5's generic function slots
-		add_rostest_gtest(${PROJECT_NAME}-test-task_model test_task_model.launch test_task_model.cpp)
-		target_link_libraries(${PROJECT_NAME}-test-task_model
-			motion_planning_tasks_rviz_plugin
-			${catkin_LIBRARIES}
-			gtest_main)
-	endif()
+	add_rostest_gtest(${PROJECT_NAME}-test-task_model test_task_model.launch test_task_model.cpp)
+	target_link_libraries(${PROJECT_NAME}-test-task_model
+		motion_planning_tasks_rviz_plugin ${catkin_LIBRARIES} gtest_main)
 endif()

--- a/visualization/motion_planning_tasks/test/test_solution_models.cpp
+++ b/visualization/motion_planning_tasks/test/test_solution_models.cpp
@@ -1,0 +1,56 @@
+#include <remote_task_model.h>
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
+
+using namespace moveit_rviz_plugin;
+
+class SolutionModelTest : public ::testing::Test {
+protected:
+	template <typename T>
+	inline std::vector<T> reversed(const std::vector<T> &in) {
+		return std::vector<T>(in.rbegin(), in.rend());
+	}
+	void validateSorting(QAbstractTableModel& model, int sort_column, Qt::SortOrder sort_order,
+	                     const std::vector<uint32_t>& expected_id_order) {
+		SCOPED_TRACE(qPrintable(QString("sorting in %1 %2 order")
+		                        .arg(sort_order == Qt::AscendingOrder ? "ascending" : "descending")
+		                        .arg(sort_column == 0 ? "creation" : "cost")));
+		model.sort(sort_column, sort_order);
+		std::vector<uint32_t> actual_id_order(model.rowCount());
+		for (int row = 0; row < model.rowCount(); ++row)
+			actual_id_order[row] = model.data(model.index(row, 0), Qt::UserRole).toInt();
+		EXPECT_THAT(actual_id_order, ::testing::ElementsAreArray(expected_id_order));
+	}
+	void processAndValidate(RemoteSolutionModel& model,
+	                        const std::vector<uint32_t>& success_ids,
+	                        const std::vector<uint32_t>& failure_ids) {
+		model.processSolutionIDs(success_ids, failure_ids, failure_ids.size());
+
+		std::vector<uint32_t> cost_ordered_ids(success_ids.begin(), success_ids.end());
+		std::vector<uint32_t> sorted_failure_ids(failure_ids.begin(), failure_ids.end());
+		std::sort(sorted_failure_ids.begin(), sorted_failure_ids.end());
+		std::copy(sorted_failure_ids.begin(), sorted_failure_ids.end(), std::back_inserter(cost_ordered_ids));
+
+		std::vector<uint32_t> creation_ordered_ids(cost_ordered_ids.size());
+		for (size_t i=0; i < cost_ordered_ids.size(); ++i)
+			creation_ordered_ids[i] = i+1;
+
+		validateSorting(model, 0, Qt::AscendingOrder, creation_ordered_ids);
+		validateSorting(model, 0, Qt::DescendingOrder, reversed(creation_ordered_ids));
+
+		validateSorting(model, 1, Qt::AscendingOrder, cost_ordered_ids);
+		validateSorting(model, 1, Qt::DescendingOrder, reversed(cost_ordered_ids));
+	}
+};
+
+#define processAndValidate(...) { \
+	SCOPED_TRACE("processSolutionIDs(" #__VA_ARGS__ ")"); \
+	processAndValidate(model, __VA_ARGS__); \
+}
+
+TEST_F(SolutionModelTest, sorting) {
+	RemoteSolutionModel model;
+	processAndValidate({1,3}, {2});
+	processAndValidate({4,1,6,3}, {5,2});
+}

--- a/visualization/visualization_tools/src/display_solution.cpp
+++ b/visualization/visualization_tools/src/display_solution.cpp
@@ -116,8 +116,8 @@ void DisplaySolution::setFromMessage(const planning_scene::PlanningScenePtr& sta
 	for (const auto& sub : msg.sub_trajectory) {
 		data_[i].trajectory_.reset(new robot_trajectory::RobotTrajectory(ref_scene->getRobotModel(), ""));
 		data_[i].trajectory_->setRobotTrajectoryMsg(ref_scene->getCurrentState(), sub.trajectory);
-		data_[i].comment_ = sub.comment;
-		data_[i].creator_id_ = sub.stage_id;
+		data_[i].comment_ = sub.info.comment;
+		data_[i].creator_id_ = sub.info.stage_id;
 		steps_ += data_[i].trajectory_->getWayPointCount();
 
 		ref_scene->setPlanningSceneDiffMsg(sub.scene_diff);
@@ -126,8 +126,8 @@ void DisplaySolution::setFromMessage(const planning_scene::PlanningScenePtr& sta
 		// create new reference scene for next iteration
 		ref_scene = ref_scene->diff();
 
-		if (sub.markers.size())
-			data_[i].markers_.reset(new MarkerVisualization(sub.markers, *ref_scene));
+		if (sub.info.markers.size())
+			data_[i].markers_.reset(new MarkerVisualization(sub.info.markers, *ref_scene));
 		else
 			data_[i].markers_.reset();
 		++i;


### PR DESCRIPTION
(Revival of #73.)
This is an incrementally growing branch, intended to be fast-forwarded into master. For now, 
- cherry-picked incremental `ComputeIK`
- fixed sorting of Solution pointers (they were sorted by pointer value, not pointee value!)
- fixed #75
- `Merger`: allow empty sub trajectories
- `Connect`: check for attached objects too
- ComputeIK: allow attached body as ik_frame reference
- includes the following other open PRs:
  - #80: setDefaultTimeout for ComputeIK
  - #76: fix some visualization issues
  - #84: fix deduction/validation of (nested) interfaces
- ~~new `ContainerBase::findChild()` to fetch `Stage*` by name, e.g. "pick/grasp".~~
- ~~new `GeneratePlacePose`: allow to place a grasped object in a specific pose~~
- ~~fixed `SimpleUnGrasp`~~
- ~~use simple `InterpolationPlanner` to open/close gripper~~

@v4hn Feel free to fast-forward at any time. I will push new commits either to this or a new PR branch (if you already merged).