### PR TITLE
Fix SerialContainer

### DIFF
--- a/capabilities/CMakeLists.txt
+++ b/capabilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(moveit_task_constructor_capabilities)
 
 add_compile_options(-std=c++14)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(moveit_task_constructor_core)
 
 find_package(Boost REQUIRED)
@@ -27,16 +27,11 @@ catkin_package(
 		visualization_msgs
 )
 
-if ("${CMAKE_VERSION}" VERSION_LESS "3.1")
-	add_compile_options(-std=c++14)
-else ()
-	set(CMAKE_CXX_STANDARD 14)
-endif ()
+set(CMAKE_CXX_STANDARD 14)
 
 # check for MOVEIT_MASTER
 include(CheckIncludeFileCXX)
 set(CMAKE_REQUIRED_INCLUDES ${moveit_core_INCLUDE_DIRS})
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
 CHECK_INCLUDE_FILE_CXX(moveit/collision_detection/collision_env.h MOVEIT_MASTER)
 if(NOT MOVEIT_MASTER)
   set(MOVEIT_MASTER 0)

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -107,7 +107,7 @@ protected:
 	/// the full trace (from start to end, but not including start) and its accumulated costs
 	template <Interface::Direction dir>
 	void traverse(const SolutionBase& start, const SolutionProcessor& cb, SolutionSequence::container_type& trace,
-	              const InterfaceState::Priority& = InterfaceState::Priority());
+	              const InterfaceState::Priority& = InterfaceState::Priority(0, 0.0));
 
 protected:
 	SerialContainer(SerialContainerPrivate* impl);

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -98,17 +98,6 @@ protected:
 	/// called by a (direct) child when a new solution becomes available
 	void onNewSolution(const SolutionBase& s) override;
 
-	using SolutionProcessor =
-	    std::function<void(const SolutionSequence::container_type&, const InterfaceState::Priority&)>;
-
-	/// Traverse all solution pathes starting at start and going in given direction dir
-	/// until the end, i.e. until there are no more subsolutions in the given direction
-	/// For each solution path, callback the given processor passing
-	/// the full trace (from start to end, but not including start) and its accumulated costs
-	template <Interface::Direction dir>
-	void traverse(const SolutionBase& start, const SolutionProcessor& cb, SolutionSequence::container_type& trace,
-	              const InterfaceState::Priority& = InterfaceState::Priority(0, 0.0));
-
 protected:
 	SerialContainer(SerialContainerPrivate* impl);
 };

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -98,7 +98,8 @@ protected:
 	/// called by a (direct) child when a new solution becomes available
 	void onNewSolution(const SolutionBase& s) override;
 
-	using SolutionProcessor = std::function<void(const SolutionSequence::container_type&, double)>;
+	using SolutionProcessor =
+	    std::function<void(const SolutionSequence::container_type&, const InterfaceState::Priority&)>;
 
 	/// Traverse all solution pathes starting at start and going in given direction dir
 	/// until the end, i.e. until there are no more subsolutions in the given direction
@@ -106,7 +107,7 @@ protected:
 	/// the full trace (from start to end, but not including start) and its accumulated costs
 	template <Interface::Direction dir>
 	void traverse(const SolutionBase& start, const SolutionProcessor& cb, SolutionSequence::container_type& trace,
-	              double trace_cost = 0);
+	              const InterfaceState::Priority& = InterfaceState::Priority());
 
 protected:
 	SerialContainer(SerialContainerPrivate* impl);

--- a/core/include/moveit/task_constructor/cost_terms.h
+++ b/core/include/moveit/task_constructor/cost_terms.h
@@ -68,6 +68,7 @@ public:
 class TrajectoryCostTerm : public CostTerm
 {
 public:
+	double operator()(const SolutionSequence& s, std::string& comment) const override;
 	double operator()(const WrappedSolution& s, std::string& comment) const override;
 };
 

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -227,20 +227,20 @@ public:
 	const ordered<SolutionBaseConstPtr>& solutions() const;
 	const std::list<SolutionBaseConstPtr>& failures() const;
 	size_t numFailures() const;
-	/// call to increase number of failures w/o storing a (failure) trajectory
+	/// Call to increase number of failures w/o storing a (failure) trajectory
 	void silentFailure();
-	/// should we generate failure solutions?
+	/// Should we generate failure solutions? Note: Always report a failure!
 	bool storeFailures() const;
 
-	/// get the stage's property map
+	/// Get the stage's property map
 	PropertyMap& properties();
 	const PropertyMap& properties() const { return const_cast<Stage*>(this)->properties(); }
