### PR TITLE
apply clang-format 10 changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,7 @@ BraceWrapping:
   BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
+  SplitEmptyRecord: false
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -120,7 +120,7 @@ class ParallelContainerBase;
  *  - Fallbacks: the children are considered in series
  *  - Merger: solutions of all children (actuating disjoint groups)
  *            are merged into a single solution for parallel execution
-*/
+ */
 class ParallelContainerBase : public ContainerBase
 {
 public:

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -49,8 +49,8 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(JointModelGroup)
 MOVEIT_CLASS_FORWARD(RobotState)
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/marker_tools.h
+++ b/core/include/moveit/task_constructor/marker_tools.h
@@ -12,8 +12,8 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 MOVEIT_CLASS_FORWARD(LinkModel)
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/solvers/planner_interface.h
+++ b/core/include/moveit/task_constructor/solvers/planner_interface.h
@@ -54,8 +54,8 @@ namespace core {
 MOVEIT_CLASS_FORWARD(LinkModel)
 MOVEIT_CLASS_FORWARD(RobotModel)
 MOVEIT_CLASS_FORWARD(JointModelGroup)
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -54,7 +54,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 }
-}
+}  // namespace moveit
 
 namespace planning_scene {
 MOVEIT_CLASS_FORWARD(PlanningScene)

--- a/core/include/moveit/task_constructor/stages/compute_ik.h
+++ b/core/include/moveit/task_constructor/stages/compute_ik.h
@@ -45,8 +45,8 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 MOVEIT_CLASS_FORWARD(JointModelGroup)
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -47,7 +47,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 }
-}
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/stages/modify_planning_scene.h
+++ b/core/include/moveit/task_constructor/stages/modify_planning_scene.h
@@ -48,7 +48,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(JointModelGroup)
 }
-}
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/stages/move_relative.h
+++ b/core/include/moveit/task_constructor/stages/move_relative.h
@@ -48,7 +48,7 @@ namespace moveit {
 namespace core {
 class RobotState;
 }
-}
+}  // namespace moveit
 namespace moveit {
 namespace task_constructor {
 namespace stages {

--- a/core/include/moveit/task_constructor/stages/move_to.h
+++ b/core/include/moveit/task_constructor/stages/move_to.h
@@ -48,7 +48,7 @@ namespace moveit {
 namespace core {
 class RobotState;
 }
-}
+}  // namespace moveit
 namespace moveit {
 namespace task_constructor {
 namespace stages {
@@ -101,10 +101,10 @@ protected:
 	bool getJointStateGoal(const boost::any& goal, const core::JointModelGroup* jmg, moveit::core::RobotState& state);
 	bool getPoseGoal(const boost::any& goal, const geometry_msgs::PoseStamped& ik_pose_msg,
 	                 const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-	                 decltype(std::declval<SolutionBase>().markers()) & markers);
+	                 decltype(std::declval<SolutionBase>().markers())& markers);
 	bool getPointGoal(const boost::any& goal, const moveit::core::LinkModel* link,
 	                  const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-	                  decltype(std::declval<SolutionBase>().markers()) & /*unused*/);
+	                  decltype(std::declval<SolutionBase>().markers())& /*unused*/);
 
 protected:
 	solvers::PlannerInterfacePtr planner_;

--- a/core/include/moveit/task_constructor/stages/predicate_filter.h
+++ b/core/include/moveit/task_constructor/stages/predicate_filter.h
@@ -41,7 +41,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 }
-}
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {

--- a/core/include/moveit/task_constructor/stages/simple_grasp.h
+++ b/core/include/moveit/task_constructor/stages/simple_grasp.h
@@ -45,7 +45,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 }
-}
+}  // namespace moveit
 namespace moveit {
 namespace task_constructor {
 namespace stages {

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -182,10 +182,10 @@ private:
 
 	// restrict access to some functions to ensure consistency
 	// (we need to set/unset InterfaceState::owner_)
-	using base_type::moveTo;
-	using base_type::moveFrom;
-	using base_type::insert;
 	using base_type::erase;
+	using base_type::insert;
+	using base_type::moveFrom;
+	using base_type::moveTo;
 	using base_type::remove_if;
 };
 
@@ -329,4 +329,4 @@ struct less<moveit::task_constructor::SolutionBase*>
 		return *x < *y;
 	}
 };
