### PR TITLE
rework PipelinePlanner creation

### DIFF
--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -55,7 +55,21 @@ MOVEIT_CLASS_FORWARD(PipelinePlanner)
 class PipelinePlanner : public PlannerInterface
 {
 public:
-	PipelinePlanner();
+	struct Specification
+	{
+		moveit::core::RobotModelConstPtr model;
+		std::string ns{ "move_group" };
+		std::string pipeline{ "ompl" };
+		std::string adapter_param{ "request_adapters" };
+	};
+
+	static planning_pipeline::PlanningPipelinePtr create(const moveit::core::RobotModelConstPtr& model) {
+		return create(Specification{ .model = model });
+	}
+
+	static planning_pipeline::PlanningPipelinePtr create(const Specification& spec);
+
+	PipelinePlanner(const std::string& pipeline = "ompl");
 
 	PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline);
 
@@ -73,6 +87,7 @@ public:
 	          const moveit_msgs::Constraints& path_constraints = moveit_msgs::Constraints()) override;
 
 protected:
+	std::string pipeline_name_;
 	planning_pipeline::PlanningPipelinePtr planner_;
 };
 }  // namespace solvers

--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -64,7 +64,9 @@ public:
 	};
 
 	static planning_pipeline::PlanningPipelinePtr create(const moveit::core::RobotModelConstPtr& model) {
-		return create(Specification{ .model = model });
+		Specification spec;
+		spec.model = model;
+		return create(spec);
 	}
 
 	static planning_pipeline::PlanningPipelinePtr create(const Specification& spec);

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -73,11 +73,9 @@ class Task : protected WrapperBase
 public:
 	PRIVATE_CLASS(Task)
 
-	// +1 TODO: move into MoveIt core
-	static planning_pipeline::PlanningPipelinePtr
-	createPlanner(const moveit::core::RobotModelConstPtr& model, const std::string& ns = "move_group",
-	              const std::string& planning_plugin_param_name = "planning_plugin",
-	              const std::string& adapter_plugins_param_name = "request_adapters");
+	[[deprecated("use PipelinePlanner::create")]] static planning_pipeline::PlanningPipelinePtr
+	    createPlanner(const moveit::core::RobotModelConstPtr& model);
+
 	Task(const std::string& ns = "", bool introspection = true,
 	     ContainerBase::pointer&& container = std::make_unique<SerialContainer>("task pipeline"));
 	Task(Task&& other);  // NOLINT(performance-noexcept-move-constructor)

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -73,9 +73,6 @@ class Task : protected WrapperBase
 public:
 	PRIVATE_CLASS(Task)
 
-	[[deprecated("use PipelinePlanner::create")]] static planning_pipeline::PlanningPipelinePtr
-	    createPlanner(const moveit::core::RobotModelConstPtr& model);
-
 	Task(const std::string& ns = "", bool introspection = true,
 	     ContainerBase::pointer&& container = std::make_unique<SerialContainer>("task pipeline"));
 	Task(Task&& other);  // NOLINT(performance-noexcept-move-constructor)

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -77,15 +77,13 @@ struct PlannerCache
 planning_pipeline::PlanningPipelinePtr PipelinePlanner::create(const PipelinePlanner::Specification& spec) {
 	static PlannerCache cache;
 
-	constexpr char PLUGIN_PARAMETER_NAME[]{ "planning_plugin" };
+	constexpr char const* PLUGIN_PARAMETER_NAME = "planning_plugin";
 
-	std::string pipeline_ns{ spec.ns + "/planning_pipelines/" + spec.pipeline };
+	std::string pipeline_ns = spec.ns + "/planning_pipelines/" + spec.pipeline;
 	// fallback to old structure for pipeline parameters in MoveIt
-	if (!ros::NodeHandle{ pipeline_ns }.hasParam(PLUGIN_PARAMETER_NAME)) {
-		ROS_WARN_STREAM("Failed to find '" << pipeline_ns << "/" << PLUGIN_PARAMETER_NAME
-		                                   << "'."
-		                                      "Attempting to load pipeline from old parameter structure. Please update "
-		                                      "your MoveIt config.");
+	if (!ros::NodeHandle(pipeline_ns).hasParam(PLUGIN_PARAMETER_NAME)) {
+		ROS_WARN("Failed to find '%s/%s'. %s", pipeline_ns.c_str(), PLUGIN_PARAMETER_NAME,
+		         "Attempting to load pipeline from old parameter structure. Please update your MoveIt config.");
 		pipeline_ns = spec.ns;
 	}
 
@@ -122,7 +120,7 @@ PipelinePlanner::PipelinePlanner(const std::string& pipeline_name) : pipeline_na
 	                    planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC);
 }
 
-PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline) : PipelinePlanner{} {
+PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline) : PipelinePlanner() {
 	planner_ = planning_pipeline;
 }
 

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -48,7 +48,62 @@ namespace moveit {
 namespace task_constructor {
 namespace solvers {
 
-PipelinePlanner::PipelinePlanner() {
+struct PlannerCache
+{
+	using PlannerID = std::tuple<std::string, std::string>;
+	using PlannerMap = std::map<PlannerID, std::weak_ptr<planning_pipeline::PlanningPipeline> >;
+	using ModelList = std::list<std::pair<std::weak_ptr<const robot_model::RobotModel>, PlannerMap> >;
+	ModelList cache_;
+
+	PlannerMap::mapped_type& retrieve(const robot_model::RobotModelConstPtr& model, const PlannerID& id) {
+		// find model in cache_ and remove expired entries while doing so
+		ModelList::iterator model_it = cache_.begin();
+		while (model_it != cache_.end()) {
+			if (model_it->first.expired()) {
+				model_it = cache_.erase(model_it);
+				continue;
+			}
+			if (model_it->first.lock() == model)
+				break;
+			++model_it;
+		}
+		if (model_it == cache_.end())  // if not found, create a new PlannerMap for this model
+			model_it = cache_.insert(cache_.begin(), std::make_pair(model, PlannerMap()));
+
+		return model_it->second.insert(std::make_pair(id, PlannerMap::mapped_type())).first->second;
+	}
+};
+
+planning_pipeline::PlanningPipelinePtr PipelinePlanner::create(const PipelinePlanner::Specification& spec) {
+	static PlannerCache cache;
+
+	constexpr char PLUGIN_PARAMETER_NAME[]{ "planning_plugin" };
+
+	std::string pipeline_ns{ spec.ns + "/planning_pipelines/" + spec.pipeline };
+	// fallback to old structure for pipeline parameters in MoveIt
+	if (!ros::NodeHandle{ pipeline_ns }.hasParam(PLUGIN_PARAMETER_NAME)) {
+		ROS_WARN_STREAM("Failed to find '" << pipeline_ns << "/" << PLUGIN_PARAMETER_NAME
+		                                   << "'."
+		                                      "Attempting to load pipeline from old parameter structure. Please update "
+		                                      "your MoveIt config.");
+		pipeline_ns = spec.ns;
+	}
+
+	PlannerCache::PlannerID id(pipeline_ns, spec.adapter_param);
+
+	std::weak_ptr<planning_pipeline::PlanningPipeline>& entry = cache.retrieve(spec.model, id);
+	planning_pipeline::PlanningPipelinePtr planner = entry.lock();
+	if (!planner) {
+		// create new entry
+		planner = std::make_shared<planning_pipeline::PlanningPipeline>(spec.model, ros::NodeHandle(pipeline_ns),
+		                                                                PLUGIN_PARAMETER_NAME, spec.adapter_param);
+		// store in cache
+		entry = planner;
+	}
+	return planner;
+}
+
+PipelinePlanner::PipelinePlanner(const std::string& pipeline_name) : pipeline_name_{ pipeline_name } {
 	auto& p = properties();
 	p.declare<std::string>("planner", "", "planner id");
 
@@ -67,13 +122,16 @@ PipelinePlanner::PipelinePlanner() {
 	                    planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC);
 }
 
-PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline) : PipelinePlanner() {
+PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline) : PipelinePlanner{} {
 	planner_ = planning_pipeline;
 }
 
 void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
 	if (!planner_) {
-		planner_ = Task::createPlanner(robot_model);
+		Specification spec;
+		spec.model = robot_model;
+		spec.pipeline = pipeline_name_;
+		planner_ = create(spec);
 	} else if (robot_model != planner_->getRobotModel()) {
 		throw std::runtime_error(
 		    "The robot model of the planning pipeline isn't the same as the task's robot model -- "

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -40,8 +40,6 @@
 #include <moveit/task_constructor/introspection.h>
 #include <moveit_task_constructor_msgs/ExecuteTaskSolutionAction.h>
 
-#include <moveit/task_constructor/solvers/pipeline_planner.h>
-
 #include <ros/ros.h>
 #include <actionlib/client/simple_action_client.h>
 
@@ -126,11 +124,6 @@ Task& Task::operator=(Task&& other) {  // NOLINT(performance-noexcept-move-const
 	clear();  // remove all stages of current task
 	swap(this->pimpl_, other.pimpl_);
 	return *this;
-}
-
-planning_pipeline::PlanningPipelinePtr Task::createPlanner(const moveit::core::RobotModelConstPtr& model) {
-	using namespace moveit::task_constructor::solvers;
-	return PipelinePlanner::create(PipelinePlanner::Specification{ .model = model });
 }
 
 Task::~Task() {


### PR DESCRIPTION
https://github.com/ros-planning/moveit/pull/2127 merged support
for multiple planner plugins. As a result, the planner specification
should include a pipeline name from now on.

Support the new schema and provide a fallback for older configurations.

While doing so, I moved the create methods to the class they actually belong to
and introduced a clean options parameter

This change is somewhat urgent because the pickplace demo is broken since moveit/2127 was merged.