### PR TITLE
SolutionMsg: always fill start_scene

### DIFF
--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -133,9 +133,10 @@ void Introspection::registerSolution(const SolutionBase& s) {
 
 void Introspection::fillSolution(moveit_task_constructor_msgs::Solution& msg, const SolutionBase& s) {
 	s.fillMessage(msg, this);
+	s.start()->scene()->getPlanningSceneMsg(msg.start_scene);
+
 	msg.process_id = impl->process_id_;
 	msg.task_id = impl->task_->id();
-	s.start()->scene()->getPlanningSceneMsg(msg.start_scene);
 }
 
 void Introspection::publishSolution(const SolutionBase& s) {

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -318,6 +318,8 @@ moveit_msgs::MoveItErrorCodes Task::execute(const SolutionBase& s) {
 
 	moveit_task_constructor_msgs::ExecuteTaskSolutionGoal goal;
 	s.fillMessage(goal.solution, pimpl()->introspection_.get());
+	s.start()->scene()->getPlanningSceneMsg(goal.solution.start_scene);
+
 	ac.sendGoal(goal);
 	ac.waitForResult();
 	return ac.getResult()->error_code;


### PR DESCRIPTION
So far, the `start_scene` field of a `SolutionMsg` was only filled by `Introspection::fillSolution()`,
but not yet by `Task::execute()`. This PR fixes #171.

I also considered filling `start_scene` in `SolutionBase::fillMessage()`. However, for sequences, this field would have been filled multiple times then, which is not an option.