### PR TITLE
Added C++11 flags for MOVEIT_MASTER check

### DIFF
--- a/capabilities/CMakeLists.txt
+++ b/capabilities/CMakeLists.txt
@@ -22,6 +22,7 @@ catkin_package(
 # check for MOVEIT_MASTER
 include(CheckIncludeFileCXX)
 set(CMAKE_REQUIRED_INCLUDES ${moveit_core_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 CHECK_INCLUDE_FILE_CXX(moveit/collision_detection/collision_env.h MOVEIT_MASTER)
 if(NOT MOVEIT_MASTER)
   set(MOVEIT_MASTER 0)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,7 @@ endif ()
 # check for MOVEIT_MASTER
 include(CheckIncludeFileCXX)
 set(CMAKE_REQUIRED_INCLUDES ${moveit_core_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 CHECK_INCLUDE_FILE_CXX(moveit/collision_detection/collision_env.h MOVEIT_MASTER)
 if(NOT MOVEIT_MASTER)
   set(MOVEIT_MASTER 0)


### PR DESCRIPTION
This is required if you are compiling MTC against moveit/master in xenial (gcc-5.5 does not compile with C++11 by default)