### PR TITLE
Allow to consider specific joints only in PathLength

### DIFF
--- a/core/include/moveit/task_constructor/cost_terms.h
+++ b/core/include/moveit/task_constructor/cost_terms.h
@@ -115,9 +115,12 @@ public:
 /// trajectory length (interpolated between waypoints)
 class PathLength : public TrajectoryCostTerm
 {
-	// TODO(v4hn): allow to consider specific joints only
 public:
-	double operator()(const SubTrajectory& s, std::string& comment) const override;
+	PathLength() = default;
+	PathLength(std::vector<std::string> j) : joints{ std::move(j) } {};
+	double operator()(const SubTrajectory&, std::string&) const override;
+
+	std::vector<std::string> joints;
 };
 
 /// execution duration of the whole trajectory


### PR DESCRIPTION
Implements [this](https://github.com/ros-planning/moveit_task_constructor/blob/master/core/include/moveit/task_constructor/cost_terms.h#L118) TODO.

By passing a vector of joint names to the constructor of `PathLength`, the cost of the path is now computed by only considering these joints. If no vector is passed, all joints are considered.