### PR TITLE
Rework Pruning

### DIFF
--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -77,6 +77,8 @@ public:
 
 	/// called by a (direct) child when a new solution becomes available
 	virtual void onNewSolution(const SolutionBase& s) = 0;
+	/// called by a (direct) child when a solution failed
+	virtual void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) = 0;
 
 protected:
 	ContainerBase(ContainerBasePrivate* impl);
@@ -95,8 +97,8 @@ public:
 	void compute() override;
 
 protected:
-	/// called by a (direct) child when a new solution becomes available
 	void onNewSolution(const SolutionBase& s) override;
+	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
 
 protected:
 	SerialContainer(SerialContainerPrivate* impl);
@@ -116,6 +118,7 @@ class ParallelContainerBase : public ContainerBase
 public:
 	PRIVATE_CLASS(ParallelContainerBase)
 	ParallelContainerBase(const std::string& name = "parallel container");
+	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
 
 protected:
 	ParallelContainerBase(ParallelContainerBasePrivate* impl);

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -324,6 +324,10 @@ public:
 	bool canCompute() const override;
 	void compute() override;
 
+	// Check whether there are pending feasible states that could connect to source
+	template <Interface::Direction dir>
+	bool hasPendingOpposites(const InterfaceState* source) const;
+
 private:
 	// Create a pair of Interface states for pending list, such that the order (start, end) is maintained
 	template <Interface::Direction other>

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -144,7 +144,7 @@ public:
 	void spawn(InterfaceState&& state, const SolutionBasePtr& solution);
 	void connect(const InterfaceState& from, const InterfaceState& to, const SolutionBasePtr& solution);
 
