### PR TITLE
Generalised code for object_name

### DIFF
--- a/demo/src/pick_place_task.cpp
+++ b/demo/src/pick_place_task.cpp
@@ -84,7 +84,7 @@ void PickPlaceTask::loadParameters() {
 
 void PickPlaceTask::init() {
 	ROS_INFO_NAMED(LOGNAME, "Initializing task pipeline");
-	const std::string object = "object";
+	const std::string object = object_name_;
 
 	// Reset ROS introspection before constructing the new object
 	// TODO(henningkayser): verify this is a bug, fix if possible
@@ -121,7 +121,7 @@ void PickPlaceTask::init() {
 	{
 		auto _current_state = std::make_unique<stages::CurrentState>("current state");
 
-		// Verify that object is not attachd
+		// Verify that object is not attached
 		auto applicability_filter =
 		    std::make_unique<stages::PredicateFilter>("applicability test", std::move(_current_state));
 		applicability_filter->setPredicate([object](const SolutionBase& s, std::string& comment) {


### PR DESCRIPTION
Previous code was generating the error on changing object_name in config/panda_config.yaml file because of this bug as here we are overwriting the object_name as "object" which brought the inconsistency in code.