### PR TITLE
Avoid private API

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,7 +48,8 @@ set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/moveit/task_constructor)
 add_subdirectory(src)
 add_subdirectory(test)
 
-install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+	PATTERN "*_p.h" EXCLUDE)
 install(FILES
 	motion_planning_stages_plugin_description.xml
 	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -54,6 +54,8 @@ public:
 	size_t numChildren() const;
 	Stage* findChild(const std::string& name) const;
 
+	/** Callback function type used by traverse functions
+	 *  The callback should return false if traversal should be stopped. */
 	typedef std::function<bool(const Stage&, int depth)> StageCallback;
 	/// traverse direct children of this container, calling the callback for each of them
 	bool traverseChildren(const StageCallback& processor) const;

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -81,7 +81,7 @@ bool ContainerBasePrivate::traverseStages(const ContainerBase::StageCallback& pr
 
 	for (auto& stage : children_) {
 		if (!processor(*stage, cur_depth))
-			continue;
+			return false;
 		const ContainerBasePrivate* container = dynamic_cast<const ContainerBasePrivate*>(stage->pimpl());
 		if (container)
 			container->traverseStages(processor, cur_depth + 1, max_depth);

--- a/visualization/motion_planning_tasks/src/local_task_model.h
+++ b/visualization/motion_planning_tasks/src/local_task_model.h
@@ -44,7 +44,7 @@ namespace moveit_rviz_plugin {
 class LocalTaskModel : public BaseTaskModel, public moveit::task_constructor::Task
 {
 	Q_OBJECT
-	typedef moveit::task_constructor::StagePrivate Node;
+	using Node = moveit::task_constructor::Stage;
 	Node* root_;
 	StageFactoryPtr stage_factory_;
 	std::map<Node*, rviz::PropertyTreeModel*> properties_;


### PR DESCRIPTION
As a follow-up to #119, this PR replaces all uses of private API in the `visualization` package, making the code slightly harder to read in my opinion. @v4hn if you approve, I suggest fast-forwarding.