### PR TITLE
adapt tests to new moveit_resources layout

### DIFF
--- a/core/package.xml
+++ b/core/package.xml
@@ -21,6 +21,7 @@
 
 	<test_depend>rosunit</test_depend>
 	<test_depend>rostest</test_depend>
+	<test_depend>moveit_resources_fanuc_moveit_config</test_depend>
 
 	<export>
 		<moveit_task_constructor_core plugin="${prefix}/motion_planning_stages_plugin_description.xml"/>

--- a/core/test/test_stage.launch
+++ b/core/test/test_stage.launch
@@ -1,5 +1,5 @@
 <launch>
-	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
 		<arg name="load_robot_description" value="true"/>
 	</include>
 	<test pkg="moveit_task_constructor_core"

--- a/visualization/motion_planning_tasks/test/test_task_model.launch
+++ b/visualization/motion_planning_tasks/test/test_task_model.launch
@@ -1,5 +1,5 @@
 <launch>
-	<include file="$(find moveit_resources)/fanuc_moveit_config/launch/planning_context.launch">
+	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
 		<arg name="load_robot_description" value="true"/>
 	</include>
 	<test pkg="moveit_task_constructor_visualization"

--- a/visualization/package.xml
+++ b/visualization/package.xml
@@ -19,7 +19,7 @@
 
 	<test_depend>rosunit</test_depend>
 	<test_depend>rostest</test_depend>
-	<test_depend>moveit_resources</test_depend>
+	<test_depend>moveit_resources_fanuc_moveit_config</test_depend>
 
 	<export>
 		<rviz plugin="${prefix}/motion_planning_tasks_rviz_plugin_description.xml"/>


### PR DESCRIPTION
CI fails after the recent moveit_resources split:
https://travis-ci.com/github/ros-planning/moveit_task_constructor/jobs/375505517#L931