### PR TITLE
Fix pick-place-demo: Correctly set hand group

### DIFF
--- a/demo/src/pick_place_task.cpp
+++ b/demo/src/pick_place_task.cpp
@@ -229,7 +229,7 @@ void PickPlaceTask::init() {
 		 ***************************************************/
 		{
 			auto stage = std::make_unique<stages::MoveTo>("close hand", sampling_planner);
-			stage->properties().property("group").configureInitFrom(Stage::PARENT, hand_group_name_);
+			stage->setGroup(hand_group_name_);
 			stage->setGoal(hand_close_pose_);
 			grasp->insert(std::move(stage));
 		}
@@ -357,7 +357,7 @@ void PickPlaceTask::init() {
 		 *****************************************************/
 		{
 			auto stage = std::make_unique<stages::MoveTo>("open hand", sampling_planner);
-			stage->properties().property("group").configureInitFrom(Stage::PARENT, hand_group_name_);
+			stage->setGroup(hand_group_name_);
 			stage->setGoal(hand_open_pose_);
 			place->insert(std::move(stage));
 		}


### PR DESCRIPTION
In the panda example, the `hand` group was "hand" as well, so it didn't make a difference... However, if the group has a different name, it's important to either inherent from the correct parent property (`hand`) or to directly set the correct name.

Fixes #204.