-	/// set a previously declared property to a new value
+	/// Set a previously declared property to a new value
 	void setProperty(const std::string& name, const boost::any& value);
 	/// overload: const char* values are stored as std::string
 	inline void setProperty(const std::string& name, const char* value) { setProperty(name, std::string(value)); }
 
-	/// analyze source of error and report accordingly
+	/// Analyze source of error and report accordingly
 	[[noreturn]] void reportPropertyError(const Property::error& e);
 
 	double getTotalComputeTime() const;
@@ -373,9 +373,6 @@ protected:
 class ConnectingPrivate;
 class Connecting : public ComputeBase
 {
-protected:
-	virtual bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const;
-
 public:
 	PRIVATE_CLASS(Connecting)
 	Connecting(const std::string& name = "connecting");
@@ -385,6 +382,8 @@ public:
 	virtual void compute(const InterfaceState& from, const InterfaceState& to) = 0;
 
 protected:
+	virtual bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const;
+
 	/// register solution as a solution connecting states from -> to
 	void connect(const InterfaceState& from, const InterfaceState& to, const SolutionBasePtr& solution);
 

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -100,7 +100,7 @@ public:
 	inline InterfaceConstPtr prevEnds() const { return prev_ends_.lock(); }
 	inline InterfaceConstPtr nextStarts() const { return next_starts_.lock(); }
 
-	/// templated access to pull/push interfaces
+	/// direction-based access to pull/push interfaces
 	inline InterfacePtr& pullInterface(Interface::Direction dir) { return dir == Interface::FORWARD ? starts_ : ends_; }
 	inline InterfacePtr pushInterface(Interface::Direction dir) {
 		return dir == Interface::FORWARD ? next_starts_.lock() : prev_ends_.lock();

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -236,11 +236,6 @@ public:
 
 	bool hasEndState() const;
 	const InterfaceState& fetchEndState();
-
-protected:
-	// drop states corresponding to failed (infinite-cost) trajectories
-	void dropFailedStarts(Interface::iterator state);
-	void dropFailedEnds(Interface::iterator state);
 };
 PIMPL_FUNCTIONS(PropagatingEitherWay)
 

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -105,6 +105,7 @@ public:
 
 	/// copy an existing InterfaceState, but not including incoming/outgoing trajectories
 	InterfaceState(const InterfaceState& other);
+	InterfaceState(InterfaceState&& other) = default;
 
 	inline const planning_scene::PlanningSceneConstPtr& scene() const { return scene_; }
 	inline const Solutions& incomingTrajectories() const { return incoming_trajectories_; }

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -207,10 +207,6 @@ public:
 	inline const InterfaceState* start() const { return start_; }
 	inline const InterfaceState* end() const { return end_; }
 
-	/// Retrieve following (FORWARD) or preceding (BACKWARD) solution segments
-	template <Interface::Direction dir>
-	inline const InterfaceState::Solutions& trajectories() const;
-
 	/** set the solution's start_state_
 	 *
 	 * Must not be used with different states because it registers the solution with the state as well.
@@ -367,13 +363,28 @@ private:
 	const SolutionBase* wrapped_;
 };
 
+/// Trait to retrieve the end (FORWARD) or start (BACKWARD) state of a given solution
+template <Interface::Direction dir>
+const InterfaceState* state(const SolutionBase& solution);
 template <>
-inline const InterfaceState::Solutions& SolutionBase::trajectories<Interface::FORWARD>() const {
-	return end_->outgoingTrajectories();
+inline const InterfaceState* state<Interface::FORWARD>(const SolutionBase& solution) {
+	return solution.end();
 }
 template <>
-inline const InterfaceState::Solutions& SolutionBase::trajectories<Interface::BACKWARD>() const {
-	return start_->incomingTrajectories();
+inline const InterfaceState* state<Interface::BACKWARD>(const SolutionBase& solution) {
+	return solution.start();
+}
+
+/// Trait to retrieve outgoing (FORWARD) or incoming (BACKWARD) solution segments of a given state
+template <Interface::Direction dir>
+const InterfaceState::Solutions& trajectories(const InterfaceState* state);
+template <>
+inline const InterfaceState::Solutions& trajectories<Interface::FORWARD>(const InterfaceState* state) {
+	return state->outgoingTrajectories();
+}
+template <>
+inline const InterfaceState::Solutions& trajectories<Interface::BACKWARD>(const InterfaceState* state) {
+	return state->incomingTrajectories();
 }
 }  // namespace task_constructor
 }  // namespace moveit

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -83,7 +83,6 @@ public:
 	 */
 	struct Priority : public std::pair<unsigned int, double>
 	{
-		Priority() : Priority(0, 0.0) {}
 		Priority(unsigned int depth, double cost) : std::pair<unsigned int, double>(depth, cost) {}
 
 		inline unsigned int depth() const { return this->first; }

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -88,6 +88,7 @@ public:
 		inline unsigned int depth() const { return this->first; }
 		inline double cost() const { return this->second; }
 
+		// add priorities
 		Priority operator+(const Priority& other) const {
 			return Priority(this->depth() + other.depth(), this->cost() + other.cost());
 		}
@@ -144,20 +145,19 @@ public:
 	class iterator : public base_type::iterator
 	{
 	public:
+		using base_type::iterator::iterator;  // inherit base constructors
 		iterator(base_type::iterator other) : base_type::iterator(other) {}
 
 		InterfaceState& operator*() const noexcept { return *base_type::iterator::operator*(); }
-
 		InterfaceState* operator->() const noexcept { return base_type::iterator::operator*(); }
 	};
 	class const_iterator : public base_type::const_iterator
 	{
 	public:
+		using base_type::const_iterator::const_iterator;  // inherit base constructors
 		const_iterator(base_type::const_iterator other) : base_type::const_iterator(other) {}
-		const_iterator(base_type::iterator other) : base_type::const_iterator(other) {}
 
 		const InterfaceState& operator*() const noexcept { return *base_type::const_iterator::operator*(); }
-
 		const InterfaceState* operator->() const noexcept { return base_type::const_iterator::operator*(); }
 	};
 

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -120,8 +120,6 @@ void ContainerBasePrivate::copyState(Interface::iterator external, const Interfa
 
 void ContainerBasePrivate::liftSolution(const SolutionBasePtr& solution, const InterfaceState* internal_from,
                                         const InterfaceState* internal_to) {
-	solution->setCreator(me());
-
 	computeCost(*internal_from, *internal_to, *solution);
 
 	if (!storeSolution(solution))
@@ -143,8 +141,8 @@ void ContainerBasePrivate::liftSolution(const SolutionBasePtr& solution, const I
 	InterfaceState* external_to = find_or_create_external(internal_to, created_to);
 
 	// connect solution to start/end state
-	solution->setStartStateUnsafe(*external_from);
-	solution->setEndStateUnsafe(*external_to);
+	solution->setStartState(*external_from);
+	solution->setEndState(*external_to);
 
 	// spawn created states in external interfaces
 	if (created_from)

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -609,9 +609,8 @@ ParallelContainerBase::ParallelContainerBase(const std::string& name)
   : ParallelContainerBase(new ParallelContainerBasePrivate(this, name)) {}
 
 void ParallelContainerBase::liftSolution(const SolutionBase& solution, double cost, std::string comment) {
-	auto impl = pimpl();
-	impl->liftSolution(std::make_shared<WrappedSolution>(this, &solution, cost, std::move(comment)), solution.start(),
-	                   solution.end());
+	pimpl()->liftSolution(std::make_shared<WrappedSolution>(this, &solution, cost, std::move(comment)),
+	                      solution.start(), solution.end());
 }
 
 void ParallelContainerBase::spawn(InterfaceState&& state, SubTrajectory&& t) {

--- a/core/src/cost_terms.cpp
+++ b/core/src/cost_terms.cpp
@@ -53,7 +53,15 @@ double CostTerm::operator()(const SubTrajectory& s, std::string&) const {
 	return s.cost();
 }
 
-double CostTerm::operator()(const SolutionSequence& s, std::string& comment) const {
+double CostTerm::operator()(const SolutionSequence& s, std::string& /*comment*/) const {
+	return s.cost();
+}
+
+double CostTerm::operator()(const WrappedSolution& s, std::string& /*comment*/) const {
+	return s.cost();
+}
+
+double TrajectoryCostTerm::operator()(const SolutionSequence& s, std::string& comment) const {
 	double cost{ 0.0 };
 	std::string subcomment;
 	for (auto& solution : s.solutions()) {
@@ -67,10 +75,6 @@ double CostTerm::operator()(const SolutionSequence& s, std::string& comment) con
 	}
 
 	return cost;
-}
-
-double CostTerm::operator()(const WrappedSolution& s, std::string& /*comment*/) const {
-	return s.cost();
 }
 
 double TrajectoryCostTerm::operator()(const WrappedSolution& s, std::string& comment) const {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -681,12 +681,12 @@ InterfaceFlags ConnectingPrivate::requiredInterface() const {
 template <>
 ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::BACKWARD>(Interface::const_iterator first,
                                                                                Interface::const_iterator second) {
-	return std::make_pair(first, second);
+	return StatePair(first, second);
 }
 template <>
 ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(Interface::const_iterator first,
                                                                               Interface::const_iterator second) {
-	return std::make_pair(second, first);
+	return StatePair(second, first);
 }
 
 template <Interface::Direction other>

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -363,7 +363,7 @@ void Stage::setCostTerm(const CostTermConstPtr& term) {
 	if (!term)
 		pimpl()->cost_term_ = std::make_unique<CostTerm>();
 	else
-		pimpl()->cost_term_ = std::move(term);
+		pimpl()->cost_term_ = term;
 }
 
 const ordered<SolutionBaseConstPtr>& Stage::solutions() const {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -476,15 +476,14 @@ void PropagatingEitherWayPrivate::initInterface(PropagatingEitherWay::Direction 
 		case PropagatingEitherWay::FORWARD:
 			required_interface_ = PROPAGATE_FORWARDS;
 			if (!starts_)  // keep existing interface if possible
-				starts_.reset(
-				    new Interface([this](Interface::iterator it, bool /*updated*/) { this->dropFailedStarts(it); }));
+				starts_.reset(new Interface());
 			ends_.reset();
 			return;
 		case PropagatingEitherWay::BACKWARD:
 			required_interface_ = PROPAGATE_BACKWARDS;
 			starts_.reset();
 			if (!ends_)  // keep existing interface if possible
-				ends_.reset(new Interface([this](Interface::iterator it, bool /*updated*/) { this->dropFailedEnds(it); }));
+				ends_.reset(new Interface());
 			return;
 		case PropagatingEitherWay::AUTO:
 			required_interface_ = UNKNOWN;
@@ -517,15 +516,6 @@ void PropagatingEitherWayPrivate::resolveInterface(InterfaceFlags expected) {
 
 InterfaceFlags PropagatingEitherWayPrivate::requiredInterface() const {
 	return required_interface_;
-}
-
-void PropagatingEitherWayPrivate::dropFailedStarts(Interface::iterator state) {
-	if (std::isinf(state->priority().cost()))
-		starts_->remove(state);
-}
-void PropagatingEitherWayPrivate::dropFailedEnds(Interface::iterator state) {
-	if (std::isinf(state->priority().cost()))
-		ends_->remove(state);
 }
 
 inline bool PropagatingEitherWayPrivate::hasStartState() const {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -693,13 +693,8 @@ ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(In
 
 template <Interface::Direction other>
 void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
-	// TODO: only consider interface states with priority depth > threshold
-	if (!std::isfinite(it->priority().cost())) {
-		// remove pending pairs, if cost updated to infinity
-		if (updated)
-			pending.remove_if([it](const StatePair& p) { return p.first == it; });
+	if (!std::isfinite(it->priority().cost()))
 		return;
-	}
 	if (updated) {
 		// many pairs might be affected: sort
 		pending.sort();
@@ -722,6 +717,7 @@ void ConnectingPrivate::compute() {
 	const StatePair& top = pending.pop();
 	const InterfaceState& from = *top.first;
 	const InterfaceState& to = *top.second;
+	assert(std::isfinite((from.priority() + to.priority()).cost()));
 	static_cast<Connecting*>(me_)->compute(from, to);
 }
 

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -179,31 +179,34 @@ SolutionSequencePtr
 Connect::makeSequential(const std::vector<robot_trajectory::RobotTrajectoryConstPtr>& sub_trajectories,
                         const std::vector<planning_scene::PlanningSceneConstPtr>& intermediate_scenes,
                         const InterfaceState& from, const InterfaceState& to) {
+	assert(!sub_trajectories.empty());
 	assert(sub_trajectories.size() + 1 == intermediate_scenes.size());
-	auto scene_it = intermediate_scenes.begin();
-	planning_scene::PlanningSceneConstPtr start_ps = *scene_it;
-	const InterfaceState* state = &from;
 
+	/* We need to decouple the sequence of subsolutions, created here, from the external from and to states.
+	   Hence, we create new interface states for all subsolutions. */
+	const InterfaceState* start = &*states_.insert(states_.end(), InterfaceState(from.scene()));
+
+	auto scene_it = intermediate_scenes.begin();
 	SolutionSequence::container_type sub_solutions;
 	for (const auto& sub : sub_trajectories) {
-		planning_scene::PlanningSceneConstPtr end_ps = *++scene_it;
-
+		// persistently store sub solution
 		auto inserted = subsolutions_.insert(subsolutions_.end(), SubTrajectory(sub));
 		inserted->setCreator(this);
+		if (!sub)  // a null RobotTrajectoryPtr indicates a failure
+			inserted->markAsFailure();
 		// push back solution pointer
 		sub_solutions.push_back(&*inserted);
 
-		// provide meaningful start/end states
-		subsolutions_.back().setStartState(*state);
+		// create a new end state, either from intermediate or final planning scene
+		planning_scene::PlanningSceneConstPtr end_ps =
+		    (sub_solutions.size() < sub_trajectories.size()) ? *++scene_it : to.scene();
+		const InterfaceState* end = &*states_.insert(states_.end(), InterfaceState(end_ps));
 
-		// for all but last scene, create a new state
-		if (sub_solutions.size() < sub_trajectories.size()) {
-			state = &*states_.insert(states_.end(), InterfaceState(end_ps));
-			subsolutions_.back().setEndState(*state);
-		} else
-			subsolutions_.back().setEndState(to);
+		// provide newly created start/end states
+		subsolutions_.back().setStartState(*start);
+		subsolutions_.back().setEndState(*end);
 
-		start_ps = end_ps;
+		start = end;  // end state becomes next start state
 	}
 
 	return std::make_shared<SolutionSequence>(std::move(sub_solutions));

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -46,16 +46,17 @@
 namespace moveit {
 namespace task_constructor {
 
-const planning_scene::PlanningScenePtr& ensureUpdated(const planning_scene::PlanningScenePtr& scene) {
+planning_scene::PlanningSceneConstPtr ensureUpdated(const planning_scene::PlanningScenePtr& scene) {
 	// ensure scene's state is updated
 	if (scene->getCurrentState().dirty())
 		scene->getCurrentStateNonConst().update();
 	return scene;
 }
 
-InterfaceState::InterfaceState(const planning_scene::PlanningScenePtr& ps) : scene_(ensureUpdated(ps)) {}
+InterfaceState::InterfaceState(const planning_scene::PlanningScenePtr& ps) : InterfaceState(ensureUpdated(ps)) {}
 
-InterfaceState::InterfaceState(const planning_scene::PlanningSceneConstPtr& ps) : scene_(ps) {
+InterfaceState::InterfaceState(const planning_scene::PlanningSceneConstPtr& ps)
+  : scene_(ps), priority_(Priority(0, 0.0)) {
 	if (scene_->getCurrentState().dirty())
 		ROS_ERROR_NAMED("InterfaceState", "Dirty PlanningScene! Please only forward clean ones into InterfaceState.");
 }

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -125,7 +125,7 @@ Interface::container_type Interface::remove(iterator it) {
 }
 
 void Interface::updatePriority(InterfaceState* state, const InterfaceState::Priority& priority) {
-	if (priority != state->priority()) {
+	if (priority < state->priority()) {  // only allow decreasing of priority (smaller is better)
 		auto it = std::find(begin(), end(), state);  // find iterator to state
 		assert(it != end());  // state should be part of this interface
 		state->priority_ = priority;  // update priority

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -141,16 +141,6 @@ void SolutionBase::setCreator(Stage* creator) {
 	creator_ = creator;
 }
 
-void SolutionBase::setStartStateUnsafe(const InterfaceState& state) {
-	start_ = &state;
-	const_cast<InterfaceState&>(state).addOutgoing(this);
-}
-
-void SolutionBase::setEndStateUnsafe(const InterfaceState& state) {
-	end_ = &state;
-	const_cast<InterfaceState&>(state).addIncoming(this);
-}
-
 void SolutionBase::setCost(double cost) {
 	cost_ = cost;
 }

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -126,10 +126,9 @@ Interface::container_type Interface::remove(iterator it) {
 
 void Interface::updatePriority(InterfaceState* state, const InterfaceState::Priority& priority) {
 	if (priority != state->priority()) {
-		auto it = std::find_if(begin(), end(), [state](const InterfaceState* other) { return state == other; });
-		// state should be part of the interface
-		assert(it != end());
-		state->priority_ = priority;
+		auto it = std::find(begin(), end(), state);  // find iterator to state
+		assert(it != end());  // state should be part of this interface
+		state->priority_ = priority;  // update priority
 		update(it);
 		if (notify_)
 			notify_(it, true);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -15,6 +15,9 @@ if (CATKIN_ENABLE_TESTING)
 	catkin_add_gtest(${PROJECT_NAME}-test-container test_container.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-container ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
 
+	catkin_add_gtest(${PROJECT_NAME}-test-serial test_serial.cpp)
+	target_link_libraries(${PROJECT_NAME}-test-serial ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_main)
+
 	catkin_add_gtest(${PROJECT_NAME}-test-properties test_properties.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-properties ${PROJECT_NAME} gtest_main)
 

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -669,11 +669,13 @@ TEST_F(ParallelTest, init_any) {
 }
 
 TEST(Task, move) {
+	MOCK_ID = 0;
 	Task t1("foo");
 	t1.add(std::make_unique<GeneratorMockup>());
 	t1.add(std::make_unique<GeneratorMockup>());
 	EXPECT_EQ(t1.stages()->numChildren(), 2u);
 
+	MOCK_ID = 0;
 	Task t2 = std::move(t1);
 	EXPECT_EQ(t2.stages()->numChildren(), 2u);
 	EXPECT_EQ(t1.stages()->numChildren(), 0u);
@@ -694,6 +696,7 @@ TEST(Task, reuse) {
 	t.setRobotModel(robot_model);
 
 	auto configure = [](Task& t) {
+		MOCK_ID = 0;
 		auto ref = new stages::FixedState("fixed");
 		auto scene = std::make_shared<planning_scene::PlanningScene>(t.getRobotModel());
 		ref->setState(scene);
@@ -721,6 +724,7 @@ TEST(Task, reuse) {
 }
 
 TEST(Task, timeout) {
+	MOCK_ID = 0;
 	// create dummy robot model
 	moveit::core::RobotModelBuilder builder("robot", "base");
 	builder.addChain("base->a->b->c", "continuous");

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -1,6 +1,13 @@
-#include <list>
 #include <moveit/task_constructor/storage.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <memory>
+#include <algorithm>
+#include <iterator>
+#include <vector>
 #include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
 
 using namespace moveit::task_constructor;
 TEST(InterfaceStatePriority, compare) {
@@ -16,4 +23,46 @@ TEST(InterfaceStatePriority, compare) {
 	EXPECT_TRUE(Prio(0, 0) < Prio(0, 1));  // higher cost is larger
 	EXPECT_TRUE(Prio(0, 0) < Prio(0, inf));
 	EXPECT_TRUE(Prio(0, inf) > Prio(0, 0));
+}
+
+moveit::core::RobotModelConstPtr getModel() {
+	ros::console::set_logger_level("ros.moveit_core.robot_model", ros::console::levels::Error);
+	moveit::core::RobotModelBuilder builder("robot", "base");
+	builder.addChain("base->tip", "continuous");
+	return builder.build();
+}
+
+using Prio = InterfaceState::Priority;
+
+// Interface that also stores passed states
+class StoringInterface : public Interface
+{
+	std::vector<std::unique_ptr<InterfaceState>> storage_;
+
+public:
+	using Interface::Interface;
+	void add(InterfaceState&& state) {
+		storage_.emplace_back(std::make_unique<InterfaceState>(std::move(state)));
+		Interface::add(*storage_.back());
+	}
+	std::vector<unsigned int> depths() const {
+		std::vector<unsigned int> result;
+		std::transform(cbegin(), cend(), std::back_inserter(result),
+		               [](const InterfaceState* state) { return state->priority().depth(); });
+		return result;
+	}
+};
+
+TEST(Interface, update) {
+	auto ps = std::make_shared<planning_scene::PlanningScene>(getModel());
+	StoringInterface i;
+	i.add(InterfaceState(ps, Prio(1, 0.0)));
+	i.add(InterfaceState(ps, Prio(3, 0.0)));
+	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 1 }));
+
+	i.updatePriority(*i.rbegin(), Prio(5, 0.0));
+	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
+
+	i.updatePriority(*i.begin(), Prio(1, 0.0));
+	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 1 }));
 }

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -12,16 +12,19 @@
 using namespace moveit::task_constructor;
 TEST(InterfaceStatePriority, compare) {
 	using Prio = InterfaceState::Priority;
-	const double inf = std::numeric_limits<double>::infinity();
+	constexpr double inf = std::numeric_limits<double>::infinity();
 
 	EXPECT_TRUE(Prio(0, 0) == Prio(0, 0));
 	EXPECT_TRUE(Prio(0, inf) == Prio(0, inf));
 
 	EXPECT_TRUE(Prio(1, 0) < Prio(0, 0));  // higher depth is smaller
+	EXPECT_TRUE(Prio(1, 42) < Prio(0, 0));
+	EXPECT_TRUE(Prio(1, inf) > Prio(0, 0));  // infinite costs are always largest
 	EXPECT_TRUE(Prio(1, inf) < Prio(0, inf));
 
-	EXPECT_TRUE(Prio(0, 0) < Prio(0, 1));  // higher cost is larger
+	EXPECT_TRUE(Prio(0, 0) < Prio(0, 42));  // higher cost is larger
 	EXPECT_TRUE(Prio(0, 0) < Prio(0, inf));
+	EXPECT_TRUE(Prio(0, 42) > Prio(0, 0));
 	EXPECT_TRUE(Prio(0, inf) > Prio(0, 0));
 }
 
@@ -63,6 +66,6 @@ TEST(Interface, update) {
 	i.updatePriority(*i.rbegin(), Prio(5, 0.0));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
 
-	i.updatePriority(*i.begin(), Prio(1, 0.0));
-	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 1 }));
+	i.updatePriority(*i.begin(), Prio(6, std::numeric_limits<double>::infinity()));
+	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));  // larger priority is ignored
 }

--- a/core/test/test_serial.cpp
+++ b/core/test/test_serial.cpp
@@ -1,0 +1,159 @@
+#include <moveit/task_constructor/task.h>
+#include <moveit/task_constructor/stages.h>
+#include <moveit/task_constructor/cost_terms.h>
+#include <moveit/task_constructor/solvers/joint_interpolation.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/utils/robot_model_test_utils.h>
+
+#include <list>
+#include <memory>
+#include <gtest/gtest.h>
+
+using namespace moveit::task_constructor;
+using namespace planning_scene;
+
+MOVEIT_STRUCT_FORWARD(PredefinedCosts);
+struct PredefinedCosts : CostTerm
+{
+	mutable std::list<double> costs_;  // list of costs to assign
+	mutable double cost_ = 0.0;  // last assigned cost
+	bool finite_;  // finite number of compute() attempts?
+
+	PredefinedCosts(bool finite, std::list<double>&& costs) : costs_(std::move(costs)), finite_(finite) {}
+	bool exhausted() const { return finite_ && costs_.empty(); }
+	double cost() const {
+		if (!costs_.empty()) {
+			cost_ = costs_.front();
+			costs_.pop_front();
+		}
+		return cost_;
+	}
+
+	double operator()(const SubTrajectory& s, std::string& comment) const override { return cost(); }
+	double operator()(const SolutionSequence& s, std::string& comment) const override { return cost(); }
+	double operator()(const WrappedSolution& s, std::string& comment) const override { return cost(); }
+};
+
+/** Generator creating solutions with given costs */
+struct GeneratorMockup : Generator
+{
+	PlanningScenePtr ps_;
+	PredefinedCosts costs_;
+	static unsigned int id_;
+
+	GeneratorMockup(std::initializer_list<double> costs = { 0.0 })
+	  : Generator("GEN" + std::to_string(++id_)), costs_(true, costs) {}
+
+	void init(const moveit::core::RobotModelConstPtr& robot_model) override {
+		ps_.reset(new PlanningScene(robot_model));
+		Generator::init(robot_model);
+	}
+
+	bool canCompute() const override { return !costs_.exhausted(); }
+	void compute() override { spawn(InterfaceState(ps_), costs_.cost()); }
+};
+
+/* Forward propagator, contributing no solutions at all */
+struct ForwardDummy : PropagatingForward
+{
+	using PropagatingForward::PropagatingForward;
+	void computeForward(const InterfaceState& from) override {}
+};
+
+/* Connect creating solutions with given costs */
+struct Connect : stages::Connect
+{
+	PlanningScenePtr ps_;
+	PredefinedCostsPtr costs_;
+	unsigned int calls_ = 0;
+	static unsigned int id_;
+
+	static GroupPlannerVector getPlanners() {
+		auto planner = std::make_shared<solvers::JointInterpolationPlanner>();
+		return { { "group1", planner }, { "group2", planner } };
+	}
+
+	Connect(std::initializer_list<double> costs = {}, bool enforce_sequential = false)
+	  : stages::Connect("CON" + std::to_string(++id_), getPlanners()) {
+		costs_ = std::make_shared<PredefinedCosts>(false, costs);
+		setCostTerm(costs_);
+		if (enforce_sequential)
+			setProperty("merge_mode", SEQUENTIAL);
+	}
+	void compute(const InterfaceState& from, const InterfaceState& to) override {
+		++calls_;
+		stages::Connect::compute(from, to);
+	}
+};
+
+constexpr double inf = std::numeric_limits<double>::infinity();
+unsigned int GeneratorMockup::id_ = 0;
+unsigned int Connect::id_ = 0;
+
+moveit::core::RobotModelConstPtr getModel() {
+	ros::console::set_logger_level("ros.moveit_core.robot_model", ros::console::levels::Error);
+	moveit::core::RobotModelBuilder builder("robot", "base");
+	builder.addChain("base->a->b->c", "continuous");
+	builder.addGroupChain("base", "b", "group1");
+	builder.addGroupChain("b", "c", "group2");
+	return builder.build();
+}
+
+// https://github.com/ros-planning/moveit_task_constructor/issues/182
+TEST(ConnectConnect, SuccSucc) {
+	GeneratorMockup::id_ = Connect::id_ = 0;  // reset IDs
+	Task t;
+	t.setRobotModel(getModel());
+	t.add(Stage::pointer(new GeneratorMockup({ 1, 2, 3 })));
+	t.add(Stage::pointer(new Connect()));
+	t.add(Stage::pointer(new GeneratorMockup({ 10, 20 })));
+	t.add(Stage::pointer(new Connect()));
+	t.add(Stage::pointer(new GeneratorMockup()));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 3u * 2u);
+	std::vector<double> expected_costs = { 11, 12, 13, 21, 22, 23 };
+	auto expected_cost = expected_costs.begin();
+	for (const auto& s : t.solutions()) {
+		EXPECT_EQ(s->cost(), *expected_cost);
+		++expected_cost;
+	}
+}
+
+TEST(ConnectConnect, Pruning) {
+	GeneratorMockup::id_ = Connect::id_ = 0;  // reset IDs
+	Task t;
+	t.setRobotModel(getModel());
+	Connect *c1, *c2;
+	t.add(Stage::pointer(new GeneratorMockup({ 1, 2, 3 })));
+	t.add(Stage::pointer(c1 = new Connect()));
+	t.add(Stage::pointer(new GeneratorMockup({ 0, inf, 10, 20 })));  // 2nd is a dummy to postpone creation of 3rd
+	t.add(Stage::pointer(c2 = new Connect({ inf, 0 })));  // 1st attempt is a failure
+	t.add(Stage::pointer(new GeneratorMockup()));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 3u * 2u);
+	std::vector<double> expected_costs = { 11, 12, 13, 21, 22, 23 };
+	auto expected_cost = expected_costs.begin();
+	for (const auto& s : t.solutions()) {
+		EXPECT_EQ(s->cost(), *expected_cost);
+		++expected_cost;
+	}
+	EXPECT_EQ(c2->calls_, 3u);
+	// EXPECT_EQ(c1->calls_, 6u);  // TODO: avoid compute() calls on failure of remaining part
+}
+
+// https://github.com/ros-planning/moveit_task_constructor/issues/218
+TEST(ConnectConnect, FailSucc) {
+	GeneratorMockup::id_ = Connect::id_ = 0;  // reset IDs
+	Task t;
+	t.setRobotModel(getModel());
+	t.add(Stage::pointer(new GeneratorMockup()));
+	t.add(Stage::pointer(new Connect({ inf }, true)));
+	t.add(Stage::pointer(new GeneratorMockup()));
+	t.add(Stage::pointer(new Connect()));
+	t.add(Stage::pointer(new GeneratorMockup()));
+	t.add(Stage::pointer(new ForwardDummy()));
+
+	EXPECT_FALSE(t.plan());
+}

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(moveit_task_constructor_demo)
 
 add_compile_options(-std=c++14)

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(moveit_task_constructor_msgs)
 
 set(MSG_DEPS moveit_msgs visualization_msgs)

--- a/rviz_marker_tools/CMakeLists.txt
+++ b/rviz_marker_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(rviz_marker_tools)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -20,11 +20,7 @@ catkin_package(
 		rviz
 )
 
-if ("${CMAKE_VERSION}" VERSION_LESS "3.1")
-	add_compile_options(-std=c++14)
-else ()
-	set(CMAKE_CXX_STANDARD 14)
-endif ()
+set(CMAKE_CXX_STANDARD 14)
 
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME})
 

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1.3)
 project(moveit_task_constructor_visualization)
 
 find_package(catkin REQUIRED COMPONENTS
@@ -46,11 +46,7 @@ catkin_package(
 		rviz
 )
 
-if ("${CMAKE_VERSION}" VERSION_LESS "3.1")
-	add_compile_options(-std=c++14)
-else ()
-	set(CMAKE_CXX_STANDARD 14)
-endif ()
+set(CMAKE_CXX_STANDARD 14)
 
 add_subdirectory(visualization_tools)
 add_subdirectory(motion_planning_tasks)


### PR DESCRIPTION
Fixes #218. Fixes #182.
The `SerialContainer` was accepting solution sequences comprising a failure-only `Connect` stage, because the `Connect` stage didn't correctly mark its sequentialized subsolutions as a failure (but only the overall sequence). @JafarAbdi, please validate that this solves your issue.