### PR TITLE
use MoveIt's codecov configuration

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # allow coverage to drop by this amount and still post success
+        threshold: 0.5%
+        base: auto
+        branches:
+          - master
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false


### PR DESCRIPTION
With some recent changes in the ros-planning organization
it looks like Codecov got enabled for this project too.
https://github.com/ros-planning/moveit_task_constructor/pull/167#issuecomment-642476913

It's good to have the check around, but -0.03% is not supposed to fail.