### PR TITLE
fast-forward master

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -78,13 +78,14 @@ public:
 	createPlanner(const moveit::core::RobotModelConstPtr& model, const std::string& ns = "move_group",
 	              const std::string& planning_plugin_param_name = "planning_plugin",
 	              const std::string& adapter_plugins_param_name = "request_adapters");
-	Task(const std::string& id = "", bool introspection = true,
+	Task(const std::string& ns = "", bool introspection = true,
 	     ContainerBase::pointer&& container = std::make_unique<SerialContainer>("task pipeline"));
 	Task(Task&& other);  // NOLINT(performance-noexcept-move-constructor)
 	Task& operator=(Task&& other);  // NOLINT(performance-noexcept-move-constructor)
 	~Task() override;
 
-	const std::string& id() const;
+	const std::string& name() const { return stages()->name(); }
+	void setName(const std::string& name) { stages()->setName(name); }
 
 	const moveit::core::RobotModelConstPtr& getRobotModel() const;
 	/// setting the robot model also resets the task

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -53,15 +53,15 @@ class TaskPrivate : public WrapperBasePrivate
 	friend class Task;
 
 public:
-	TaskPrivate(Task* me, const std::string& id);
-	const std::string& id() const { return id_; }
+	TaskPrivate(Task* me, const std::string& ns);
+	const std::string& ns() const { return ns_; }
 	const ContainerBase* stages() const;
 
 protected:
 	static void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 private:
-	std::string id_;
+	std::string ns_;
 	robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
 	moveit::core::RobotModelConstPtr robot_model_;
 	bool preempt_requested_;

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -86,9 +86,8 @@ void Connect::init(const core::RobotModelConstPtr& robot_model) {
 		}
 	}
 
