### PR TITLE
Load ExecuteTaskSolutionCapability in demo.launch

### DIFF
--- a/demo/launch/demo.launch
+++ b/demo/launch/demo.launch
@@ -18,6 +18,9 @@
   <!-- Given the published joint states, publish tf for the robot links -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
 
+  <!-- Load  ExecuteTaskSolutionCapability so we can execute found solutions in simulation -->
+  <param name="move_group/capabilities" value="move_group/ExecuteTaskSolutionCapability" />
+  
   <!-- Run the main MoveIt executable (the move_group node) -->
   <include file="$(find panda_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>


### PR DESCRIPTION
With demo.launch it was not possible to execute found solutions because the required capability was not loaded.
This commit fixes this issue by adding the capability's name to move_group's _capabilities_ parameter.