### PR TITLE
build tests using gmock via catkin_add_gmock

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (CATKIN_ENABLE_TESTING)
 	catkin_add_gtest(${PROJECT_NAME}-test-properties test_properties.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-properties ${PROJECT_NAME} gtest_main)
 
-	catkin_add_gtest(${PROJECT_NAME}-test-cost_queue test_cost_queue.cpp)
+	catkin_add_gmock(${PROJECT_NAME}-test-cost_queue test_cost_queue.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-cost_queue ${PROJECT_NAME} gtest_main)
 
 	catkin_add_gtest(${PROJECT_NAME}-test-interface_state test_interface_state.cpp)

--- a/visualization/motion_planning_tasks/test/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/test/CMakeLists.txt
@@ -10,7 +10,7 @@ if (CATKIN_ENABLE_TESTING)
 	target_link_libraries(${PROJECT_NAME}-test-merge-models
 		motion_planning_tasks_utils gtest_main)
 
-	catkin_add_gtest(${PROJECT_NAME}-test-solution-models test_solution_models.cpp)
+	catkin_add_gmock(${PROJECT_NAME}-test-solution-models test_solution_models.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-solution-models
 		motion_planning_tasks_rviz_plugin gtest_main)
 


### PR DESCRIPTION
Otherwise these suddenly started to fail for me on Lunar Linux
because gmock headers were no longer included.