### PR TITLE
GHA: Address Sanitizer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,9 @@ jobs:
             CXX: clang++
           - IMAGE: noetic-source
             CLANG_TIDY: true
+          - IMAGE: noetic-source
+            NAME: asan
+            TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1"
     env:
       CATKIN_LINT: true
       # CXXFLAGS: "-Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls -Wno-strict-aliasing -Wno-sign-compare"


### PR DESCRIPTION
Looking into the issues described in https://github.com/ros-planning/moveit_task_constructor/pull/254#pullrequestreview-662459305, I enabled ASan and stumbled over this other issue:

```
==10713==ERROR: AddressSanitizer: heap-use-after-free on address 0x6120000035bc at pc 0x7fda140a81a4 bp 0x7ffeed3fc060 sp 0x7ffeed3fc050
    READ of size 4 at 0x6120000035bc thread T0
        #0 0x7fda140a81a3 in moveit::task_constructor::InterfaceState::Priority::operator<(moveit::task_constructor::InterfaceState::Priority const&) const (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1ca1a3)
        #1 0x7fda140b7971 in std::_List_iterator<moveit::task_constructor::InterfaceState*> std::__upper_bound<std::_List_iterator<moveit::task_constructor::InterfaceState*>, moveit::task_constructor::InterfaceState*, __gnu_cxx::__ops::_Val_comp_iter<ValueOrPointeeLess<moveit::task_constructor::InterfaceState*, bool> > >(std::_List_iterator<moveit::task_constructor::InterfaceState*>, std::_List_iterator<moveit::task_constructor::InterfaceState*>, moveit::task_constructor::InterfaceState* const&, __gnu_cxx::__ops::_Val_comp_iter<ValueOrPointeeLess<moveit::task_constructor::InterfaceState*, bool> >) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1d9971)
        #2 0x7fda140a9a1c in moveit::task_constructor::Interface::add(moveit::task_constructor::InterfaceState&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1cba1c)
        #3 0x7fda13f68dc7 in moveit::task_constructor::ContainerBasePrivate::liftSolution(std::shared_ptr<moveit::task_constructor::SolutionBase> const&, moveit::task_constructor::InterfaceState const*, moveit::task_constructor::InterfaceState const*) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x8adc7)
        #4 0x7fda13f6e069 in moveit::task_constructor::SerialContainer::onNewSolution(moveit::task_constructor::SolutionBase const&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x90069)
```
```
    0x6120000035bc is located 252 bytes inside of 264-byte region [0x6120000034c0,0x6120000035c8)
    freed by thread T0 here:
        #0 0x7fda1468b8df in operator delete(void*) (/lib/x86_64-linux-gnu/libasan.so.5+0x1108df)
        #1 0x7fda144302fd in std::__cxx11::_List_base<moveit::task_constructor::InterfaceState, std::allocator<moveit::task_constructor::InterfaceState> >::_M_clear() (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core_stages.so+0x1de2fd)
        #2 0x7fda14081a35 in moveit::task_constructor::Stage::reset() (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1a3a35)
        #3 0x7fda13f79250 in moveit::task_constructor::ContainerBase::reset() (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x9b250)
        #4 0x55ed78d536cf in Standalone<moveit::task_constructor::SerialContainer>::prepare() (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/moveit_task_constructor_core/moveit_task_constructor_core-test-cost_terms+0x396cf)
```
```
    previously allocated by thread T0 here:
        #0 0x7fda1468a947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
        #1 0x7fda1444af2f in std::_List_iterator<moveit::task_constructor::InterfaceState> std::__cxx11::list<moveit::task_constructor::InterfaceState, std::allocator<moveit::task_constructor::InterfaceState> >::emplace<moveit::task_constructor::InterfaceState>(std::_List_const_iterator<moveit::task_constructor::InterfaceState>, moveit::task_constructor::InterfaceState&&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core_stages.so+0x1f8f2f)
        #2 0x7fda13f67cc5 in moveit::task_constructor::ContainerBasePrivate::liftSolution(std::shared_ptr<moveit::task_constructor::SolutionBase> const&, moveit::task_constructor::InterfaceState const*, moveit::task_constructor::InterfaceState const*) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x89cc5)
        #3 0x7fda13f6e069 in moveit::task_constructor::SerialContainer::onNewSolution(moveit::task_constructor::SolutionBase const&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x90069)
        #4 0x7fda140747e7 in moveit::task_constructor::StagePrivate::newSolution(std::shared_ptr<moveit::task_constructor::SolutionBase> const&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1967e7)
        #5 0x7fda1408ebc0 in moveit::task_constructor::StagePrivate::spawn(moveit::task_constructor::InterfaceState&&, std::shared_ptr<moveit::task_constructor::SolutionBase> const&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1b0bc0)
        #6 0x7fda1408ef43 in moveit::task_constructor::Generator::spawn(moveit::task_constructor::InterfaceState&&, moveit::task_constructor::SubTrajectory&&) (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/libmoveit_task_constructor_core.so+0x1b0f43)
        #7 0x55ed78d6d530 in GeneratorMockup::compute() (/home/runner/work/target_ws/build/moveit_task_constructor_core/devel/lib/moveit_task_constructor_core/moveit_task_constructor_core-test-cost_terms+0x53530)
```

Interestingly, only the unittest `SetLambdaCostTerm` is affected, although most other cost tests use the `Standalone` class as well.