### PR TITLE
add an icon for the RViz interface

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -58,3 +58,5 @@ add_subdirectory(motion_planning_tasks)
 install(FILES
 	motion_planning_tasks_rviz_plugin_description.xml
 	DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(DIRECTORY icons DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/visualization/icons/classes/Motion Planning Tasks.svg
+++ b/visualization/icons/classes/Motion Planning Tasks.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg917"
+   version="1.1"
+   viewBox="0 0 36.529999 36.529999"
+   height="36.529999mm"
+   width="36.529999mm">
+  <defs
+     id="defs911">
+    <clipPath
+       id="clipPath1666"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         ry="0"
+         y="76.250359"
+         x="40.626255"
+         height="36.53022"
+         width="36.53022"
+         id="rect1668"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata914">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-260.47)"
+     id="layer1">
+    <g
+       transform="translate(-40,184.47083)"
+       id="g5966">
+      <g
+         id="g1644"
+         clip-path="url(#clipPath1666)"
+         transform="translate(-0.62625504,-0.22310049)">
+        <g
+           transform="matrix(0.35277777,0,0,-0.35277777,77.429457,92.419541)"
+           id="g46">
+          <path
+             id="path48"
+             style="fill:#0a58f7;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             d="M 0,0 C 0.307,-0.275 0.6,-0.573 0.877,-0.892 4.5,-5.06 4.059,-11.376 -0.109,-15 l -43.774,-38.051 c -4.168,-3.623 -10.484,-3.181 -14.107,0.987 -3.623,4.168 -3.182,10.484 0.986,14.107 l 35.669,31.007 -33.434,33.434 c -3.905,3.905 -3.905,10.237 0,14.142 3.906,3.905 10.238,3.905 14.143,0 z m -7.691,-13.951 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -40,41 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -2,-79 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5" />
+        </g>
+        <g
+           transform="matrix(0.35277777,0,0,-0.35277777,91.518439,92.419541)"
+           id="g46-3">
+          <path
+             id="path48-5"
+             style="fill:#0a58f7;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             d="M 0,0 C 0.307,-0.275 0.6,-0.573 0.877,-0.892 4.5,-5.06 4.059,-11.376 -0.109,-15 l -43.774,-38.051 c -4.168,-3.623 -10.484,-3.181 -14.107,0.987 -3.623,4.168 -3.182,10.484 0.986,14.107 l 35.669,31.007 -33.434,33.434 c -3.905,3.905 -3.905,10.237 0,14.142 3.906,3.905 10.238,3.905 14.143,0 z m -7.691,-13.951 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -40,41 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -2,-79 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5" />
+        </g>
+        <g
+           transform="matrix(0.35277777,0,0,-0.35277777,61.885105,92.419541)"
+           id="g46-3-6">
+          <path
+             id="path48-5-2"
+             style="fill:#0a58f7;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             d="M 0,0 C 0.307,-0.275 0.6,-0.573 0.877,-0.892 4.5,-5.06 4.059,-11.376 -0.109,-15 l -43.774,-38.051 c -4.168,-3.623 -10.484,-3.181 -14.107,0.987 -3.623,4.168 -3.182,10.484 0.986,14.107 l 35.669,31.007 -33.434,33.434 c -3.905,3.905 -3.905,10.237 0,14.142 3.906,3.905 10.238,3.905 14.143,0 z m -7.691,-13.951 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -40,41 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -2,-79 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5" />
+        </g>
+        <g
+           transform="matrix(0.35277777,0,0,-0.35277777,48.12207,92.419541)"
+           id="g46-3-9">
+          <path
+             id="path48-5-1"
+             style="fill:#0a58f7;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             d="M 0,0 C 0.307,-0.275 0.6,-0.573 0.877,-0.892 4.5,-5.06 4.059,-11.376 -0.109,-15 l -43.774,-38.051 c -4.168,-3.623 -10.484,-3.181 -14.107,0.987 -3.623,4.168 -3.182,10.484 0.986,14.107 l 35.669,31.007 -33.434,33.434 c -3.905,3.905 -3.905,10.237 0,14.142 3.906,3.905 10.238,3.905 14.143,0 z m -7.691,-13.951 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -40,41 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5 m -2,-79 c 3.589,0 6.5,2.91 6.5,6.5 0,3.59 -2.911,6.5 -6.5,6.5 -3.59,0 -6.5,-2.91 -6.5,-6.5 0,-3.59 2.91,-6.5 6.5,-6.5" />
+        </g>
+      </g>
+      <rect
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.08017526;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="rect2243"
+         width="36.529999"
+         height="36.529995"
+         x="40"
+         y="75.999176" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Obviously not the most pressing issue, but nice to have.

I quite like the idea of multiple MoveIt logos resembling a conveyor belt.

The original SVG was taken from MoveIt's press kit.
@davetcoleman I hope it is ok for us to use this as a logo?

![mtc-rviz](https://user-images.githubusercontent.com/680358/76531923-310bd900-6476-11ea-9c75-c77660345c00.png)