-}
+}  // namespace std

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -52,8 +52,8 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 MOVEIT_CLASS_FORWARD(RobotState)
-}
-}
+}  // namespace core
+}  // namespace moveit
 
 namespace moveit {
 namespace task_constructor {
@@ -108,9 +108,9 @@ public:
 	void eraseTaskCallback(TaskCallbackList::const_iterator which);
 
 	/// expose SolutionCallback API
-	using WrapperBase::SolutionCallback;
 	using WrapperBase::addSolutionCallback;
 	using WrapperBase::removeSolutionCallback;
+	using WrapperBase::SolutionCallback;
 
 	/// reset all stages
 	void reset() final;

--- a/core/include/moveit/task_constructor/type_traits.h
+++ b/core/include/moveit/task_constructor/type_traits.h
@@ -54,8 +54,9 @@ struct is_container_helper
 
 template <typename T>
 struct is_container<
-    T, std::conditional_t<false, is_container_helper<typename T::const_iterator, decltype(std::declval<T>().cbegin()),
-                                                     decltype(std::declval<T>().cend())>,
+    T, std::conditional_t<false,
+                          is_container_helper<typename T::const_iterator, decltype(std::declval<T>().cbegin()),
+                                              decltype(std::declval<T>().cend())>,
                           void> > : public std::true_type
 {};
 }  // namespace task_constructor

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -57,7 +57,7 @@ std::string getProcessId() {
 	gethostname(our_hostname, sizeof(our_hostname) - 1);
 	return std::to_string(getpid()) + "@" + our_hostname;
 }
-}
+}  // namespace
 
 class IntrospectionPrivate
 {

--- a/core/src/solvers/planner_interface.cpp
+++ b/core/src/solvers/planner_interface.cpp
@@ -47,6 +47,6 @@ PlannerInterface::PlannerInterface() {
 	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
 	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
 }
-}
-}
+}  // namespace solvers
+}  // namespace task_constructor
 }  // namespace moveit

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -720,7 +720,7 @@ bool Connecting::compatible(const InterfaceState& from_state, const InterfaceSta
 		auto it = std::find_if(to_attached.cbegin(), to_attached.cend(),
 		                       [from_object](const moveit::core::AttachedBody* object) {
 			                       return object->getName() == from_object->getName();
-			                    });
+		                       });
 		if (it == to_attached.cend()) {
 			ROS_DEBUG_STREAM_NAMED("Connecting", name() << ": object missing: " << from_object->getName());
 			return false;

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -354,8 +354,9 @@ void ComputeIK::compute() {
 	double min_solution_distance = props.get<double>("min_solution_distance");
 
 	IKSolutions ik_solutions;
-	auto is_valid = [sandbox_scene, ignore_collisions, min_solution_distance, &ik_solutions](
-	    robot_state::RobotState* state, const robot_model::JointModelGroup* jmg, const double* joint_positions) {
+	auto is_valid = [sandbox_scene, ignore_collisions, min_solution_distance,
+	                 &ik_solutions](robot_state::RobotState* state, const robot_model::JointModelGroup* jmg,
+	                                const double* joint_positions) {
 		for (const auto& sol : ik_solutions) {
 			if (jmg->distance(joint_positions, sol.data()) < min_solution_distance)
 				return false;  // too close to already found solution

--- a/core/src/stages/fix_collision_objects.cpp
+++ b/core/src/stages/fix_collision_objects.cpp
@@ -72,8 +72,8 @@ bool computeCorrection(const std::vector<cd::Contact>& contacts, Eigen::Vector3d
 	correction.setZero();
 	for (const cd::Contact& c : contacts) {
 		if ((c.body_type_1 != cd::BodyTypes::WORLD_OBJECT && c.body_type_2 != cd::BodyTypes::WORLD_OBJECT)) {
-			ROS_WARN_STREAM_NAMED("FixCollisionObjects", "Cannot fix collision between " << c.body_name_1 << " and "
-			                                                                             << c.body_name_2);
+			ROS_WARN_STREAM_NAMED("FixCollisionObjects",
+			                      "Cannot fix collision between " << c.body_name_1 << " and " << c.body_name_2);
 			return false;
 		}
 		if (c.body_type_1 == cd::BodyTypes::WORLD_OBJECT)

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -125,7 +125,7 @@ bool MoveTo::getJointStateGoal(const boost::any& goal, const moveit::core::Joint
 
 bool MoveTo::getPoseGoal(const boost::any& goal, const geometry_msgs::PoseStamped& ik_pose_msg,
                          const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-                         decltype(std::declval<SolutionBase>().markers()) & markers) {
+                         decltype(std::declval<SolutionBase>().markers())& markers) {
 	try {
 		const geometry_msgs::PoseStamped& target = boost::any_cast<geometry_msgs::PoseStamped>(goal);
 		tf::poseMsgToEigen(target.pose, target_eigen);
@@ -147,7 +147,7 @@ bool MoveTo::getPoseGoal(const boost::any& goal, const geometry_msgs::PoseStampe
 
 bool MoveTo::getPointGoal(const boost::any& goal, const moveit::core::LinkModel* link,
                           const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-                          decltype(std::declval<SolutionBase>().markers()) & /*unused*/) {
+                          decltype(std::declval<SolutionBase>().markers())& /*unused*/) {
 	try {
 		const geometry_msgs::PointStamped& target = boost::any_cast<geometry_msgs::PointStamped>(goal);
 		Eigen::Vector3d target_point;

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -117,7 +117,7 @@ Task::Task(const std::string& id, bool introspection, ContainerBase::pointer&& c
 }
 
 Task::Task(Task&& other)  // NOLINT(performance-noexcept-move-constructor)
-    : WrapperBase(new TaskPrivate(this, std::string()), std::make_unique<SerialContainer>()) {
+  : WrapperBase(new TaskPrivate(this, std::string()), std::make_unique<SerialContainer>()) {
 	*this = std::move(other);
 }
 
@@ -223,7 +223,7 @@ void Task::enableIntrospection(bool enable) {
 		    [](Stage& stage, int /*depth*/) {
 			    stage.pimpl()->setIntrospection(nullptr);
 			    return true;
-			 },
+		    },
 		    1, UINT_MAX);
 		impl->introspection_.reset();
 	}
@@ -275,7 +275,7 @@ void Task::init() {
 	    [impl](Stage& stage, int /*depth*/) {
 		    stage.pimpl()->setIntrospection(impl->introspection_.get());
 		    return true;
-		 },
+	    },
 	    1, UINT_MAX);
 
 	// first time publish task

--- a/core/test/models.h
+++ b/core/test/models.h
@@ -6,7 +6,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 }
-}
+}  // namespace moveit
 
 // get a hard-coded model
 moveit::core::RobotModelPtr getModel();

--- a/visualization/motion_planning_tasks/properties/property_factory.h
+++ b/visualization/motion_planning_tasks/properties/property_factory.h
@@ -48,7 +48,7 @@ namespace rviz {
 class Property;
 class PropertyTreeModel;
 class DisplayContext;
-}
+}  // namespace rviz
 namespace planning_scene {
 class PlanningScene;
 }
@@ -56,7 +56,7 @@ namespace moveit {
 namespace task_constructor {
 class Stage;
 }
-}
+}  // namespace moveit
 
 namespace moveit_rviz_plugin {
 

--- a/visualization/motion_planning_tasks/src/icons.cpp
+++ b/visualization/motion_planning_tasks/src/icons.cpp
@@ -11,5 +11,5 @@ const Icon FORWARD({ { QLatin1String(":icons/downarrow.png"), QColor::fromRgba(0
 const Icon BACKWARD({ { QLatin1String(":icons/uparrow.png"), QColor::fromRgba(0xff000000) } }, Icon::TINT);
 const Icon BOTHWAY({ { QLatin1String(":icons/updownarrow.png"), QColor::fromRgba(0xff000000) } }, Icon::TINT);
 const Icon GENERATE({ { QLatin1String(":icons/generatearrow.png"), QColor::fromRgba(0xff000000) } }, Icon::TINT);
-}
-}
+}  // namespace icons
+}  // namespace moveit_rviz_plugin

--- a/visualization/motion_planning_tasks/src/icons.h
+++ b/visualization/motion_planning_tasks/src/icons.h
@@ -10,5 +10,5 @@ extern const moveit_rviz_plugin::utils::Icon FORWARD;
 extern const moveit_rviz_plugin::utils::Icon BACKWARD;
 extern const moveit_rviz_plugin::utils::Icon BOTHWAY;
 extern const moveit_rviz_plugin::utils::Icon GENERATE;
-}
-}
+}  // namespace icons
+}  // namespace moveit_rviz_plugin

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -596,7 +596,7 @@ void RemoteSolutionModel::sortInternal() {
 			          if (comp == 0)  // if still undecided, id decides
 				          comp = (left->id < right->id ? -1 : 1);
 			          return (sort_order_ == Qt::AscendingOrder) ? (comp < 0) : (comp >= 0);
-			       });
+		          });
 	}
 
 	// map old indexes to new ones

