### PR TITLE
add external properties to SolutionInfo

### DIFF
--- a/msgs/msg/SolutionInfo.msg
+++ b/msgs/msg/SolutionInfo.msg
@@ -12,3 +12,7 @@ uint32 stage_id
 
 # markers, e.g. providing additional hints or illustrating failure
 visualization_msgs/Marker[] markers
+
+# user-defined values that can provide additional information,
+# e.g., whether to switch a suction gripper on or off or when to call some other execution interface
+Property[] external


### PR DESCRIPTION
This interface can be customized by the user to state when/where additional execution hooks should run.

This is an initial thread to discuss/extend this idea as discussed in #192