### PR TITLE
MoveRelative: provide failure message

### DIFF
--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -257,7 +257,8 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 			}
 		} else if (min_distance == 0.0) {  // if min_distance is zero, we succeed in any case
 			success = true;
-		}
+		} else if (!success)
+			solution.setComment("failed to move full distance");
 
 		// add an arrow marker
 		visualization_msgs::Marker m;


### PR DESCRIPTION
As pointed out in https://github.com/ros-planning/moveit_task_constructor/issues/174#issuecomment-643458939, the failure comment was missing in case MoveRelative could not plan for the full distance and there was no min_distance specified (the default).