--- a/visualization/motion_planning_tasks/src/task_display.h
+++ b/visualization/motion_planning_tasks/src/task_display.h
@@ -54,13 +54,13 @@
 namespace rviz {
 class StringProperty;
 class RosTopicProperty;
-}
+}  // namespace rviz
 
 namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 }
-}
+}  // namespace moveit
 namespace rdf_loader {
 MOVEIT_CLASS_FORWARD(RDFLoader)
 }

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -58,7 +58,7 @@ class ServiceClient;
 namespace rviz {
 class PropertyTreeModel;
 class DisplayContext;
-}
+}  // namespace rviz
 
 namespace moveit_rviz_plugin {
 

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -226,7 +226,7 @@ TaskViewPrivate::TaskViewPrivate(TaskView* q_ptr) : q_ptr(q_ptr), exec_action_cl
 			                 }
 			                 tasks_view->setExpanded(parent, true);  // expand parent group item
 		                 }
-		              });
+	                 });
 
 	tasks_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
 	tasks_view->setAcceptDrops(true);

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -49,7 +49,7 @@ class WindowManagerInterface;
 class Property;
 class BoolProperty;
 class EnumProperty;
-}
+}  // namespace rviz
 
 namespace moveit_rviz_plugin {
 
@@ -108,7 +108,7 @@ class MetaTaskListModel;
  *  Subscribing to task_monitoring and task_solution topics, it collects information
  *  about running tasks and their solutions and allows to inspect both,
  *  successful solutions and failed solution attempts.
-*/
+ */
 class TaskViewPrivate;
 class TaskView : public SubPanel
 {

--- a/visualization/motion_planning_tasks/test/test_merge_models.cpp
+++ b/visualization/motion_planning_tasks/test/test_merge_models.cpp
@@ -61,17 +61,18 @@ void modifySourceModel(QAbstractItemModel* src, T* proxy, const QModelIndex& src
 	const char* new_value = "foo";
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	auto con = proxy->connect(proxy, &T::dataChanged, [&called, &src_index, new_value](const QModelIndex& topLeft,
-	                                                                                   const QModelIndex& bottomRight) {
-		EXPECT_EQ(topLeft.row(), src_index.row());
-		EXPECT_EQ(topLeft.column(), src_index.column());
+	auto con =
+	    proxy->connect(proxy, &T::dataChanged,
+	                   [&called, &src_index, new_value](const QModelIndex& topLeft, const QModelIndex& bottomRight) {
+		                   EXPECT_EQ(topLeft.row(), src_index.row());
+		                   EXPECT_EQ(topLeft.column(), src_index.column());
 
-		EXPECT_EQ(bottomRight.row(), src_index.row());
-		EXPECT_EQ(bottomRight.column(), src_index.column());
+		                   EXPECT_EQ(bottomRight.row(), src_index.row());
+		                   EXPECT_EQ(bottomRight.column(), src_index.column());
 
-		EXPECT_STREQ(topLeft.data().toString().toLatin1().data(), new_value);
-		called = true;
-	});
+		                   EXPECT_STREQ(topLeft.data().toString().toLatin1().data(), new_value);
+		                   called = true;
+	                   });
 #endif
 
 	EXPECT_TRUE(src->setData(src_index, new_value));

--- a/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
@@ -43,7 +43,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 }
-}
+}  // namespace moveit
 namespace planning_scene {
 MOVEIT_CLASS_FORWARD(PlanningScene)
 }

