### PR TITLE
Printing success log only if execution completes

### DIFF
--- a/demo/src/moveit_task_constructor_demo.cpp
+++ b/demo/src/moveit_task_constructor_demo.cpp
@@ -121,6 +121,7 @@ int main(int argc, char** argv) {
 		ROS_INFO_NAMED(LOGNAME, "Planning succeded");
 		if (pnh.param("execute", false)) {
 			pick_place_task.execute();
+			ROS_INFO_NAMED(LOGNAME, "Execution complete");
 		} else {
 			ROS_INFO_NAMED(LOGNAME, "Execution disabled");
 		}
@@ -128,7 +129,6 @@ int main(int argc, char** argv) {
 		ROS_INFO_NAMED(LOGNAME, "Planning failed");
 	}
 
-	ROS_INFO_NAMED(LOGNAME, "Execution complete");
 
 	// Keep introspection alive
 	ros::waitForShutdown();

--- a/demo/src/moveit_task_constructor_demo.cpp
+++ b/demo/src/moveit_task_constructor_demo.cpp
@@ -129,7 +129,6 @@ int main(int argc, char** argv) {
 		ROS_INFO_NAMED(LOGNAME, "Planning failed");
 	}
 
-
 	// Keep introspection alive
 	ros::waitForShutdown();
 	return 0;


### PR DESCRIPTION
Previous code will print/log "Execution complete" even if the execution was disabled.