### PR TITLE
Add public SolutionCallback interface to Task

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -105,6 +105,13 @@ public:
 	/// remove function callback
 	void erase(TaskCallbackList::const_iterator which);
 
+	typedef std::function<void(const SolutionBase& t)> SolutionCallback;
+	typedef std::list<SolutionCallback> SolutionCallbackList;
+	/// add function to be called every time a new solution is available
+	SolutionCallbackList::const_iterator addSolutionCallback(SolutionCallback&& cb);
+	/// remove function callback
+	void erase(SolutionCallbackList::const_iterator which);
+
 	/// reset all stages
 	void reset() final;
 	/// initialize all stages with given scene

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -105,12 +105,10 @@ public:
 	/// remove function callback
 	void erase(TaskCallbackList::const_iterator which);
 
-	typedef std::function<void(const SolutionBase& t)> SolutionCallback;
-	typedef std::list<SolutionCallback> SolutionCallbackList;
-	/// add function to be called every time a new solution is available
-	SolutionCallbackList::const_iterator addSolutionCallback(SolutionCallback&& cb);
-	/// remove function callback
-	void erase(SolutionCallbackList::const_iterator which);
+	/// expose SolutionCallback API
+	using WrapperBase::SolutionCallback;
+	using WrapperBase::addSolutionCallback;
+	using WrapperBase::removeSolutionCallback;
 
 	/// reset all stages
 	void reset() final;

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -69,6 +69,7 @@ private:
 	// introspection and monitoring
 	std::unique_ptr<Introspection> introspection_;
 	std::list<Task::TaskCallback> task_cbs_;  // functions to monitor task's planning progress
+	std::list<Task::SolutionCallback> solution_cbs_;  // functions to monitor new solutions
 };
 PIMPL_FUNCTIONS(Task)
 }

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -69,7 +69,6 @@ private:
 	// introspection and monitoring
 	std::unique_ptr<Introspection> introspection_;
 	std::list<Task::TaskCallback> task_cbs_;  // functions to monitor task's planning progress
-	std::list<Task::SolutionCallback> solution_cbs_;  // functions to monitor new solutions
 };
 PIMPL_FUNCTIONS(Task)
 }

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -233,16 +233,6 @@ void Task::erase(TaskCallbackList::const_iterator which) {
 	pimpl()->task_cbs_.erase(which);
 }
 
-Task::SolutionCallbackList::const_iterator Task::addSolutionCallback(SolutionCallback&& cb) {
-	auto impl = pimpl();
-	impl->solution_cbs_.emplace_back(std::move(cb));
-	return --(impl->solution_cbs_.cend());
-}
-
-void Task::erase(SolutionCallbackList::const_iterator which) {
-	pimpl()->solution_cbs_.erase(which);
-}
-
 void Task::reset() {
 	auto impl = pimpl();
 	// signal introspection, that this task was reset

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -233,6 +233,16 @@ void Task::erase(TaskCallbackList::const_iterator which) {
 	pimpl()->task_cbs_.erase(which);
 }
 
+Task::SolutionCallbackList::const_iterator Task::addSolutionCallback(SolutionCallback&& cb) {
+	auto impl = pimpl();
+	impl->solution_cbs_.emplace_back(std::move(cb));
+	return --(impl->solution_cbs_.cend());
+}
+
+void Task::erase(SolutionCallbackList::const_iterator which) {
+	pimpl()->solution_cbs_.erase(which);
+}
+
 void Task::reset() {
 	auto impl = pimpl();
 	// signal introspection, that this task was reset
@@ -320,6 +330,8 @@ void Task::publishAllSolutions(bool wait) {
 
 void Task::onNewSolution(const SolutionBase& s) {
 	auto impl = pimpl();
+	for (const auto& cb : impl->solution_cbs_)
+		cb(s);
 	// no need to call WrapperBase::onNewSolution!
 	if (impl->introspection_)
 		impl->introspection_->publishSolution(s);


### PR DESCRIPTION
This adds a convenient callback for getting the newest solution of the current task planning instance. Using the TaskCallback would require keeping track of all solutions and compare which is the newest one as `solutions()` returns all solutions ordered by cost.