### PR TITLE
Allow constructing PipelinePlanner from PlanningPipelinePtr

### DIFF
--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -57,6 +57,8 @@ class PipelinePlanner : public PlannerInterface
 public:
 	PipelinePlanner();
 
+	PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline);
+
 	void setPlannerId(const std::string& planner) { setProperty("planner", planner); }
 
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -67,11 +67,17 @@ PipelinePlanner::PipelinePlanner() {
 	                    planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC);
 }
 
-void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
-	planner_ = Task::createPlanner(robot_model);
+PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline) : PipelinePlanner() {
+	planner_ = planning_pipeline;
+}
 
-	planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
-	planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
+void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
+	if (!planner_) {
+		planner_ = Task::createPlanner(robot_model);
+
+		planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
+		planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
+	}
 }
 
 void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req, const PropertyMap& p,

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -74,10 +74,9 @@ PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& p
 void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
 	if (!planner_) {
 		planner_ = Task::createPlanner(robot_model);
-
-		planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
-		planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
 	}
+	planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
+	planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
 }
 
 void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req, const PropertyMap& p,

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -74,6 +74,10 @@ PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& p
 void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
 	if (!planner_) {
 		planner_ = Task::createPlanner(robot_model);
+	} else if (robot_model != planner_->getRobotModel()) {
+		throw std::runtime_error(
+		    "The robot model of the planning pipeline isn't the same as the task's robot model -- "
+		    "use Task::setRobotModel for setting the robot model when using custom planning pipeline");
 	}
 	planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
 	planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));


### PR DESCRIPTION
This adds the ability to construct PipelinePlanner from PlanningPipelinePtr, the current implementation always construct  `planner_`  by using `Task::createPlanner` [see](https://github.com/ros-planning/moveit_task_constructor/blob/master/core/src/solvers/pipeline_planner.cpp#L71) but this expect the parameters to be loaded under `move_group` namespace [see](https://github.com/ros-planning/moveit_task_constructor/blob/master/core/include/moveit/task_constructor/task.h#L78) which isn't always the case (for example when using moveit_cpp) -- another solution would be adding a new property `p.declare<std::string>("planner_ns", "move_group", "desc");` and using it in the `PipelinePlanner::init` function but doing so is resulting into a segfault with the following backtrace (it find the solution once after that it segfault), not sure if it's related to OMPL planning pipeline is already being loaded in moveit_cpp

![Screenshot from 2020-04-07 22-35-08](https://user-images.githubusercontent.com/16278108/78715156-a78ce100-7925-11ea-857a-e4ae3e690252.png)
