### PR TITLE
demo: switch to moveit_resources_panda_moveit_config

### DIFF
--- a/demo/launch/demo.launch
+++ b/demo/launch/demo.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
-  <include file="$(find panda_moveit_config)/launch/planning_context.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>
   </include>
 
@@ -22,7 +22,7 @@
   <param name="move_group/capabilities" value="move_group/ExecuteTaskSolutionCapability" />
   
   <!-- Run the main MoveIt executable (the move_group node) -->
-  <include file="$(find panda_moveit_config)/launch/move_group.launch">
+  <include file="$(find moveit_resources_panda_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
@@ -31,6 +31,6 @@
 
   <!-- Run Rviz -->
   <node name="$(anon rviz)" pkg="rviz" type="rviz" respawn="false" args="-d $(find moveit_task_constructor_demo)/config/mtc.rviz">
-    <rosparam command="load" file="$(find panda_moveit_config)/config/kinematics.yaml"/>
+    <rosparam command="load" file="$(find moveit_resources_panda_moveit_config)/config/kinematics.yaml"/>
   </node>
 </launch>

--- a/demo/package.xml
+++ b/demo/package.xml
@@ -15,5 +15,5 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>moveit_core</depend>
   <depend>rosparam_shortcuts</depend>
-  <exec_depend version_gte="0.7.4">panda_moveit_config</exec_depend>
+  <exec_depend>moveit_resources_panda_moveit_config</exec_depend>
 </package>


### PR DESCRIPTION
In Noetic, the tutorial demos don't work anymore, because Franka has changed the collision model of the robot.
As a quick hack for this, this PR switches to the old Panda config, available in `moveit_resources`.