### PR TITLE
external source needed in moveit-master branch

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -3,7 +3,7 @@
 - git:
     local-name: moveit_task_constructor
     uri: https://github.com/ros-planning/moveit_task_constructor.git
-    version: master
+    version: moveit-master
 - git:
     local-name: mtc_demos
     uri: https://github.com/ubi-agni/mtc_demos.git
@@ -12,3 +12,7 @@
     local-name: mtc_pour
     uri: https://github.com/TAMS-Group/mtc_pour.git
     version: master
+- git:
+    local-name: panda_moveit_config
+    uri: https://github.com/ros-planning/panda_moveit_config
+    version: melodic-devel


### PR DESCRIPTION
To run the demo of the moveit-master branch, an open gripper pose is missing, 
``` [ERROR] [1574258838.504600244]: Initialization failed: Error initializing stage:
generate grasp pose: unknown end effector pose: open
```

solution is to use the latest melodic-devel branch of panda_moveit_config

a PR for the doc that is related to this will be also provided.