-	bool storeSolution(const SolutionBasePtr& solution);
+	bool storeSolution(const SolutionBasePtr& solution, const InterfaceState* from, const InterfaceState* to);
 	void newSolution(const SolutionBasePtr& solution);
 	bool storeFailures() const { return introspection_ != nullptr; }
 	void runCompute() {

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -157,6 +157,10 @@ public:
 	/** compute cost for solution through configured CostTerm */
 	void computeCost(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 
+	/// Set ENABLED / DISABLED status of the solution tree starting from s into given direction
+	template <Interface::Direction dir>
+	static void setStatus(const InterfaceState* s, InterfaceState::Status status);
+
 protected:
 	// associated/owning Stage instance
 	Stage* me_;

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -328,6 +328,8 @@ public:
 	template <Interface::Direction dir>
 	bool hasPendingOpposites(const InterfaceState* source) const;
 
+	std::ostream& printPendingPairs(std::ostream& os = std::cerr) const;
+
 private:
 	// Create a pair of Interface states for pending list, such that the order (start, end) is maintained
 	template <Interface::Direction other>

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -79,9 +79,9 @@ class InterfaceState
 public:
 	enum Status
 	{
-		ENABLED,
-		DISABLED_START,  // state that was the root cause for disabling due to failure
-		DISABLED_END  // state on the other end of a disabled solution sequence
+		ENABLED,  // state is actively considered during planning
+		DISABLED,  // state is disabled because a required connected state failed
+		DISABLED_FAILED,  // state that failed, causing the whole partial solution to be disabled
 	};
 	/** InterfaceStates are ordered according to two values:
 	 *  Depth of interlinked trajectory parts and accumulated trajectory costs along that path.

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -390,6 +390,18 @@ template <>
 inline const InterfaceState::Solutions& trajectories<Interface::BACKWARD>(const InterfaceState* state) {
 	return state->incomingTrajectories();
 }
+
+/// Trait to retrieve opposite direction (FORWARD <-> BACKWARD)
+template <Interface::Direction dir>
+constexpr Interface::Direction opposite();
+template <>
+inline constexpr Interface::Direction opposite<Interface::FORWARD>() {
+	return Interface::BACKWARD;
+}
+template <>
+inline constexpr Interface::Direction opposite<Interface::BACKWARD>() {
+	return Interface::FORWARD;
+}
 }  // namespace task_constructor
 }  // namespace moveit
 

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -205,6 +205,9 @@ private:
 	using base_type::remove_if;
 };
 
+std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio);
+std::ostream& operator<<(std::ostream& os, const Interface& interface);
+
 class CostTerm;
 class StagePrivate;
 class ContainerBasePrivate;

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -76,6 +76,8 @@ class InterfaceState
 {
 	friend class SolutionBase;  // addIncoming() / addOutgoing() should be called only by SolutionBase
 	friend class Interface;  // allow Interface to set owner_ and priority_
+	friend class StagePrivate;
+
 public:
 	enum Status
 	{

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -157,19 +157,20 @@ public:
 	class iterator : public base_type::iterator
 	{
 	public:
-		using base_type::iterator::iterator;  // inherit base constructors
 		iterator(base_type::iterator other) : base_type::iterator(other) {}
 
 		InterfaceState& operator*() const noexcept { return *base_type::iterator::operator*(); }
+
 		InterfaceState* operator->() const noexcept { return base_type::iterator::operator*(); }
 	};
 	class const_iterator : public base_type::const_iterator
 	{
 	public:
-		using base_type::const_iterator::const_iterator;  // inherit base constructors
 		const_iterator(base_type::const_iterator other) : base_type::const_iterator(other) {}
+		const_iterator(base_type::iterator other) : base_type::const_iterator(other) {}
 
 		const InterfaceState& operator*() const noexcept { return *base_type::const_iterator::operator*(); }
+
 		const InterfaceState* operator->() const noexcept { return base_type::const_iterator::operator*(); }
 	};
 

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -391,14 +391,14 @@ inline const InterfaceState* state<Interface::BACKWARD>(const SolutionBase& solu
 
 /// Trait to retrieve outgoing (FORWARD) or incoming (BACKWARD) solution segments of a given state
 template <Interface::Direction dir>
-const InterfaceState::Solutions& trajectories(const InterfaceState* state);
+const InterfaceState::Solutions& trajectories(const InterfaceState& state);
 template <>
-inline const InterfaceState::Solutions& trajectories<Interface::FORWARD>(const InterfaceState* state) {
-	return state->outgoingTrajectories();
+inline const InterfaceState::Solutions& trajectories<Interface::FORWARD>(const InterfaceState& state) {
+	return state.outgoingTrajectories();
 }
 template <>
-inline const InterfaceState::Solutions& trajectories<Interface::BACKWARD>(const InterfaceState* state) {
-	return state->incomingTrajectories();
+inline const InterfaceState::Solutions& trajectories<Interface::BACKWARD>(const InterfaceState& state) {
+	return state.incomingTrajectories();
 }
 
 /// Trait to retrieve opposite direction (FORWARD <-> BACKWARD)

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -298,7 +298,7 @@ struct SolutionCollector
 			solutions.emplace_back(std::make_pair(trace, prio));
 		} else {
 			for (SolutionBase* successor : next) {
-				if (successor->isFailure())
+				if (successor->isFailure())  // skip failure "solutions"
 					continue;
 
 				trace.push_back(successor);
@@ -345,7 +345,7 @@ void SerialContainer::onNewSolution(const SolutionBase& current) {
 			InterfaceState::Priority prio = in.second + InterfaceState::Priority(1u, current.cost()) + out.second;
 			// found a complete solution path connecting start to end?
 			if (prio.depth() == children.size()) {
-				assert(std::isfinite(prio.cost()));
+				assert(prio.enabled());
 				assert(solution.empty());
 				// insert incoming solutions in reverse order
 				solution.insert(solution.end(), in.first.rbegin(), in.first.rend());

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -317,7 +317,7 @@ struct SolutionCollector
 	}
 
 	void traverse(const SolutionBase& start, const InterfaceState::Priority& prio) {
-		const InterfaceState::Solutions& next = trajectories<dir>(state<dir>(start));
+		const InterfaceState::Solutions& next = trajectories<dir>(*state<dir>(start));
 		if (next.empty()) {  // when reaching the end, add the trace to solutions
 			assert(prio.depth() == trace.size());
 			assert(prio.depth() <= max_depth);

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -399,7 +399,6 @@ void SerialContainer::onNewSolution(const SolutionBase& current) {
 			}
 		}
 	}
-	printChildrenInterfaces(*this, true, *current.creator());
 
 	// finally, store + announce new solutions to external interface
 	for (const auto& solution : sorted)
@@ -429,7 +428,6 @@ void SerialContainer::onNewFailure(const Stage& child, const InterfaceState* fro
 			}
 			break;
 	}
-	printChildrenInterfaces(*this, false, child);
 }
 
 SerialContainer::SerialContainer(SerialContainerPrivate* impl) : ContainerBase(impl) {}

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -353,7 +353,13 @@ inline void updateStatePrios(const SolutionSequence::container_type& partial_sol
 }
 
 void SerialContainer::onNewSolution(const SolutionBase& current) {
+	// failures should never trigger this callback
 	assert(!current.isFailure());
+
+	// states of solution must be active, otherwise this would not have been computed
+	assert(current.start()->priority().enabled());
+	assert(current.end()->priority().enabled());
+
 	auto impl = pimpl();
 	const Stage* creator = current.creator();
 	auto& children = impl->children();

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -295,9 +295,9 @@ static void printChildrenInterfaces(const ContainerBase& container, bool success
 
 	for (const auto& child : container.pimpl()->children()) {
 		auto cimpl = child->pimpl();
-		if (!cimpl->starts() && !cimpl->ends())
-			continue;  // skip generator
 		os << std::setw(width) << std::left << child->name();
+		if (!cimpl->starts() && !cimpl->ends())
+			os << "↕ " << std::endl;
 		if (cimpl->starts())
 			os << "↓ " << *child->pimpl()->starts() << std::endl;
 		if (cimpl->starts() && cimpl->ends())
@@ -399,6 +399,7 @@ void SerialContainer::onNewSolution(const SolutionBase& current) {
 			}
 		}
 	}
+	// printChildrenInterfaces(*this, true, *current.creator());
 
 	// finally, store + announce new solutions to external interface
 	for (const auto& solution : sorted)
@@ -429,6 +430,7 @@ void SerialContainer::onNewFailure(const Stage& child, const InterfaceState* fro
 			}
 			break;
 	}
+	// printChildrenInterfaces(*this, false, child);
 }
 
 SerialContainer::SerialContainer(SerialContainerPrivate* impl) : ContainerBase(impl) {}

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -408,23 +408,24 @@ void SerialContainer::onNewSolution(const SolutionBase& current) {
 void SerialContainer::onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) {
 	switch (child.pimpl()->interfaceFlags()) {
 		case GENERATE:
-			break;  // just ignore: the pair of (new) states isn't known to us anyway
+			// just ignore: the pair of (new) states isn't known to us anyway
 			// TODO: If child is a container, from and to might have associated solutions already!
-
-		case PROPAGATE_FORWARDS:  // mark from as dead (backwards)
-			StagePrivate::setStatus<Interface::BACKWARD>(from, InterfaceState::Status::DISABLED_START);
 			break;
-		case PROPAGATE_BACKWARDS:  // mark to as dead (forwards)
-			StagePrivate::setStatus<Interface::FORWARD>(to, InterfaceState::Status::DISABLED_START);
+
+		case PROPAGATE_FORWARDS:  // mark from as failed (backwards)
+			StagePrivate::setStatus<Interface::BACKWARD>(from, InterfaceState::Status::DISABLED_FAILED);
+			break;
+		case PROPAGATE_BACKWARDS:  // mark to as failed (forwards)
+			StagePrivate::setStatus<Interface::FORWARD>(to, InterfaceState::Status::DISABLED_FAILED);
 			break;
 
 		case CONNECT:
 			if (const Connecting* conn = dynamic_cast<const Connecting*>(&child)) {
 				auto cimpl = conn->pimpl();
 				if (!cimpl->hasPendingOpposites<Interface::FORWARD>(from))
-					StagePrivate::setStatus<Interface::BACKWARD>(from, InterfaceState::Status::DISABLED_START);
+					StagePrivate::setStatus<Interface::BACKWARD>(from, InterfaceState::Status::DISABLED_FAILED);
 				if (!cimpl->hasPendingOpposites<Interface::BACKWARD>(to))
-					StagePrivate::setStatus<Interface::FORWARD>(to, InterfaceState::Status::DISABLED_START);
+					StagePrivate::setStatus<Interface::FORWARD>(to, InterfaceState::Status::DISABLED_FAILED);
 			}
 			break;
 	}

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -761,6 +761,9 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 			}
 		}
 	}
+	// std::cerr << name_ << ": ";
+	// printPendingPairs(std::cerr);
+	// std::cerr << std::endl;
 }
 
 // Check whether there are pending feasible states that could connect to source.

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -562,7 +562,7 @@ InterfaceFlags PropagatingEitherWayPrivate::requiredInterface() const {
 }
 
 inline bool PropagatingEitherWayPrivate::hasStartState() const {
-	return starts_ && !starts_->empty();
+	return starts_ && !starts_->empty() && starts_->front()->priority().enabled();
 }
 
 const InterfaceState& PropagatingEitherWayPrivate::fetchStartState() {
@@ -571,7 +571,7 @@ const InterfaceState& PropagatingEitherWayPrivate::fetchStartState() {
 }
 
 inline bool PropagatingEitherWayPrivate::hasEndState() const {
-	return ends_ && !ends_->empty();
+	return ends_ && !ends_->empty() && ends_->front()->priority().enabled();
 }
 
 const InterfaceState& PropagatingEitherWayPrivate::fetchEndState() {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -747,8 +747,6 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 			}
 		}
 	}
-	std::cerr << name_ << ": ";
-	printPendingPairs(std::cerr);
 }
 
 // Check whether there are pending feasible states that could connect to source.

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -720,6 +720,8 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 			}
 		}
 	}
+	std::cerr << name_ << ": ";
+	printPendingPairs(std::cerr);
 }
 
 // Check whether there are pending feasible states that could connect to source.
@@ -757,6 +759,28 @@ void ConnectingPrivate::compute() {
 	const InterfaceState& to = *top.second;
 	assert(from.priority().enabled() && to.priority().enabled());
 	static_cast<Connecting*>(me_)->compute(from, to);
+}
+
+std::ostream& ConnectingPrivate::printPendingPairs(std::ostream& os) const {
+	static const char* red = "\033[31m";
+	static const char* reset = "\033[m";
+	for (const auto& candidate : pending) {
+		if (!candidate.first->priority().enabled() || !candidate.second->priority().enabled())
+			os << " " << red;
+		// find indeces of InterfaceState pointers in start/end Interfaces
+		unsigned int first = 0, second = 0;
+		std::find_if(starts()->begin(), starts()->end(), [&](const InterfaceState* s) {
+			++first;
+			return &*candidate.first == s;
+		});
+		std::find_if(ends()->begin(), ends()->end(), [&](const InterfaceState* s) {
+			++second;
+			return &*candidate.second == s;
+		});
+		os << first << ":" << second << " ";
+	}
+	os << reset;
+	return os;
 }
 
 Connecting::Connecting(const std::string& name) : ComputeBase(new ConnectingPrivate(this, name)) {}

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -701,16 +701,12 @@ ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(In
 
 template <Interface::Direction other>
 void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
-	if (!std::isfinite(it->priority().cost()))
-		return;
 	if (updated) {
 		// many pairs might be affected: sort
 		pending.sort();
 	} else {  // new state: insert all pairs with other interface
 		InterfacePtr other_interface = pullInterface(other);
 		for (Interface::iterator oit = other_interface->begin(), oend = other_interface->end(); oit != oend; ++oit) {
-			if (!std::isfinite(oit->priority().cost()))
-				break;
 			if (static_cast<Connecting*>(me_)->compatible(*it, *oit))
 				pending.insert(make_pair<other>(it, oit));
 		}
@@ -725,7 +721,7 @@ void ConnectingPrivate::compute() {
 	const StatePair& top = pending.pop();
 	const InterfaceState& from = *top.first;
 	const InterfaceState& to = *top.second;
-	assert(std::isfinite((from.priority() + to.priority()).cost()));
+	assert(from.priority().enabled() && to.priority().enabled());
 	static_cast<Connecting*>(me_)->compute(from, to);
 }
 

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -166,7 +166,7 @@ void StagePrivate::setStatus(const InterfaceState* s, InterfaceState::Status sta
 		status = InterfaceState::DISABLED;  // only the first state is marked as FAILED
 
 	// traverse solution tree
-	for (const SolutionBase* successor : trajectories<dir>(s))
+	for (const SolutionBase* successor : trajectories<dir>(*s))
 		setStatus<dir>(state<dir>(*successor), status);
 }
 template void StagePrivate::setStatus<Interface::FORWARD>(const InterfaceState* s, InterfaceState::Status status);

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -81,10 +81,6 @@ bool InterfaceState::Priority::operator<(const InterfaceState::Priority& other) 
 		return depth() > other.depth();  // larger depth = smaller prio!
 }
 
-std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& p) {
-	return os << "[depth: " << p.depth() << ", cost: " << p.cost() << "]";
-}
-
 Interface::Interface(const Interface::NotifyFunction& notify) : notify_(notify) {}
 
 // Announce a new InterfaceState
@@ -136,6 +132,21 @@ void Interface::updatePriority(InterfaceState* state, const InterfaceState::Prio
 	update(it);  // update position in ordered list
 	if (notify_)
 		notify_(it, true);  // notify callback
+}
+
+std::ostream& operator<<(std::ostream& os, const Interface& interface) {
+	if (interface.empty())
+		os << "---";
+	for (const auto& istate : interface)
+		os << istate->priority() << "  ";
+	return os;
+}
+std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio) {
+	static const char* red = "\033[31m";
+	static const char* green = "\033[32m";
+	static const char* color_reset = "\033[m";
+	os << (prio.enabled() ? green : red) << prio.depth() << ":" << prio.cost() << color_reset;
+	return os;
 }
 
 void SolutionBase::setCreator(Stage* creator) {

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -127,14 +127,15 @@ Interface::container_type Interface::remove(iterator it) {
 }
 
 void Interface::updatePriority(InterfaceState* state, const InterfaceState::Priority& priority) {
-	if (priority < state->priority()) {  // only allow decreasing of priority (smaller is better)
-		auto it = std::find(begin(), end(), state);  // find iterator to state
-		assert(it != end());  // state should be part of this interface
-		state->priority_ = priority;  // update priority
-		update(it);
-		if (notify_)
-			notify_(it, true);
-	}
+	if (priority == state->priority())
+		return;  // nothing to do
+
+	auto it = std::find(begin(), end(), state);  // find iterator to state
+	assert(it != end());  // state should be part of this interface
+	state->priority_ = priority;  // update priority
+	update(it);  // update position in ordered list
+	if (notify_)
+		notify_(it, true);  // notify callback
 }
 
 void SolutionBase::setCreator(Stage* creator) {

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -19,7 +19,7 @@ TEST(InterfaceStatePriority, compare) {
 	EXPECT_TRUE(Prio(1, 42) < Prio(0, 0));
 	EXPECT_TRUE(Prio(0, 0) < Prio(0, 42));  // at same depth, higher cost is larger
 
-	auto dstart = InterfaceState::DISABLED_START;
+	auto dstart = InterfaceState::DISABLED_FAILED;
 	EXPECT_TRUE(Prio(0, 0, dstart) == Prio(0, 0, dstart));
 	EXPECT_TRUE(Prio(1, 0, dstart) < Prio(0, 0, dstart));
 	EXPECT_TRUE(Prio(1, 42, dstart) < Prio(0, 0, dstart));
@@ -68,7 +68,7 @@ TEST(Interface, update) {
 	i.updatePriority(*i.rbegin(), Prio(5, 0.0));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
 
-	i.updatePriority(*i.begin(), Prio(6, 0, InterfaceState::DISABLED_START));
+	i.updatePriority(*i.begin(), Prio(6, 0, InterfaceState::DISABLED_FAILED));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 6 }));
 }
 
@@ -87,7 +87,7 @@ TEST(StatePairs, compare) {
 	EXPECT_TRUE(pair(Prio(1, 1), Prio(1, 1)) < pair(Prio(1, 0), Prio(0, 0)));
 
 	auto good = InterfaceState::ENABLED;
-	auto bad = InterfaceState::DISABLED_START;
+	auto bad = InterfaceState::DISABLED_FAILED;
 	EXPECT_TRUE(pair(good, good) < pair(good, bad));
 	EXPECT_TRUE(pair(good, good) < pair(bad, good));
 	EXPECT_TRUE(pair(bad, good) < pair(good, bad));

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -68,7 +68,7 @@ TEST(Interface, update) {
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
 
 	i.updatePriority(*i.begin(), Prio(6, 0, false));
-	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));  // larger priority is ignored
+	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 6 }));
 }
 
 using PrioPair = std::pair<Prio, Prio>;

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -13,20 +13,26 @@
 using namespace moveit::task_constructor;
 TEST(InterfaceStatePriority, compare) {
 	using Prio = InterfaceState::Priority;
-	constexpr double inf = std::numeric_limits<double>::infinity();
-
 	EXPECT_TRUE(Prio(0, 0) == Prio(0, 0));
-	EXPECT_TRUE(Prio(0, inf) == Prio(0, inf));
-
 	EXPECT_TRUE(Prio(1, 0) < Prio(0, 0));  // higher depth is smaller
 	EXPECT_TRUE(Prio(1, 42) < Prio(0, 0));
-	EXPECT_TRUE(Prio(1, inf) > Prio(0, 0));  // infinite costs are always largest
-	EXPECT_TRUE(Prio(1, inf) < Prio(0, inf));
+	EXPECT_TRUE(Prio(0, 0) < Prio(0, 42));  // at same depth, higher cost is larger
 
-	EXPECT_TRUE(Prio(0, 0) < Prio(0, 42));  // higher cost is larger
-	EXPECT_TRUE(Prio(0, 0) < Prio(0, inf));
-	EXPECT_TRUE(Prio(0, 42) > Prio(0, 0));
-	EXPECT_TRUE(Prio(0, inf) > Prio(0, 0));
+	EXPECT_TRUE(Prio(0, 0, false) == Prio(0, 0, false));
+	EXPECT_TRUE(Prio(1, 0, false) < Prio(0, 0, false));
+	EXPECT_TRUE(Prio(1, 42, false) < Prio(0, 0, false));
+	EXPECT_TRUE(Prio(0, 0, false) < Prio(0, 42, false));
+
+	// disabled prios are always larger than enabled ones
+	EXPECT_TRUE(Prio(0, 42) < Prio(1, 0, false));
+	EXPECT_TRUE(Prio(1, 0) < Prio(0, 42, false));
+
+	// other comparison operators
+	EXPECT_TRUE(Prio(0, 0) <= Prio(0, 0));
+	EXPECT_TRUE(Prio(0, 0) <= Prio(0, 1));
+	EXPECT_TRUE(Prio(0, 0) > Prio(1, 10));
+	EXPECT_TRUE(Prio(0, 0) >= Prio(0, 0));
+	EXPECT_TRUE(Prio(0, 10) >= Prio(0, 0));
 }
 
 using Prio = InterfaceState::Priority;
@@ -60,6 +66,6 @@ TEST(Interface, update) {
 	i.updatePriority(*i.rbegin(), Prio(5, 0.0));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
 
-	i.updatePriority(*i.begin(), Prio(6, std::numeric_limits<double>::infinity()));
+	i.updatePriority(*i.begin(), Prio(6, 0, false));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));  // larger priority is ignored
 }

--- a/core/test/test_serial.cpp
+++ b/core/test/test_serial.cpp
@@ -182,6 +182,22 @@ TEST(ConnectConnect, FailSucc) {
 	EXPECT_FALSE(t.plan());
 }
 
+TEST(Pruning, PropagatorFailure) {
+	resetIds();
+	Task t;
+	t.setRobotModel(getModel());
+	BackwardMockup* b;
+	t.add(Stage::pointer(b = new BackwardMockup()));
+	t.add(Stage::pointer(new GeneratorMockup({ 0 })));
+	t.add(Stage::pointer(new ForwardMockup({ inf })));
+
+	t.plan();
+
+	ASSERT_EQ(t.solutions().size(), 0);
+	// ForwardMockup fails, so the backward stage should never compute
+	EXPECT_EQ(b->calls_, 0);
+}
+
 TEST(Pruning, PruningMultiForward) {
 	resetIds();
 	Task t;

--- a/core/test/test_serial.cpp
+++ b/core/test/test_serial.cpp
@@ -172,7 +172,7 @@ TEST(ConnectConnect, Pruning) {
 		++expected_cost;
 	}
 	EXPECT_EQ(c2->calls_, 3u);
-	// EXPECT_EQ(c1->calls_, 6u);  // TODO: avoid compute() calls on failure of remaining part
+	EXPECT_EQ(c1->calls_, 6u);  // TODO: avoid compute() calls on failure of remaining part
 }
 
 // https://github.com/ros-planning/moveit_task_constructor/issues/218


### PR DESCRIPTION
With #220 I essentially disabled pruning to fix some urgent issues. It turned out that this feature wasn't fully thought about and it was broken literally everywhere. This is my work-in-progress to re-enable that important feature (or make it work in the first place).

I noticed several things:
- The action to be taken for pruning is highly dependent based on the stage that triggers it. 
  - Generator-like stages shouldn't trigger pruning at all: They just don't push new states to their push interfaces.
  - Propagator stages can _remove_ all interface states that are incoming to the failed source state.
However, this rule only applies to the default propagators MoveTo and MoveRelative that forward states in a 1:1 fashion.
If the propagator generates multiple output states for each input state, the source state can only be removed if all candidate extensions are exhausted. Thus, **pruning needs to be triggered from within the individual stages.**
  - Connect stages, on the other hand, must not remove these states, but just disable them (temporarily). If later new input states arrive, they can get reactivated.

So far, I considered pruning for `Connecting` stages only. Here, I stumbled over a symmetry issue: In the initial situation shown in the leftmost figure, we have several successful solutions (green) and some pending connect pairs (grey). CON2 fails to connect the red pair. This will disable (yellow) the solution trees originating from both ends as shown in the next figure.
If a new input arrives from the bottom to CON2, this should be connected to the disabled branch, thus re-enabling it.
On the other hand, if a new input arrives from the top for CON1, this must not be connected to the disabled branch!
The solution, I eventually found, is to remember on which end we originally failed and allow reconnecting at this side only.

![image](https://user-images.githubusercontent.com/5376030/101496187-c1297100-3969-11eb-819f-d34921ef5596.png)
