### PR TITLE
remove roscpp as an export dependency for the core package

### DIFF
--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -64,7 +64,7 @@ public:
 
 	void add(Stage::pointer&& stage);
 
-	virtual bool insert(Stage::pointer&& stage, int before = -1);
+	virtual void insert(Stage::pointer&& stage, int before = -1);
 	virtual Stage::pointer remove(int pos);
 	virtual Stage::pointer remove(Stage* child);
 	virtual void clear();
@@ -205,7 +205,7 @@ public:
 	WrapperBase(const std::string& name = "wrapper", Stage::pointer&& child = Stage::pointer());
 
 	/// insertion is only allowed if children() is empty
-	bool insert(Stage::pointer&& stage, int before = -1) override;
+	void insert(Stage::pointer&& stage, int before = -1) override;
 
 	/// access the single wrapped child, NULL if still empty
 	Stage* wrapped();

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -43,8 +43,6 @@
 #include <moveit/task_constructor/cost_terms.h>
 #include <moveit/task_constructor/cost_queue.h>
 
-#include <ros/ros.h>
-
 #include <ostream>
 #include <chrono>
 
@@ -116,8 +114,8 @@ public:
 	/// enforce only one parent exists
 	inline bool setParent(ContainerBase* parent) {
 		if (parent_) {
-			ROS_ERROR_STREAM("Tried to add stage '" << name() << "' to two parents");
-			return false;  // it's not allowed to add a stage to a parent if it already has one
+			// it's not allowed to add a stage to a parent if it already has one
+			throw std::runtime_error("Tried to add stage '" + name() + "' to two parents");
 		}
 		parent_ = parent;
 		return true;
@@ -181,7 +179,7 @@ protected:
 	std::list<InterfaceState> states_;  // storage for created states
 	ordered<SolutionBaseConstPtr> solutions_;
 	std::list<SolutionBaseConstPtr> failures_;
-	size_t num_failures_ = 0;  // num of failures if not stored
+	std::size_t num_failures_ = 0;  // num of failures if not stored
 
 private:
 	// !! items write-accessed only by ContainerBasePrivate to maintain hierarchy !!

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -112,13 +112,12 @@ public:
 
 	/// set parent of stage
 	/// enforce only one parent exists
-	inline bool setParent(ContainerBase* parent) {
+	inline void setParent(ContainerBase* parent) {
 		if (parent_) {
 			// it's not allowed to add a stage to a parent if it already has one
 			throw std::runtime_error("Tried to add stage '" + name() + "' to two parents");
 		}
 		parent_ = parent;
-		return true;
 	}
 
 	/// explicitly orphan stage

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -94,7 +94,7 @@ public:
 	void loadRobotModel(const std::string& robot_description = "robot_description");
 
 	void add(Stage::pointer&& stage);
-	bool insert(Stage::pointer&& stage, int before = -1) override;
+	void insert(Stage::pointer&& stage, int before = -1) override;
 	void clear() final;
 
 	/// enable introspection publishing for use with rviz

--- a/core/package.xml
+++ b/core/package.xml
@@ -9,9 +9,11 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
+	<build_depend>roscpp</build_depend>
+	<exec_depend>roscpp</exec_depend>
+
 	<depend>eigen_conversions</depend>
 	<depend>geometry_msgs</depend>
-	<depend>roscpp</depend>
 	<depend>moveit_core</depend>
 	<depend>moveit_ros_planning</depend>
 	<depend>moveit_ros_planning_interface</depend>

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -203,8 +203,8 @@ void Task::add(Stage::pointer&& stage) {
 	stages()->add(std::move(stage));
 }
 
-bool Task::insert(Stage::pointer&& stage, int before) {
-	return stages()->insert(std::move(stage), before);
+void Task::insert(Stage::pointer&& stage, int before) {
+	stages()->insert(std::move(stage), before);
 }
 
 void Task::clear() {

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -298,28 +298,28 @@ TEST_F(SerialTest, insertion_order) {
 	/*****  inserting first stage  *****/
 	auto g = std::make_unique<GeneratorMockup>();
 	StagePrivate* gp = g->pimpl();
-	ASSERT_TRUE(container.insert(std::move(g)));
+	container.insert(std::move(g));
 	EXPECT_FALSE(g);  // ownership transferred to container
 	VALIDATE(gp);
 
 	/*****  inserting second stage  *****/
 	auto f = std::make_unique<ForwardMockup>();
 	StagePrivate* fp = f->pimpl();
-	ASSERT_TRUE(container.insert(std::move(f)));
+	container.insert(std::move(f));
 	EXPECT_FALSE(f);  // ownership transferred to container
 	VALIDATE(gp, fp);
 
 	/*****  inserting third stage  *****/
 	auto f2 = std::make_unique<ForwardMockup>();
 	StagePrivate* fp2 = f2->pimpl();
-	ASSERT_TRUE(container.insert(std::move(f2), 1));
+	container.insert(std::move(f2), 1);
 	EXPECT_FALSE(f2);  // ownership transferred to container
 	VALIDATE(gp, fp2, fp);
 
 	/*****  inserting another generator stage  *****/
 	auto g2 = std::make_unique<GeneratorMockup>();
 	StagePrivate* gp2 = g2->pimpl();
-	ASSERT_TRUE(container.insert(std::move(g2)));
+	container.insert(std::move(g2));
 	VALIDATE(gp, fp2, fp, gp2);
 }
 


### PR DESCRIPTION
We do use ROS in the background. But there is no need for a public export dependency on it.

This patch also resolves the following catkin_lint issue:

    moveit_task_constructor_core: CMakeLists.txt(17): error: package 'roscpp' must be in CATKIN_DEPENDS in catkin_package()

I also see this other warning which we might want to address, but I'm not convinced it's worth the additional include directives in dependent targets.

    moveit_task_constructor_core: src/CMakeLists.txt(37): warning: target_include_directories() exports external PUBLIC path '${catkin_INCLUDE_DIRS}'