-	if (!errors && groups.size() >= 2) {  // enable merging?
+	if (!errors && groups.size() >= 2 && !merged_jmg_) {  // enable merging?
 		try {
-			merged_jmg_.reset();
 			merged_jmg_.reset(task_constructor::merge(groups));
 		} catch (const std::runtime_error& e) {
 			ROS_INFO_STREAM_NAMED("Connect", this->name() << ": " << e.what() << ". Disabling merging.");

--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -252,6 +252,11 @@ bool MoveTo::compute(const InterfaceState& state, planning_scene::PlanningSceneP
 	}
 
 	// store result
+	if (!robot_trajectory && storeFailures()) {
+		robot_trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(robot_model, jmg);
+		robot_trajectory->addSuffixWayPoint(state.scene()->getCurrentState(), 0.0);
+		robot_trajectory->addSuffixWayPoint(scene->getCurrentState(), 1.0);
+	}
 	if (robot_trajectory) {
 		scene->setCurrentState(robot_trajectory->getLastWayPoint());
 		if (dir == BACKWARD)

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -300,8 +300,7 @@ bool Task::plan(size_t max_solutions) {
 	impl->preempt_requested_ = false;
 	const double available_time = timeout();
 	const auto start_time = std::chrono::steady_clock::now();
-	while (ros::ok() && !impl->preempt_requested_ && canCompute() &&
-	       (max_solutions == 0 || numSolutions() < max_solutions) &&
+	while (!impl->preempt_requested_ && canCompute() && (max_solutions == 0 || numSolutions() < max_solutions) &&
 	       std::chrono::duration<double>(std::chrono::steady_clock::now() - start_time).count() < available_time) {
 		compute();
 		for (const auto& cb : impl->task_cbs_)

--- a/msgs/msg/Solution.msg
+++ b/msgs/msg/Solution.msg
@@ -1,7 +1,4 @@
-# id of generating process
-string process_id
-
-# id of associated task
+# id of generating task
 string task_id
 
 # planning scene of start state

--- a/msgs/msg/TaskDescription.msg
+++ b/msgs/msg/TaskDescription.msg
@@ -1,8 +1,5 @@
-# id of generating process
-string process_id
-
-# unique ID of this task
-string id
+# unique id of this task
+string task_id
 
 # list of all stages, including the task stage itself
 StageDescription[] stages

--- a/msgs/msg/TaskStatistics.msg
+++ b/msgs/msg/TaskStatistics.msg
@@ -1,8 +1,5 @@
-# id of generating process
-string process_id
-
-# unique of this task
-string id
+# unique id of generating task
+string task_id
 
 # list of all stages, including the task stage itself
 StageStatistics[] stages

--- a/visualization/motion_planning_tasks/src/remote_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/remote_task_model.cpp
@@ -45,7 +45,6 @@
 #include <rviz/properties/property_tree_model.h>
 #include <rviz/properties/string_property.h>
 #include <ros/console.h>
-#include <ros/service_client.h>
 
 #include <QApplication>
 #include <QPalette>
@@ -181,18 +180,17 @@ QModelIndex RemoteTaskModel::index(const Node* n) const {
 	return QModelIndex();
 }
 
-RemoteTaskModel::RemoteTaskModel(const planning_scene::PlanningSceneConstPtr& scene,
+RemoteTaskModel::RemoteTaskModel(ros::NodeHandle& nh, const std::string& service_name,
+                                 const planning_scene::PlanningSceneConstPtr& scene,
                                  rviz::DisplayContext* display_context, QObject* parent)
   : BaseTaskModel(scene, display_context, parent), root_(new Node(nullptr)) {
 	id_to_stage_[0] = root_;  // root node has ID 0
+	// service to request solutions
+	get_solution_client_ = nh.serviceClient<moveit_task_constructor_msgs::GetSolution>(service_name);
 }
 
 RemoteTaskModel::~RemoteTaskModel() {
 	delete root_;
-}
-
-void RemoteTaskModel::setSolutionClient(ros::ServiceClient* client) {
-	get_solution_client_ = client;
 }
 
 int RemoteTaskModel::rowCount(const QModelIndex& parent) const {
@@ -420,15 +418,16 @@ DisplaySolutionPtr RemoteTaskModel::getSolution(const QModelIndex& index) {
 		// to avoid some communication overhead
 
 		DisplaySolutionPtr result;
-		if (!(flags_ & IS_DESTROYED) && get_solution_client_) {
+		if (!(flags_ & IS_DESTROYED)) {
 			// request solution via service
 			moveit_task_constructor_msgs::GetSolution srv;
 			srv.request.solution_id = id;
 			try {
-				if (get_solution_client_->call(srv)) {
+				if (get_solution_client_.call(srv)) {
 					id_to_solution_[id] = result = processSolutionMessage(srv.response.solution);
 					return result;
 				} else {  // on failure mark remote task as destroyed: don't retrieve more solutions
+					get_solution_client_.shutdown();
 					flags_ |= IS_DESTROYED;
 				}
 			} catch (const std::exception& e) {

--- a/visualization/motion_planning_tasks/src/remote_task_model.h
+++ b/visualization/motion_planning_tasks/src/remote_task_model.h
@@ -38,12 +38,9 @@
 
 #include "task_list_model.h"
 #include <moveit/visualization_tools/display_solution.h>
+#include <ros/service_client.h>
 #include <memory>
 #include <limits>
-
-namespace ros {
-class ServiceClient;
-}
 
 namespace moveit_rviz_plugin {
 
@@ -57,7 +54,7 @@ class RemoteTaskModel : public BaseTaskModel
 	Q_OBJECT
 	struct Node;
 	Node* const root_;
-	ros::ServiceClient* get_solution_client_ = nullptr;
+	ros::ServiceClient get_solution_client_;
 
 	std::map<uint32_t, Node*> id_to_stage_;
 	std::map<uint32_t, DisplaySolutionPtr> id_to_solution_;
@@ -70,11 +67,10 @@ class RemoteTaskModel : public BaseTaskModel
 	void setSolutionData(const moveit_task_constructor_msgs::SolutionInfo& info);
 
 public:
-	RemoteTaskModel(const planning_scene::PlanningSceneConstPtr& scene, rviz::DisplayContext* display_context,
+	RemoteTaskModel(ros::NodeHandle& nh, const std::string& service_name,
+	                const planning_scene::PlanningSceneConstPtr& scene, rviz::DisplayContext* display_context,
 	                QObject* parent = nullptr);
 	~RemoteTaskModel() override;
-
-	void setSolutionClient(ros::ServiceClient* client);
 
 	int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 

--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -98,8 +98,8 @@ void TaskDisplay::onInitialize() {
 	trajectory_visual_->onInitialize(scene_node_, context_);
 	task_list_model_->setDisplayContext(context_);
 	// create a new TaskPanel by default
-	// by post-poning this to main loop, we can ensure that rviz has loaded everything before
-	mainloop_jobs_.addJob([this]() { TaskPanel::incDisplayCount(context_->getWindowManager()); });
+	// by post-poning this to Qt's GUI loop, we can ensure that rviz has loaded everything before
+	QTimer::singleShot(0, [this]() { TaskPanel::incDisplayCount(context_->getWindowManager()); });
 }
 
 void TaskDisplay::loadRobotModel() {

--- a/visualization/motion_planning_tasks/src/task_display.h
+++ b/visualization/motion_planning_tasks/src/task_display.h
@@ -100,6 +100,9 @@ protected:
 	void fixedFrameChanged() override;
 	void calculateOffsetPosition();
 
+private:
+	inline void requestPanel();
+
 private Q_SLOTS:
 	/**
 	 * \brief Slot Event Functions
@@ -123,6 +126,7 @@ protected:
 	std::unique_ptr<TaskSolutionVisualization> trajectory_visual_;
 	// The TaskListModel storing actual task and solution data
 	std::unique_ptr<TaskListModel> task_list_model_;
+	bool panel_requested_;
 
 	// Load robot model
 	rdf_loader::RDFLoaderPtr rdf_loader_;

--- a/visualization/motion_planning_tasks/src/task_display.h
+++ b/visualization/motion_planning_tasks/src/task_display.h
@@ -121,9 +121,6 @@ protected:
 	ros::Subscriber task_statistics_sub;
 	ros::ServiceClient get_solution_client;
 
-	// handle processing of task+solution messages in Qt mainloop
-	moveit::tools::JobQueue mainloop_jobs_;
-
 	// The trajectory playback component
 	std::unique_ptr<TaskSolutionVisualization> trajectory_visual_;
 	// The TaskListModel storing actual task and solution data

--- a/visualization/motion_planning_tasks/src/task_display.h
+++ b/visualization/motion_planning_tasks/src/task_display.h
@@ -45,7 +45,6 @@
 #include "job_queue.h"
 #include <moveit/macros/class_forward.h>
 #include <ros/subscriber.h>
-#include <ros/service_client.h>
 #include <moveit_task_constructor_msgs/TaskDescription.h>
 #include <moveit_task_constructor_msgs/TaskStatistics.h>
 #include <moveit_task_constructor_msgs/Solution.h>
@@ -119,7 +118,6 @@ protected:
 	ros::Subscriber task_solution_sub;
 	ros::Subscriber task_description_sub;
 	ros::Subscriber task_statistics_sub;
-	ros::ServiceClient get_solution_client;
 
 	// The trajectory playback component
 	std::unique_ptr<TaskSolutionVisualization> trajectory_visual_;

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -126,10 +126,12 @@ class TaskListModel : public utils::FlatMergeProxyModel
 	// rviz::DisplayContext used to show (interactive) markers by the property models
 	rviz::DisplayContext* display_context_ = nullptr;
 
-	// map from remote task IDs to tasks
+	// map from remote task IDs to (active) tasks
 	// if task is destroyed remotely, it is marked with flag IS_DESTROYED
 	// if task is removed locally from tasks vector, it is marked with a nullptr
 	std::map<std::string, RemoteTaskModel*> remote_tasks_;
+	// mode reflecting the "Old task handling" setting
+	int old_task_handling_;
 
 	// factory used to create stages
 	StageFactoryPtr stage_factory_;
@@ -171,6 +173,9 @@ public:
 	                  const QModelIndex& parent) override;
 	Qt::DropActions supportedDropActions() const override;
 	Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+public Q_SLOTS:
+	void setOldTaskHandling(int mode);
 
 protected Q_SLOTS:
 	void highlightStage(size_t id);

--- a/visualization/motion_planning_tasks/src/task_list_model.h
+++ b/visualization/motion_planning_tasks/src/task_list_model.h
@@ -42,6 +42,7 @@
 #include <utils/flat_merge_proxy_model.h>
 
 #include <moveit/macros/class_forward.h>
+#include <ros/node_handle.h>
 #include <moveit_task_constructor_msgs/TaskDescription.h>
 #include <moveit_task_constructor_msgs/TaskStatistics.h>
 #include <moveit_task_constructor_msgs/Solution.h>
@@ -52,9 +53,6 @@
 #include <memory>
 #include <QPointer>
 
-namespace ros {
-class ServiceClient;
-}
 namespace rviz {
 class PropertyTreeModel;
 class DisplayContext;
@@ -132,7 +130,6 @@ class TaskListModel : public utils::FlatMergeProxyModel
 	// if task is destroyed remotely, it is marked with flag IS_DESTROYED
 	// if task is removed locally from tasks vector, it is marked with a nullptr
 	std::map<std::string, RemoteTaskModel*> remote_tasks_;
-	ros::ServiceClient* get_solution_client_ = nullptr;
 
 	// factory used to create stages
 	StageFactoryPtr stage_factory_;
@@ -148,7 +145,6 @@ public:
 
 	void setScene(const planning_scene::PlanningSceneConstPtr& scene);
 	void setDisplayContext(rviz::DisplayContext* display_context);
-	void setSolutionClient(ros::ServiceClient* client);
 	void setActiveTaskModel(BaseTaskModel* model) { active_task_model_ = model; }
 
 	int columnCount(const QModelIndex& parent = QModelIndex()) const override { return 4; }
@@ -157,11 +153,12 @@ public:
 	QVariant data(const QModelIndex& index, int role) const override;
 
 	/// process an incoming task description message - only call in Qt's main loop
-	void processTaskDescriptionMessage(const std::string& id, const moveit_task_constructor_msgs::TaskDescription& msg);
+	void processTaskDescriptionMessage(const moveit_task_constructor_msgs::TaskDescription& msg, ros::NodeHandle& nh,
+	                                   const std::string& service_name);
 	/// process an incoming task description message - only call in Qt's main loop
-	void processTaskStatisticsMessage(const std::string& id, const moveit_task_constructor_msgs::TaskStatistics& msg);
+	void processTaskStatisticsMessage(const moveit_task_constructor_msgs::TaskStatistics& msg);
 	/// process an incoming solution message - only call in Qt's main loop
-	DisplaySolutionPtr processSolutionMessage(const std::string& id, const moveit_task_constructor_msgs::Solution& msg);
+	DisplaySolutionPtr processSolutionMessage(const moveit_task_constructor_msgs::Solution& msg);
 
 	/// insert a TaskModel, pos is relative to modelCount()
 	bool insertModel(BaseTaskModel* model, int pos = -1);

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -407,12 +407,12 @@ void TaskView::onCurrentStageChanged(const QModelIndex& current, const QModelInd
 
 	QItemSelectionModel* sm = view->selectionModel();
 	QAbstractItemModel* m = task ? task->getSolutionModel(task_index) : nullptr;
-	view->setModel(m);
-	view->sortByColumn(sort_column, sort_order);
-	delete sm;  // we don't store the selection model
-	sm = view->selectionModel();
+	if (view->model() != m) {
+		view->setModel(m);
+		view->sortByColumn(sort_column, sort_order);
+		delete sm;  // we don't store the selection model
 
-	if (sm) {
+		sm = view->selectionModel();
 		connect(sm, SIGNAL(currentChanged(QModelIndex, QModelIndex)), this,
 		        SLOT(onCurrentSolutionChanged(QModelIndex, QModelIndex)));
 		connect(sm, SIGNAL(selectionChanged(QItemSelection, QItemSelection)), this,
@@ -420,11 +420,13 @@ void TaskView::onCurrentStageChanged(const QModelIndex& current, const QModelInd
 	}
 
 	// update the PropertyModel
-	QTreeView* pview = d_ptr->property_view;
-	sm = pview->selectionModel();
+	view = d_ptr->property_view;
+	sm = view->selectionModel();
 	m = task ? task->getPropertyModel(task_index) : nullptr;
-	pview->setModel(m);
-	delete sm;  // we don't store the selection model
+	if (view->model() != m) {
+		view->setModel(m);
+		delete sm;  // we don't store the selection model
+	}
 }
 
 void TaskView::onCurrentSolutionChanged(const QModelIndex& current, const QModelIndex& previous) {

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -135,7 +135,7 @@ void TaskPanel::incDisplayCount(rviz::WindowManagerInterface* window_manager) {
 
 	rviz::VisualizationFrame* vis_frame = dynamic_cast<rviz::VisualizationFrame*>(window_manager);
 	if (SINGLETON || !vis_frame)
-		return;  // already define, nothing to do
+		return;  // already defined, nothing to do
 
 	QDockWidget* dock =
 	    vis_frame->addPanelByName("Motion Planning Tasks", "moveit_task_constructor/Motion Planning Tasks",

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -149,9 +149,9 @@ void TaskPanel::decDisplayCount() {
 		SINGLETON->deleteLater();
 }
 
-TaskPanelPrivate::TaskPanelPrivate(TaskPanel* q_ptr) : q_ptr(q_ptr) {
-	setupUi(q_ptr);
-	tool_buttons_group = new QButtonGroup(q_ptr);
+TaskPanelPrivate::TaskPanelPrivate(TaskPanel* panel) : q_ptr(panel) {
+	setupUi(panel);
+	tool_buttons_group = new QButtonGroup(panel);
 	tool_buttons_group->setExclusive(true);
 	button_show_stage_dock_widget->setEnabled(bool(getStageFactory()));
 	button_show_stage_dock_widget->setToolTip(QStringLiteral("Show available stages"));
@@ -198,8 +198,8 @@ void setExpanded(QTreeView* view, const QModelIndex& index, bool expand, int dep
 	view->setExpanded(index, expand);
 }
 
-TaskViewPrivate::TaskViewPrivate(TaskView* q_ptr) : q_ptr(q_ptr), exec_action_client_("execute_task_solution") {
-	setupUi(q_ptr);
+TaskViewPrivate::TaskViewPrivate(TaskView* view) : q_ptr(view), exec_action_client_("execute_task_solution") {
+	setupUi(view);
 
 	MetaTaskListModel* meta_model = &MetaTaskListModel::instance();
 	StageFactoryPtr factory = getStageFactory();
@@ -520,10 +520,10 @@ void TaskView::onOldTaskHandlingChanged() {
 	Q_EMIT oldTaskHandlingChanged(old_task_handling->getOptionInt());
 }
 
-GlobalSettingsWidgetPrivate::GlobalSettingsWidgetPrivate(GlobalSettingsWidget* q_ptr, rviz::Property* root)
-  : q_ptr(q_ptr) {
-	setupUi(q_ptr);
-	properties = new rviz::PropertyTreeModel(root, q_ptr);
+GlobalSettingsWidgetPrivate::GlobalSettingsWidgetPrivate(GlobalSettingsWidget* widget, rviz::Property* root)
+  : q_ptr(widget) {
+	setupUi(widget);
+	properties = new rviz::PropertyTreeModel(root, widget);
 	view->setModel(properties);
 }
 

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -124,11 +124,19 @@ protected:
 		EXPAND_ALL,
 		EXPAND_NONE
 	};
-	rviz::EnumProperty* initial_task_expand;
 
+	rviz::EnumProperty* initial_task_expand;
+	rviz::EnumProperty* old_task_handling;
 	rviz::BoolProperty* show_time_column;
 
 public:
+	enum OldTaskHandling
+	{
+		OLD_TASK_KEEP = 1,
+		OLD_TASK_REPLACE,
+		OLD_TASK_REMOVE
+	};
+
 	TaskView(TaskPanel* parent, rviz::Property* root);
 	~TaskView() override;
 
@@ -145,6 +153,13 @@ protected Q_SLOTS:
 	void onSolutionSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
 	void onExecCurrentSolution() const;
 	void onShowTimeChanged();
+	void onOldTaskHandlingChanged();
+
+private:
+	Q_PRIVATE_SLOT(d_ptr, void _q_configureInsertedModels(QModelIndex, int, int));
+
+Q_SIGNALS:
+	void oldTaskHandlingChanged(int);
 };
 
 class GlobalSettingsWidgetPrivate;

--- a/visualization/motion_planning_tasks/src/task_panel.h
+++ b/visualization/motion_planning_tasks/src/task_panel.h
@@ -91,8 +91,8 @@ public:
 	 * If not yet done, an instance is created. If use count drops to zero,
 	 * the global instance is destroyed.
 	 */
-	static void incDisplayCount(rviz::WindowManagerInterface* window_manager);
-	static void decDisplayCount();
+	static void request(rviz::WindowManagerInterface* window_manager);
+	static void release();
 
 	void onInitialize() override;
 	void load(const rviz::Config& config) override;

--- a/visualization/motion_planning_tasks/src/task_panel_p.h
+++ b/visualization/motion_planning_tasks/src/task_panel_p.h
@@ -78,6 +78,13 @@ public:
 	/// retrieve TaskModel corresponding to given index
 	inline std::pair<BaseTaskModel*, QModelIndex> getTaskModel(const QModelIndex& index) const;
 
+	/// configure a (new) TaskListModel
+	void configureTaskListModel(TaskListModel* model);
+	/// configure all TaskListModels that were already created when TaskView gets instantiated
+	void configureExistingModels();
+	/// configure newly inserted models
+	void _q_configureInsertedModels(const QModelIndex& parent, int first, int last);
+
 	/// unlock locked_display_ if given display is different
 	void lock(TaskDisplay* display);
 

--- a/visualization/motion_planning_tasks/test/CMakeLists.txt
+++ b/visualization/motion_planning_tasks/test/CMakeLists.txt
@@ -16,5 +16,5 @@ if (CATKIN_ENABLE_TESTING)
 
 	add_rostest_gtest(${PROJECT_NAME}-test-task_model test_task_model.launch test_task_model.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-task_model
-		motion_planning_tasks_rviz_plugin ${catkin_LIBRARIES} gtest_main)
+		motion_planning_tasks_rviz_plugin ${catkin_LIBRARIES} gtest)
 endif()

--- a/visualization/motion_planning_tasks/test/test_task_model.cpp
+++ b/visualization/motion_planning_tasks/test/test_task_model.cpp
@@ -50,15 +50,17 @@ using namespace moveit::task_constructor;
 class TaskListModelTest : public ::testing::Test
 {
 protected:
+	ros::NodeHandle nh;
 	moveit_rviz_plugin::TaskListModel model;
 	int children = 0;
 	int num_inserts = 0;
 	int num_updates = 0;
 
-	moveit_task_constructor_msgs::TaskDescription genMsg(const std::string& name) {
+	moveit_task_constructor_msgs::TaskDescription genMsg(const std::string& name,
+	                                                     const std::string& task_id = std::string()) {
 		moveit_task_constructor_msgs::TaskDescription t;
-		t.id = name;
 		uint id = 0, root_id;
+		t.task_id = task_id.empty() ? name : task_id;
 
 		moveit_task_constructor_msgs::StageDescription desc;
 		desc.parent_id = id;
@@ -127,7 +129,7 @@ protected:
 			SCOPED_TRACE("first i=" + std::to_string(i));
 			num_inserts = 0;
 			num_updates = 0;
-			model.processTaskDescriptionMessage("1", genMsg("first"));
+			model.processTaskDescriptionMessage(genMsg("first"), nh, "get_solution");
 
 			if (i == 0)
 				EXPECT_EQ(num_inserts, 1);  // 1 notify for inserted task
@@ -141,7 +143,7 @@ protected:
 			SCOPED_TRACE("second i=" + std::to_string(i));
 			num_inserts = 0;
 			num_updates = 0;
-			model.processTaskDescriptionMessage("2", genMsg("second"));  // 1 notify for inserted task
+			model.processTaskDescriptionMessage(genMsg("second"), nh, "get_solution");  // 1 notify for inserted task
 
 			if (i == 0)
 				EXPECT_EQ(num_inserts, 1);
@@ -163,7 +165,7 @@ protected:
 TEST_F(TaskListModelTest, remoteTaskModel) {
 	children = 3;
 	planning_scene::PlanningSceneConstPtr scene;
-	moveit_rviz_plugin::RemoteTaskModel m(scene, nullptr);
+	moveit_rviz_plugin::RemoteTaskModel m(nh, "get_solution", scene, nullptr);
 	m.processStageDescriptions(genMsg("first").stages);
 	SCOPED_TRACE("first");
 	validate(m, { "first" });
@@ -200,13 +202,13 @@ TEST_F(TaskListModelTest, threeChildren) {
 TEST_F(TaskListModelTest, visitedPopulate) {
 	// first population without children
 	children = 0;
-	model.processTaskDescriptionMessage("1", genMsg("first"));
+	model.processTaskDescriptionMessage(genMsg("first"), nh, "get_solution");
 	validate(model, { "first" });  // validation visits root node
 	EXPECT_EQ(num_inserts, 1);
 
 	children = 3;
 	num_inserts = 0;
-	model.processTaskDescriptionMessage("1", genMsg("first"));
+	model.processTaskDescriptionMessage(genMsg("first"), nh, "get_solution");
 	validate(model, { "first" });
 	// second population with children should emit insert notifies for them
 	EXPECT_EQ(num_inserts, 3);
@@ -215,7 +217,7 @@ TEST_F(TaskListModelTest, visitedPopulate) {
 
 TEST_F(TaskListModelTest, deletion) {
 	children = 3;
-	model.processTaskDescriptionMessage("1", genMsg("first"));
+	model.processTaskDescriptionMessage(genMsg("first"), nh, "get_solution");
 	auto m = model.getModel(model.index(0, 0)).first;
 	int num_deletes = 0;
 	QObject::connect(m, &QObject::destroyed, [&num_deletes]() { ++num_deletes; });
@@ -226,4 +228,10 @@ TEST_F(TaskListModelTest, deletion) {
 	// as m is owned by model, m should be destroyed
 	// EXPECT_EQ(num_deletes, 1); // TODO: event is not processed, missing event loop?
 	EXPECT_EQ(model.rowCount(), 0);
+}
+
+int main(int argc, char** argv) {
+	testing::InitGoogleTest(&argc, argv);
+	ros::init(argc, argv, "test_task_model");
+	return RUN_ALL_TESTS();
 }

--- a/visualization/motion_planning_tasks/test/test_task_model.launch
+++ b/visualization/motion_planning_tasks/test/test_task_model.launch
@@ -1,7 +1,4 @@
 <launch>
-	<include file="$(find moveit_resources_fanuc_moveit_config)/launch/planning_context.launch">
-		<arg name="load_robot_description" value="true"/>
-	</include>
 	<test pkg="moveit_task_constructor_visualization"
 	      type="moveit_task_constructor_visualization-test-task_model" test-name="test_task_model" />
 </launch>

--- a/visualization/motion_planning_tasks/utils/flat_merge_proxy_model.cpp
+++ b/visualization/motion_planning_tasks/utils/flat_merge_proxy_model.cpp
@@ -107,7 +107,7 @@ public:
 	std::vector<ModelData> data_;
 
 public:
-	FlatMergeProxyModelPrivate(FlatMergeProxyModel* q_ptr) : q_ptr(q_ptr) {}
+	FlatMergeProxyModelPrivate(FlatMergeProxyModel* model) : q_ptr(model) {}
 
 	std::vector<ModelData>::iterator find(const QObject* model) {
 		Q_ASSERT(model);

--- a/visualization/motion_planning_tasks/utils/tree_merge_proxy_model.cpp
+++ b/visualization/motion_planning_tasks/utils/tree_merge_proxy_model.cpp
@@ -108,7 +108,7 @@ public:
 	std::vector<ModelData> data_;
 
 public:
-	TreeMergeProxyModelPrivate(TreeMergeProxyModel* q_ptr) : q_ptr(q_ptr) {}
+	TreeMergeProxyModelPrivate(TreeMergeProxyModel* model) : q_ptr(model) {}
 
 	std::vector<ModelData>::iterator find(const QObject* model) {
 		Q_ASSERT(model);


### PR DESCRIPTION
Combining PRs #214 + #215 and resolving their conflicts. **Merge from cmdline via fast-forwarding.**

Additionally, this PR adds configurable handling of destroyed remote tasks. They can be:
- always kept (marked red). Of course, one still cannot fetch new solutions in this state.
- replaced with next task (with same `task_id`)
- immediately removed from list