### PR TITLE
add property to maximize clearance during IK stage

### DIFF
--- a/core/include/moveit/task_constructor/stages/compute_ik.h
+++ b/core/include/moveit/task_constructor/stages/compute_ik.h
@@ -109,6 +109,7 @@ public:
 	void setMaxIKSolutions(uint32_t n) { setProperty("max_ik_solutions", n); }
 	void setIgnoreCollisions(bool flag) { setProperty("ignore_collisions", flag); }
 	void setMinSolutionDistance(double distance) { setProperty("min_solution_distance", distance); }
+	void setMaximizeClearance(bool flag) { setProperty("maximize_clearance", flag); }
 
 protected:
 	ordered<const SolutionBase*> upstream_solutions_;

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -370,7 +370,7 @@ void ComputeIK::compute() {
 	}
 
 	IKSolutions ik_solutions;
-	auto isValid = [sandbox_scene, ignore_collisions, min_solution_distance, maximize_clearance, &ik_solutions](
+	auto is_valid = [sandbox_scene, ignore_collisions, min_solution_distance, maximize_clearance, &ik_solutions](
 	    robot_state::RobotState* state, const robot_model::JointModelGroup* jmg, const double* joint_positions) {
 		for (const auto& sol : ik_solutions) {
 			if (jmg->distance(joint_positions, sol.data()) < min_solution_distance)

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -355,10 +355,9 @@ void ComputeIK::compute() {
 	double min_solution_distance = props.get<double>("min_solution_distance");
 	bool maximize_clearance = props.get<bool>("maximize_clearance");
 	// disable collision checking between links not in current group in order to compute
-	// clearance between links in current group and rest of the links 
+	// clearance between links in current group and rest of the links
 	auto acm = sandbox_scene->getAllowedCollisionMatrix();
-	if (maximize_clearance)
-	{
+	if (maximize_clearance) {
 		auto& all_link_names = sandbox_state.getRobotModel()->getLinkModelNames();
 		auto& group_link_names = jmg->getLinkModelNames();
 		std::vector<std::string> non_group_links;
@@ -379,8 +378,7 @@ void ComputeIK::compute() {
 		state->setJointGroupPositions(jmg, joint_positions);
 		ik_solutions.emplace_back();
 		state->copyJointGroupPositions(jmg, ik_solutions.back().first);
-		if (maximize_clearance)
-		{
+		if (maximize_clearance) {
 			collision_detection::CollisionRequest req;
 			collision_detection::CollisionResult result;
 			req.distance = true;
@@ -420,21 +418,18 @@ void ComputeIK::compute() {
 			rviz_marker_tools::appendFrame(solution.markers(), target_pose_msg, 0.1, "ik frame");
 			rviz_marker_tools::appendFrame(solution.markers(), ik_pose_msg, 0.1, "ik frame");
 
-			if (maximize_clearance)
-			{
+			if (maximize_clearance) {
 				// compute cost as 1. / clearance (larger clearance is better)
 				double clearance = ik_solutions.back().second;
 				if (clearance > 0.)
-					solution.setCost(1./(clearance + 1e-4));
+					solution.setCost(1. / (clearance + 1e-4));
 				else
 					solution.markAsFailure();
-			}
-			else
-				if (succeeded && i + 1 == ik_solutions.size())
-					// compute cost as distance to compare_pose
-					solution.setCost(s.cost() + jmg->distance(ik_solutions.back().first.data(), compare_pose.data()));
-				else  // found an IK solution, but this was not valid
-					solution.markAsFailure();
+			} else if (succeeded && i + 1 == ik_solutions.size())
+				// compute cost as distance to compare_pose
+				solution.setCost(s.cost() + jmg->distance(ik_solutions.back().first.data(), compare_pose.data()));
+			else  // found an IK solution, but this was not valid
+				solution.markAsFailure();
 
 			// set scene's robot state
 			robot_state::RobotState& robot_state = scene->getCurrentStateNonConst();


### PR DESCRIPTION
This can be useful when using an analytical solver. When maximize_clearance is set to true, the `ComputeIK` stage will loop through all IK solutions and assign a cost to them inversely proportional to the distance to self-collision.

Some initial feedback on whether you'd be willing to consider adding this feature would be appreciated.