### PR TITLE
Add visualization for Point goals

### DIFF
--- a/core/include/moveit/task_constructor/stages/move_to.h
+++ b/core/include/moveit/task_constructor/stages/move_to.h
@@ -97,12 +97,10 @@ protected:
 	bool compute(const InterfaceState& state, planning_scene::PlanningScenePtr& scene, SubTrajectory& trajectory,
 	             Interface::Direction dir) override;
 	bool getJointStateGoal(const boost::any& goal, const core::JointModelGroup* jmg, moveit::core::RobotState& state);
-	bool getPoseGoal(const boost::any& goal, const geometry_msgs::PoseStamped& ik_pose_msg,
-	                 const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-	                 decltype(std::declval<SolutionBase>().markers())& markers);
+	bool getPoseGoal(const boost::any& goal, const planning_scene::PlanningScenePtr& scene,
+	                 Eigen::Isometry3d& target_eigen);
 	bool getPointGoal(const boost::any& goal, const moveit::core::LinkModel* link,
-	                  const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen,
-	                  decltype(std::declval<SolutionBase>().markers())& /*unused*/);
+	                  const planning_scene::PlanningScenePtr& scene, Eigen::Isometry3d& target_eigen);
 
 protected:
 	solvers::PlannerInterfacePtr planner_;


### PR DESCRIPTION
Implementation for this [TODO](https://github.com/ros-planning/moveit_task_constructor/blob/master/core/src/stages/move_to.cpp#L182).

The `MoveTo` stage can now visualize both Point and Pose goals. The frame for the target is now derived from `target_eigen` instead of the target message itself, because `target_eigen` is computed in both `getPoseGoal` and `getPointGoal`.