### PR TITLE
Change solution order

### DIFF
--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -587,9 +587,9 @@ void RemoteSolutionModel::sortInternal() {
 			          int comp = 0;
 			          switch (sort_column_) {
 				          case 1:  // cost order
-					          if (left->cost_rank < right->cost_rank)
+					          if (left->cost_rank > right->cost_rank)
 						          comp = -1;
-					          else if (left->cost_rank > right->cost_rank)
+					          else if (left->cost_rank < right->cost_rank)
 						          comp = 1;
 					          break;
 				          case 2:  // comment


### PR DESCRIPTION
Sort solutions by cost according to the triangle icon shown in the QT table header.
The order was reversed w.r.t. the triangle symbol before.

I just found this patch lying around in one of my workspaces and briefly pushed it.

This triggers a failure in your tests @rhaschke. Could you have a brief look?
If this doesn't make sense to you (or you can't reproduce), feel free to just close it.