### PR TITLE
explicitly instantiate template for required values

### DIFF
--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -578,6 +578,11 @@ template <Interface::Direction dir>
 void PropagatingEitherWay::send(const InterfaceState& start, InterfaceState&& end, SubTrajectory&& trajectory) {
 	pimpl()->send<dir>(start, std::move(end), std::make_shared<SubTrajectory>(std::move(trajectory)));
 }
+// Explicit template instantiation is required. The compiler, otherwise, might just inline them.
+template void PropagatingEitherWay::send<Interface::FORWARD>(const InterfaceState& start, InterfaceState&& end,
+                                                             SubTrajectory&& trajectory);
+template void PropagatingEitherWay::send<Interface::BACKWARD>(const InterfaceState& start, InterfaceState&& end,
+                                                              SubTrajectory&& trajectory);
 
 template <Interface::Direction dir>
 void PropagatingEitherWay::computeGeneric(const InterfaceState& start) {


### PR DESCRIPTION
Fixup for 10f6b7a58ed6063771eb7b9cbe9931fc71497ca8 .

On my release workspace I see
/usr/bin/ld: libmoveit_task_constructor_core_stages.so: undefined reference to `
void moveit::task_constructor::PropagatingEitherWay::send<(moveit::task_constructor::Interface::Direction)0>(moveit::task_constructor::InterfaceState const&, moveit::task_constructor::InterfaceState&&, moveit::task_constructor::SubTrajectory&&)'
/usr/bin/ld: libmoveit_task_constructor_core_stages.so: undefined reference to `
void moveit::task_constructor::PropagatingEitherWay::send<(moveit::task_constructor::Interface::Direction)1>(moveit::task_constructor::InterfaceState const&, moveit::task_constructor::InterfaceState&&, moveit::task_constructor::SubTrajectory&&)'

and indeed the methods are not explicitly instantiated and not used in the compile unit.