### PR TITLE
do not export inline functions

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -43,6 +43,8 @@ if(NOT MOVEIT_MASTER)
 endif()
 add_definitions(-DMOVEIT_MASTER=${MOVEIT_MASTER})
 
+add_compile_options(-fvisibility-inlines-hidden)
+
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/moveit/task_constructor)
 
 add_subdirectory(src)


### PR DESCRIPTION
This makes sure that code using `pimpl()` will not compile out of the box unless the `*_p.h` header is included.

Personally, I'm not sure we actually need it, but then again, why should the libraries contain copies of inline functions anyway?
Compatible with Clang and GCC