### PR TITLE
Can now grasps some object types from the top

### DIFF
--- a/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
@@ -52,6 +52,7 @@ public:
 	void setEndEffector(const std::string &eef) { setProperty("eef", eef); }
 	void setObject(const std::string &object) { setProperty("object", object); }
 	void setAngleDelta(double delta) { setProperty("angle_delta", delta); }
+        void setTopGraspEnable(bool enabled) { setProperty("top_grasp_enabled", enabled); }
 
 	void setPreGraspPose(const std::string& pregrasp) { properties().set("pregrasp", pregrasp); }
 	void setPreGraspPose(const moveit_msgs::RobotState& pregrasp) { properties().set("pregrasp", pregrasp); }

--- a/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_grasp_pose.h
@@ -52,7 +52,7 @@ public:
 	void setEndEffector(const std::string &eef) { setProperty("eef", eef); }
 	void setObject(const std::string &object) { setProperty("object", object); }
 	void setAngleDelta(double delta) { setProperty("angle_delta", delta); }
-        void setTopGraspEnable(bool enabled) { setProperty("top_grasp_enabled", enabled); }
+        void setTopGraspEnabled(bool enabled) { setProperty("top_grasp_enabled", enabled); }
 
 	void setPreGraspPose(const std::string& pregrasp) { properties().set("pregrasp", pregrasp); }
 	void setPreGraspPose(const moveit_msgs::RobotState& pregrasp) { properties().set("pregrasp", pregrasp); }


### PR DESCRIPTION
This adds the functionality to grasp an object from the top of the object in the generate_grasp_pose stage. It will have no affect if the flag is set to false, but if set to true it will now generate grasps from above the object.