--- a/visualization/visualization_tools/include/moveit/visualization_tools/marker_visualization.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/marker_visualization.h
@@ -14,7 +14,7 @@ class SceneNode;
 namespace rviz {
 class DisplayContext;
 class MarkerBase;
-}
+}  // namespace rviz
 
 namespace planning_scene {
 MOVEIT_CLASS_FORWARD(PlanningScene)
@@ -23,7 +23,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotState)
 }
-}
+}  // namespace moveit
 
 namespace moveit_rviz_plugin {
 

--- a/visualization/visualization_tools/include/moveit/visualization_tools/task_solution_visualization.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/task_solution_visualization.h
@@ -67,7 +67,7 @@ namespace moveit {
 namespace core {
 MOVEIT_CLASS_FORWARD(RobotModel)
 }
-}
+}  // namespace moveit
 namespace planning_scene {
 MOVEIT_CLASS_FORWARD(PlanningScene)
 }

--- a/visualization/visualization_tools/src/task_solution_visualization.cpp
+++ b/visualization/visualization_tools/src/task_solution_visualization.cpp
@@ -72,10 +72,10 @@ namespace moveit_rviz_plugin {
 TaskSolutionVisualization::TaskSolutionVisualization(rviz::Property* parent, rviz::Display* display)
   : display_(display) {
 	// trajectory properties
-	interrupt_display_property_ =
-	    new rviz::BoolProperty("Interrupt Display", false, "Immediately show newly planned trajectory, "
-	                                                       "interrupting the currently displayed one.",
-	                           parent);
+	interrupt_display_property_ = new rviz::BoolProperty("Interrupt Display", false,
+	                                                     "Immediately show newly planned trajectory, "
+	                                                     "interrupting the currently displayed one.",
+	                                                     parent);
 
 	loop_display_property_ = new rviz::BoolProperty(
 	    "Loop Animation", false, "Indicates whether the last received path is to be animated in a loop", parent,
@@ -84,10 +84,11 @@ TaskSolutionVisualization::TaskSolutionVisualization(rviz::Property* parent, rvi
 	trail_display_property_ =
 	    new rviz::BoolProperty("Show Trail", false, "Show a path trail", parent, SLOT(changedTrail()), this);
 
-	state_display_time_property_ = new rviz::EditableEnumProperty(
-	    "State Display Time", "0.05 s", "The amount of wall-time to wait in between displaying "
-	                                    "states along a received trajectory path",
-	    parent);
+	state_display_time_property_ =
+	    new rviz::EditableEnumProperty("State Display Time", "0.05 s",
+	                                   "The amount of wall-time to wait in between displaying "
+	                                   "states along a received trajectory path",
+	                                   parent);
 	state_display_time_property_->addOptionStd("REALTIME");
 	state_display_time_property_->addOptionStd("0.05 s");
 	state_display_time_property_->addOptionStd("0.1 s");
@@ -100,14 +101,15 @@ TaskSolutionVisualization::TaskSolutionVisualization(rviz::Property* parent, rvi
 
 	// robot properties
 	robot_property_ = new rviz::Property("Robot", QString(), QString(), parent);
-	robot_visual_enabled_property_ =
-	    new rviz::BoolProperty("Show Robot Visual", true, "Indicates whether the geometry of the robot as defined for "
-	                                                      "visualisation purposes should be displayed",
-	                           robot_property_, SLOT(changedRobotVisualEnabled()), this);
+	robot_visual_enabled_property_ = new rviz::BoolProperty("Show Robot Visual", true,
+	                                                        "Indicates whether the geometry of the robot as defined for "
+	                                                        "visualisation purposes should be displayed",
+	                                                        robot_property_, SLOT(changedRobotVisualEnabled()), this);
 
 	robot_collision_enabled_property_ =
-	    new rviz::BoolProperty("Show Robot Collision", false, "Indicates whether the geometry of the robot as defined "
-	                                                          "for collision detection purposes should be displayed",
+	    new rviz::BoolProperty("Show Robot Collision", false,
+	                           "Indicates whether the geometry of the robot as defined "
+	                           "for collision detection purposes should be displayed",
 	                           robot_property_, SLOT(changedRobotCollisionEnabled()), this);
 
 	robot_alpha_property_ = new rviz::FloatProperty("Robot Alpha", 0.5f, "Specifies the alpha for the robot links",
@@ -119,10 +121,10 @@ TaskSolutionVisualization::TaskSolutionVisualization(rviz::Property* parent, rvi
 	    new rviz::ColorProperty("Fixed Robot Color", QColor(150, 50, 150), "The color of the animated robot",
 	                            robot_property_, SLOT(changedRobotColor()), this);
 
-	enable_robot_color_property_ =
-	    new rviz::BoolProperty("Use Fixed Robot Color", false, "Specifies whether the fixed robot color should be used."
-	                                                           " If not, the original color is used.",
-	                           robot_property_, SLOT(enabledRobotColor()), this);
+	enable_robot_color_property_ = new rviz::BoolProperty("Use Fixed Robot Color", false,
+	                                                      "Specifies whether the fixed robot color should be used."
+	                                                      " If not, the original color is used.",
+	                                                      robot_property_, SLOT(enabledRobotColor()), this);
 
 	// planning scene properties
 	scene_enabled_property_ =
@@ -404,9 +406,8 @@ void TaskSolutionVisualization::update(float wall_dt, float ros_dt) {
 			current_state_time_ = 0.0;
 			trail_scene_node_->setVisible(false);
 		} else if (tm < 0.0) {  // using realtime: skip to next waypoint based on elapsed display time
-			while (current_state_ < max_state_index &&
-			       (tm = displaying_solution_->getWayPointDurationFromPrevious(current_state_ + 1)) <
-			           current_state_time_) {
+			while (current_state_ < max_state_index && (tm = displaying_solution_->getWayPointDurationFromPrevious(
+			                                                current_state_ + 1)) < current_state_time_) {
 				++current_state_;
 				current_state_time_ -= tm;
 			}
@@ -618,9 +619,10 @@ void TaskSolutionVisualization::setVisibility(Ogre::SceneNode* node, Ogre::Scene
 
 void TaskSolutionVisualization::setVisibility() {
 	// main scene node is visible if animation, trail, or panel is shown, or if display is locked
-	setVisibility(main_scene_node_, parent_scene_node_, display_->isEnabled() && displaying_solution_ &&
-	                                                        (animating_ || locked_ || trail_scene_node_->getParent() ||
-	                                                         (slider_panel_ && slider_panel_->isVisible())));
+	setVisibility(
+	    main_scene_node_, parent_scene_node_,
+	    display_->isEnabled() && displaying_solution_ &&
+	        (animating_ || locked_ || trail_scene_node_->getParent() || (slider_panel_ && slider_panel_->isVisible())));
 }
 
 }  // namespace moveit_rviz_plugin


### PR DESCRIPTION
Looks like migrating MoveIt (and the related change in moveit_ci)
triggered the migration for this repository as well (observed [here](https://travis-ci.com/github/ros-planning/moveit_task_constructor/jobs/375505515#L569))

I only added `SplitEmptyRecord: false` to our current config and the results
look acceptable to me.