### PR TITLE
Rework rviz introspection

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -78,13 +78,11 @@ public:
 	createPlanner(const moveit::core::RobotModelConstPtr& model, const std::string& ns = "move_group",
 	              const std::string& planning_plugin_param_name = "planning_plugin",
 	              const std::string& adapter_plugins_param_name = "request_adapters");
-	Task(const std::string& id = "", bool introspection = true,
+	Task(const std::string& ns = "", bool introspection = true,
 	     ContainerBase::pointer&& container = std::make_unique<SerialContainer>("task pipeline"));
 	Task(Task&& other);  // NOLINT(performance-noexcept-move-constructor)
 	Task& operator=(Task&& other);  // NOLINT(performance-noexcept-move-constructor)
 	~Task() override;
-
-	const std::string& id() const;
 
 	const moveit::core::RobotModelConstPtr& getRobotModel() const;
 	/// setting the robot model also resets the task

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -84,6 +84,9 @@ public:
 	Task& operator=(Task&& other);  // NOLINT(performance-noexcept-move-constructor)
 	~Task() override;
 
+	const std::string& name() const { return stages()->name(); }
+	void setName(const std::string& name) { stages()->setName(name); }
+
 	const moveit::core::RobotModelConstPtr& getRobotModel() const;
 	/// setting the robot model also resets the task
 	void setRobotModel(const moveit::core::RobotModelConstPtr& robot_model);

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -53,15 +53,15 @@ class TaskPrivate : public WrapperBasePrivate
 	friend class Task;
 
 public:
-	TaskPrivate(Task* me, const std::string& id);
-	const std::string& id() const { return id_; }
+	TaskPrivate(Task* me, const std::string& ns);
+	const std::string& ns() const { return ns_; }
 	const ContainerBase* stages() const;
 
 protected:
 	static void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 private:
-	std::string id_;
+	std::string ns_;
 	robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
 	moveit::core::RobotModelConstPtr robot_model_;
 	bool preempt_requested_;

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -78,7 +78,8 @@ public:
 		    nh_.advertise<moveit_task_constructor_msgs::TaskStatistics>(STATISTICS_TOPIC, 1, true);
 		solution_publisher_ = nh_.advertise<moveit_task_constructor_msgs::Solution>(SOLUTION_TOPIC, 1, true);
 
-		get_solution_service_ = nh_.advertiseService(GET_SOLUTION_SERVICE, &Introspection::getSolution, self);
+		get_solution_service_ =
+		    nh_.advertiseService(std::string(GET_SOLUTION_SERVICE "_") + task_id_, &Introspection::getSolution, self);
 
 		resetMaps();
 	}

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -63,7 +63,7 @@ class IntrospectionPrivate
 {
 public:
 	IntrospectionPrivate(const TaskPrivate* task)
-	  : nh_(std::string("~/") + task->id())  // topics + services are advertised in private namespace
+	  : nh_(std::string("~/") + task->ns())  // topics + services are advertised in private namespace
 	  , task_(task)
 	  , process_id_(getProcessId()) {
 		task_description_publisher_ =
@@ -82,7 +82,6 @@ public:
 		// send empty task description message to indicate reset
 		::moveit_task_constructor_msgs::TaskDescription msg;
 		msg.process_id = process_id_;
-		msg.id = task_->id();
 		task_description_publisher_.publish(msg);
 	}
 
@@ -144,7 +143,6 @@ void Introspection::fillSolution(moveit_task_constructor_msgs::Solution& msg, co
 	s.start()->scene()->getPlanningSceneMsg(msg.start_scene);
 
 	msg.process_id = impl->process_id_;
-	msg.task_id = impl->task_->id();
 }
 
 void Introspection::publishSolution(const SolutionBase& s) {
@@ -242,7 +240,6 @@ Introspection::fillTaskDescription(moveit_task_constructor_msgs::TaskDescription
 	msg.stages.clear();
 	impl->task_->stages()->traverseRecursively(stage_processor);
 
-	msg.id = impl->task_->id();
 	msg.process_id = impl->process_id_;
 	return msg;
 }
@@ -263,7 +260,6 @@ Introspection::fillTaskStatistics(moveit_task_constructor_msgs::TaskStatistics& 
 	msg.stages.clear();
 	impl->task_->stages()->traverseRecursively(stage_processor);
 
-	msg.id = impl->task_->id();
 	msg.process_id = impl->process_id_;
 	return msg;
 }

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -173,6 +173,7 @@ planning_pipeline::PlanningPipelinePtr Task::createPlanner(const robot_model::Ro
 
 Task::~Task() {
 	auto impl = pimpl();
+	impl->introspection_.reset();  // stop introspection
 	clear();  // remove all stages
 	impl->robot_model_.reset();
 	// only destroy loader after all references to the model are gone!

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -71,8 +71,8 @@ std::string rosNormalizeName(const std::string& name) {
 namespace moveit {
 namespace task_constructor {
 
-TaskPrivate::TaskPrivate(Task* me, const std::string& id)
-  : WrapperBasePrivate(me, std::string()), id_(rosNormalizeName(id)), preempt_requested_(false) {}
+TaskPrivate::TaskPrivate(Task* me, const std::string& ns)
+  : WrapperBasePrivate(me, std::string()), ns_(rosNormalizeName(ns)), preempt_requested_(false) {}
 
 void swap(StagePrivate*& lhs, StagePrivate*& rhs) {
 	// It only makes sense to swap pimpl instances of a Task!
@@ -104,11 +104,8 @@ const ContainerBase* TaskPrivate::stages() const {
 	return children().empty() ? nullptr : static_cast<ContainerBase*>(children().front().get());
 }
 
-Task::Task(const std::string& id, bool introspection, ContainerBase::pointer&& container)
-  : WrapperBase(new TaskPrivate(this, id), std::move(container)) {
-	if (!id.empty())
-		stages()->setName(id);
-
+Task::Task(const std::string& ns, bool introspection, ContainerBase::pointer&& container)
+  : WrapperBase(new TaskPrivate(this, ns), std::move(container)) {
 	setTimeout(std::numeric_limits<double>::max());
 
 	// monitor state on commandline
@@ -358,10 +355,6 @@ PropertyMap& Task::properties() {
 void Task::setProperty(const std::string& name, const boost::any& value) {
 	// forward to wrapped() stage
 	wrapped()->setProperty(name, value);
-}
-
-const std::string& Task::id() const {
-	return pimpl()->id();
 }
 
 const core::RobotModelConstPtr& Task::getRobotModel() const {

--- a/msgs/msg/Solution.msg
+++ b/msgs/msg/Solution.msg
@@ -1,5 +1,5 @@
 # id of generating task
-string process_id
+string task_id
 
 # planning scene of start state
 moveit_msgs/PlanningScene start_scene

--- a/msgs/msg/Solution.msg
+++ b/msgs/msg/Solution.msg
@@ -1,8 +1,5 @@
-# id of generating process
+# id of generating task
 string process_id
-
-# id of associated task
-string task_id
 
 # planning scene of start state
 moveit_msgs/PlanningScene start_scene

--- a/msgs/msg/TaskDescription.msg
+++ b/msgs/msg/TaskDescription.msg
@@ -1,5 +1,5 @@
 # unique id of this task
-string process_id
+string task_id
 
 # list of all stages, including the task stage itself
 StageDescription[] stages

--- a/msgs/msg/TaskDescription.msg
+++ b/msgs/msg/TaskDescription.msg
@@ -1,8 +1,5 @@
-# id of generating process
+# unique id of this task
 string process_id
-
-# unique ID of this task
-string id
 
 # list of all stages, including the task stage itself
 StageDescription[] stages

--- a/msgs/msg/TaskStatistics.msg
+++ b/msgs/msg/TaskStatistics.msg
@@ -1,8 +1,5 @@
-# id of generating process
+# unique id of generating task
 string process_id
-
-# unique of this task
-string id
 
 # list of all stages, including the task stage itself
 StageStatistics[] stages

--- a/msgs/msg/TaskStatistics.msg
+++ b/msgs/msg/TaskStatistics.msg
@@ -1,5 +1,5 @@
 # unique id of generating task
-string process_id
+string task_id
 
 # list of all stages, including the task stage itself
 StageStatistics[] stages

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -45,7 +45,6 @@
 #include <rviz/properties/property_tree_model.h>
 #include <rviz/properties/string_property.h>
 #include <ros/console.h>
-#include <ros/service_client.h>
 
 #include <QApplication>
 #include <QPalette>
@@ -181,18 +180,17 @@ QModelIndex RemoteTaskModel::index(const Node* n) const {
 	return QModelIndex();
 }
 
-RemoteTaskModel::RemoteTaskModel(const planning_scene::PlanningSceneConstPtr& scene,
+RemoteTaskModel::RemoteTaskModel(ros::NodeHandle& nh, const std::string& service_name,
+                                 const planning_scene::PlanningSceneConstPtr& scene,
                                  rviz::DisplayContext* display_context, QObject* parent)
   : BaseTaskModel(scene, display_context, parent), root_(new Node(nullptr)) {
 	id_to_stage_[0] = root_;  // root node has ID 0
+	// service to request solutions
+	get_solution_client_ = nh.serviceClient<moveit_task_constructor_msgs::GetSolution>(service_name);
 }
 
 RemoteTaskModel::~RemoteTaskModel() {
 	delete root_;
-}
-
-void RemoteTaskModel::setSolutionClient(ros::ServiceClient* client) {
-	get_solution_client_ = client;
 }
 
 int RemoteTaskModel::rowCount(const QModelIndex& parent) const {
@@ -420,15 +418,16 @@ DisplaySolutionPtr RemoteTaskModel::getSolution(const QModelIndex& index) {
 		// to avoid some communication overhead
 
 		DisplaySolutionPtr result;
-		if (!(flags_ & IS_DESTROYED) && get_solution_client_) {
+		if (!(flags_ & IS_DESTROYED)) {
 			// request solution via service
 			moveit_task_constructor_msgs::GetSolution srv;
 			srv.request.solution_id = id;
 			try {
-				if (get_solution_client_->call(srv)) {
+				if (get_solution_client_.call(srv)) {
 					id_to_solution_[id] = result = processSolutionMessage(srv.response.solution);
 					return result;
 				} else {  // on failure mark remote task as destroyed: don't retrieve more solutions
+					get_solution_client_.shutdown();
 					flags_ |= IS_DESTROYED;
 				}
 			} catch (const std::exception& e) {

--- a/visualization/motion_planning_tasks/src/remote_task_model.h
+++ b/visualization/motion_planning_tasks/src/remote_task_model.h
@@ -38,12 +38,9 @@
 
 #include "task_list_model.h"
 #include <moveit/visualization_tools/display_solution.h>
+#include <ros/service_client.h>
 #include <memory>
 #include <limits>
-
-namespace ros {
-class ServiceClient;
-}
 
 namespace moveit_rviz_plugin {
 
@@ -57,7 +54,7 @@ class RemoteTaskModel : public BaseTaskModel
 	Q_OBJECT
 	struct Node;
 	Node* const root_;
-	ros::ServiceClient* get_solution_client_ = nullptr;
+	ros::ServiceClient get_solution_client_;
 
 	std::map<uint32_t, Node*> id_to_stage_;
 	std::map<uint32_t, DisplaySolutionPtr> id_to_solution_;
@@ -70,11 +67,10 @@ class RemoteTaskModel : public BaseTaskModel
 	void setSolutionData(const moveit_task_constructor_msgs::SolutionInfo& info);
 
 public:
-	RemoteTaskModel(const planning_scene::PlanningSceneConstPtr& scene, rviz::DisplayContext* display_context,
+	RemoteTaskModel(ros::NodeHandle& nh, const std::string& service_name,
+	                const planning_scene::PlanningSceneConstPtr& scene, rviz::DisplayContext* display_context,
 	                QObject* parent = nullptr);
 	~RemoteTaskModel() override;
-
-	void setSolutionClient(ros::ServiceClient* client);
 
 	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -188,20 +188,10 @@ void TaskDisplay::changedRobotDescription() {
 		loadRobotModel();
 }
 
-inline std::string getUniqueId(const std::string& process_id, const std::string& task_id) {
-	std::string id{ process_id };
-	if (!task_id.empty()) {
-		id += "/";
-		id += task_id;
-	}
-	return id;
-}
-
 void TaskDisplay::taskDescriptionCB(const moveit_task_constructor_msgs::TaskDescriptionConstPtr& msg) {
-	const std::string id = getUniqueId(msg->process_id, msg->id);
-	mainloop_jobs_.addJob([this, id, msg]() {
+	mainloop_jobs_.addJob([this, msg]() {
 		setStatus(rviz::StatusProperty::Ok, "Task Monitor", "OK");
-		task_list_model_->processTaskDescriptionMessage(id, *msg);
+		task_list_model_->processTaskDescriptionMessage(*msg);
 
 		// Start listening to other topics if this is the first description
 		// Waiting for the description ensures we do not receive data that cannot be interpreted yet
@@ -215,18 +205,16 @@ void TaskDisplay::taskDescriptionCB(const moveit_task_constructor_msgs::TaskDesc
 }
 
 void TaskDisplay::taskStatisticsCB(const moveit_task_constructor_msgs::TaskStatisticsConstPtr& msg) {
-	const std::string id = getUniqueId(msg->process_id, msg->id);
-	mainloop_jobs_.addJob([this, id, msg]() {
+	mainloop_jobs_.addJob([this, msg]() {
 		setStatus(rviz::StatusProperty::Ok, "Task Monitor", "OK");
-		task_list_model_->processTaskStatisticsMessage(id, *msg);
+		task_list_model_->processTaskStatisticsMessage(*msg);
 	});
 }
 
 void TaskDisplay::taskSolutionCB(const moveit_task_constructor_msgs::SolutionConstPtr& msg) {
-	const std::string id = getUniqueId(msg->process_id, msg->task_id);
-	mainloop_jobs_.addJob([this, id, msg]() {
+	mainloop_jobs_.addJob([this, msg]() {
 		setStatus(rviz::StatusProperty::Ok, "Task Monitor", "OK");
-		const DisplaySolutionPtr& s = task_list_model_->processSolutionMessage(id, *msg);
+		const DisplaySolutionPtr& s = task_list_model_->processSolutionMessage(*msg);
 		if (s)
 			trajectory_visual_->showTrajectory(s, false);
 		return;

--- a/visualization/motion_planning_tasks/src/task_display.h
+++ b/visualization/motion_planning_tasks/src/task_display.h
@@ -45,7 +45,6 @@
 #include "job_queue.h"
 #include <moveit/macros/class_forward.h>
 #include <ros/subscriber.h>
-#include <ros/service_client.h>
 #include <moveit_task_constructor_msgs/TaskDescription.h>
 #include <moveit_task_constructor_msgs/TaskStatistics.h>
 #include <moveit_task_constructor_msgs/Solution.h>
@@ -119,7 +118,6 @@ protected:
 	ros::Subscriber task_solution_sub;
 	ros::Subscriber task_description_sub;
 	ros::Subscriber task_statistics_sub;
-	ros::ServiceClient get_solution_client;
 
 	// handle processing of task+solution messages in Qt mainloop
 	moveit::tools::JobQueue mainloop_jobs_;

--- a/visualization/motion_planning_tasks/src/task_list_model.cpp
+++ b/visualization/motion_planning_tasks/src/task_list_model.cpp
@@ -242,7 +242,7 @@ QVariant TaskListModel::data(const QModelIndex& index, int role) const {
 // update existing RemoteTask, create a new one, or (if msg.stages is empty) delete an existing one
 void TaskListModel::processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg) {
 	// retrieve existing or insert new remote task for given task id
-	auto it_inserted = remote_tasks_.insert(std::make_pair(msg.process_id, nullptr));
+	auto it_inserted = remote_tasks_.insert(std::make_pair(msg.task_id, nullptr));
 	bool created = it_inserted.second;
 	const auto& task_it = it_inserted.first;
 	RemoteTaskModel*& remote_task = task_it->second;
@@ -274,16 +274,16 @@ void TaskListModel::processTaskDescriptionMessage(const moveit_task_constructor_
 
 	// insert newly created model into this' model instance
 	if (created) {
-		ROS_DEBUG_NAMED(LOGNAME, "received new task: %s", msg.process_id.c_str());
+		ROS_DEBUG_NAMED(LOGNAME, "received new task: %s", msg.task_id.c_str());
 		insertModel(remote_task, -1);
 	}
 }
 
 // process a task statistics message
 void TaskListModel::processTaskStatisticsMessage(const moveit_task_constructor_msgs::TaskStatistics& msg) {
-	auto it = remote_tasks_.find(msg.process_id);
+	auto it = remote_tasks_.find(msg.task_id);
 	if (it == remote_tasks_.cend()) {
-		ROS_WARN("unknown task: %s", msg.process_id.c_str());
+		ROS_WARN("unknown task: %s", msg.task_id.c_str());
 		return;
 	}
 
@@ -295,7 +295,7 @@ void TaskListModel::processTaskStatisticsMessage(const moveit_task_constructor_m
 }
 
 DisplaySolutionPtr TaskListModel::processSolutionMessage(const moveit_task_constructor_msgs::Solution& msg) {
-	auto it = remote_tasks_.find(msg.process_id);
+	auto it = remote_tasks_.find(msg.task_id);
 	if (it == remote_tasks_.cend())
 		return DisplaySolutionPtr();  // unkown task
 

--- a/visualization/motion_planning_tasks/src/task_list_model.cpp
+++ b/visualization/motion_planning_tasks/src/task_list_model.cpp
@@ -240,10 +240,9 @@ QVariant TaskListModel::data(const QModelIndex& index, int role) const {
 
 // process a task description message:
 // update existing RemoteTask, create a new one, or (if msg.stages is empty) delete an existing one
-void TaskListModel::processTaskDescriptionMessage(const std::string& id,
-                                                  const moveit_task_constructor_msgs::TaskDescription& msg) {
-	// retrieve existing or insert new remote task for given id
-	auto it_inserted = remote_tasks_.insert(std::make_pair(id, nullptr));
+void TaskListModel::processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg) {
+	// retrieve existing or insert new remote task for given task id
+	auto it_inserted = remote_tasks_.insert(std::make_pair(msg.process_id, nullptr));
 	bool created = it_inserted.second;
 	const auto& task_it = it_inserted.first;
 	RemoteTaskModel*& remote_task = task_it->second;
@@ -275,17 +274,16 @@ void TaskListModel::processTaskDescriptionMessage(const std::string& id,
 
 	// insert newly created model into this' model instance
 	if (created) {
-		ROS_DEBUG_NAMED(LOGNAME, "received new task: %s", msg.id.c_str());
+		ROS_DEBUG_NAMED(LOGNAME, "received new task: %s", msg.process_id.c_str());
 		insertModel(remote_task, -1);
 	}
 }
 
 // process a task statistics message
-void TaskListModel::processTaskStatisticsMessage(const std::string& id,
-                                                 const moveit_task_constructor_msgs::TaskStatistics& msg) {
-	auto it = remote_tasks_.find(id);
+void TaskListModel::processTaskStatisticsMessage(const moveit_task_constructor_msgs::TaskStatistics& msg) {
+	auto it = remote_tasks_.find(msg.process_id);
 	if (it == remote_tasks_.cend()) {
-		ROS_WARN("unknown task: %s", id.c_str());
+		ROS_WARN("unknown task: %s", msg.process_id.c_str());
 		return;
 	}
 
@@ -296,9 +294,8 @@ void TaskListModel::processTaskStatisticsMessage(const std::string& id,
 	remote_task->processStageStatistics(msg.stages);
 }
 
-DisplaySolutionPtr TaskListModel::processSolutionMessage(const std::string& id,
-                                                         const moveit_task_constructor_msgs::Solution& msg) {
-	auto it = remote_tasks_.find(id);
+DisplaySolutionPtr TaskListModel::processSolutionMessage(const moveit_task_constructor_msgs::Solution& msg) {
+	auto it = remote_tasks_.find(msg.process_id);
 	if (it == remote_tasks_.cend())
 		return DisplaySolutionPtr();  // unkown task
 

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -42,6 +42,7 @@
 #include <utils/flat_merge_proxy_model.h>
 
 #include <moveit/macros/class_forward.h>
+#include <ros/node_handle.h>
 #include <moveit_task_constructor_msgs/TaskDescription.h>
 #include <moveit_task_constructor_msgs/TaskStatistics.h>
 #include <moveit_task_constructor_msgs/Solution.h>
@@ -52,9 +53,6 @@
 #include <memory>
 #include <QPointer>
 
-namespace ros {
-class ServiceClient;
-}
 namespace rviz {
 class PropertyTreeModel;
 class DisplayContext;
@@ -132,7 +130,6 @@ class TaskListModel : public utils::FlatMergeProxyModel
 	// if task is destroyed remotely, it is marked with flag IS_DESTROYED
 	// if task is removed locally from tasks vector, it is marked with a nullptr
 	std::map<std::string, RemoteTaskModel*> remote_tasks_;
-	ros::ServiceClient* get_solution_client_ = nullptr;
 
 	// factory used to create stages
 	StageFactoryPtr stage_factory_;
@@ -148,7 +145,6 @@ public:
 
 	void setScene(const planning_scene::PlanningSceneConstPtr& scene);
 	void setDisplayContext(rviz::DisplayContext* display_context);
-	void setSolutionClient(ros::ServiceClient* client);
 	void setActiveTaskModel(BaseTaskModel* model) { active_task_model_ = model; }
 
 	int columnCount(const QModelIndex& parent = QModelIndex()) const override { return 4; }
@@ -157,7 +153,8 @@ public:
 	QVariant data(const QModelIndex& index, int role) const override;
 
 	/// process an incoming task description message - only call in Qt's main loop
-	void processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg);
+	void processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg, ros::NodeHandle& nh,
+	                                   const std::string& service_name);
 	/// process an incoming task description message - only call in Qt's main loop
 	void processTaskStatisticsMessage(const moveit_task_constructor_msgs::TaskStatistics& msg);
 	/// process an incoming solution message - only call in Qt's main loop

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -157,11 +157,11 @@ public:
 	QVariant data(const QModelIndex& index, int role) const override;
 
 	/// process an incoming task description message - only call in Qt's main loop
-	void processTaskDescriptionMessage(const std::string& id, const moveit_task_constructor_msgs::TaskDescription& msg);
+	void processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg);
 	/// process an incoming task description message - only call in Qt's main loop
-	void processTaskStatisticsMessage(const std::string& id, const moveit_task_constructor_msgs::TaskStatistics& msg);
+	void processTaskStatisticsMessage(const moveit_task_constructor_msgs::TaskStatistics& msg);
 	/// process an incoming solution message - only call in Qt's main loop
-	DisplaySolutionPtr processSolutionMessage(const std::string& id, const moveit_task_constructor_msgs::Solution& msg);
+	DisplaySolutionPtr processSolutionMessage(const moveit_task_constructor_msgs::Solution& msg);
 
 	/// insert a TaskModel, pos is relative to modelCount()
 	bool insertModel(BaseTaskModel* model, int pos = -1);

--- a/visualization/motion_planning_tasks/test/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/test/CMakeLists.txt
@@ -16,5 +16,5 @@ if (CATKIN_ENABLE_TESTING)
 
 	add_rostest_gtest(${PROJECT_NAME}-test-task_model test_task_model.launch test_task_model.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-task_model
-		motion_planning_tasks_rviz_plugin ${catkin_LIBRARIES} gtest_main)
+		motion_planning_tasks_rviz_plugin ${catkin_LIBRARIES} gtest)
 endif()

--- a/visualization/motion_planning_tasks/test/test_task_model.cpp
+++ b/visualization/motion_planning_tasks/test/test_task_model.cpp
@@ -56,10 +56,10 @@ protected:
 	int num_updates = 0;
 
 	moveit_task_constructor_msgs::TaskDescription genMsg(const std::string& name,
-	                                                     const std::string& process_id = std::string()) {
+	                                                     const std::string& task_id = std::string()) {
 		moveit_task_constructor_msgs::TaskDescription t;
 		uint id = 0, root_id;
-		t.process_id = process_id.empty() ? name : process_id;
+		t.task_id = task_id.empty() ? name : task_id;
 
 		moveit_task_constructor_msgs::StageDescription desc;
 		desc.parent_id = id;

--- a/visualization/motion_planning_tasks/test/test_task_model.launch
+++ b/visualization/motion_planning_tasks/test/test_task_model.launch
@@ -1,7 +1,4 @@
 <launch>
-	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
-		<arg name="load_robot_description" value="true"/>
-	</include>
 	<test pkg="moveit_task_constructor_visualization"
 	      type="moveit_task_constructor_visualization-test-task_model" test-name="test_task_model" />
 </launch>


### PR DESCRIPTION
The original design of the ROS API for introspection had several issues causing segfaults on both sides:
* While it was perfectly possible to create multiple tasks publishing on the same topic, the rviz side wasn't able to handle this.
* Additionally, multiple tasks publishing on the same topic caused conflicts when attempting to create multiple get-solution-services.

This PR:
* Adapts messages to encode a unique `task_id`, replacing previous `process_id` + `id`
* The role of `Task::id` was actually a namespace, so its named `ns` now.
* Creates a get-solution-service for each task using its unique `task_id` as service name. 
As this service should be only used for communication between rviz and the task-creating process, that should be fine. 
If needed, the `task_id` can be read from messages.

**This PR is best merged via #216.**