### PR TITLE
tf2 compatibility for Noetic

### DIFF
--- a/visualization/visualization_tools/CMakeLists.txt
+++ b/visualization/visualization_tools/CMakeLists.txt
@@ -2,6 +2,11 @@ set(MOVEIT_LIB_NAME moveit_task_visualization_tools)
 
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/moveit/visualization_tools)
 
+# TODO: Remove when Kinetic support is dropped
+if(rviz_VERSION VERSION_LESS 1.13.1) # Does rviz supports TF2?
+  add_definitions(-DRVIZ_TF1)
+endif()
+
 set(HEADERS
 	${PROJECT_INCLUDE}/display_solution.h
 	${PROJECT_INCLUDE}/marker_visualization.h

--- a/visualization/visualization_tools/src/marker_visualization.cpp
+++ b/visualization/visualization_tools/src/marker_visualization.cpp
@@ -72,13 +72,8 @@ bool MarkerVisualization::createMarkers(rviz::DisplayContext* context, Ogre::Sce
 	Ogre::Vector3 pos;
 
 	try {
-		std::string error_msg;
 #ifdef RVIZ_TF1
 		tf::TransformListener* tf = context->getFrameManager()->getTFClient();
-		if (!tf->canTransform(planning_frame_, fixed_frame, ros::Time(), &error_msg)) {
-			ROS_WARN_STREAM_NAMED("MarkerVisualization", error_msg);
-			return false;  // frame transform not (yet) available
-		}
 		tf::StampedTransform tm;
 		tf->lookupTransform(planning_frame_, fixed_frame, ros::Time(), tm);
 		auto q = tm.getRotation();

--- a/visualization/visualization_tools/src/marker_visualization.cpp
+++ b/visualization/visualization_tools/src/marker_visualization.cpp
@@ -7,6 +7,9 @@
 #include <rviz/frame_manager.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
+#ifndef RVIZ_TF1
+#include <tf/tf.h>
+#endif
 #include <tf2_msgs/TF2Error.h>
 #include <ros/console.h>
 #include <eigen_conversions/eigen_msg.h>
@@ -69,8 +72,9 @@ bool MarkerVisualization::createMarkers(rviz::DisplayContext* context, Ogre::Sce
 	Ogre::Vector3 pos;
 
 	try {
-		tf::TransformListener* tf = context->getFrameManager()->getTFClient();
 		std::string error_msg;
+#ifdef RVIZ_TF1
+		tf::TransformListener* tf = context->getFrameManager()->getTFClient();
 		if (!tf->canTransform(planning_frame_, fixed_frame, ros::Time(), &error_msg)) {
 			ROS_WARN_STREAM_NAMED("MarkerVisualization", error_msg);
 			return false;  // frame transform not (yet) available
@@ -81,6 +85,15 @@ bool MarkerVisualization::createMarkers(rviz::DisplayContext* context, Ogre::Sce
 		auto p = tm.getOrigin();
 		quat = Ogre::Quaternion(q.w(), -q.x(), -q.y(), -q.z());
 		pos = Ogre::Vector3(p.x(), p.y(), p.z());
+#else
+		std::shared_ptr<tf2_ros::Buffer> tf = context->getFrameManager()->getTF2BufferPtr();
+		geometry_msgs::TransformStamped tm;
+		tm = tf->lookupTransform(planning_frame_, fixed_frame, ros::Time());
+		auto q = tm.transform.rotation;
+		auto p = tm.transform.translation;
+		quat = Ogre::Quaternion(q.w, -q.x, -q.y, -q.z);
+		pos = Ogre::Vector3(p.x, p.y, p.z);
+#endif
 	} catch (const tf2::TransformException& e) {
 		ROS_WARN_STREAM_NAMED("MarkerVisualization", e.what());
 		return false;


### PR DESCRIPTION
Just a simple compile-time switch to handle removed rviz' `getTFClient()` in Noetic.