### PR TITLE
Fix for GCC5 (Ubuntu 16.04 / Kinetic) call to non-constexpr function

### DIFF
--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -93,13 +93,13 @@ typedef Flags<InterfaceFlag> InterfaceFlags;
 constexpr InterfaceFlags invert(InterfaceFlags f) {
 	InterfaceFlags inv;
 	if (f & READS_START)
-		inv |= WRITES_NEXT_START;
+		inv = inv | WRITES_NEXT_START;
 	if (f & WRITES_PREV_END)
-		inv |= READS_END;
+		inv = inv | READS_END;
 	if (f & READS_END)
-		inv |= WRITES_PREV_END;
+		inv = inv | WRITES_PREV_END;
 	if (f & WRITES_NEXT_START)
-		inv |= READS_START;
+		inv = inv | READS_START;
 	return inv;
 };
 


### PR DESCRIPTION
I couldn't find a specific bug for gcc5 for this error, but there are plenty of bugs in constexpr evaluation reported in bugzilla so I am not surprized this one exist.
Changing the syntax to the following compiles without problems.
Tested on 16.04 with ROS Kinetic and master branch of moveit.