### PR TITLE
Implement missing pregrasp property for RobotState.msg 

### DIFF
--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -314,6 +314,12 @@ public:
 
 	double computeCost(const CostTerm& cost, std::string& comment) const override;
 
+	static SubTrajectory failure(const std::string& msg) {
+		SubTrajectory s;
+		s.markAsFailure(msg);
+		return s;
+	}
+
 private:
 	// actual trajectory, might be empty
 	robot_trajectory::RobotTrajectoryConstPtr trajectory_;

--- a/core/src/stages/generate_grasp_pose.cpp
+++ b/core/src/stages/generate_grasp_pose.cpp
@@ -126,14 +126,7 @@ void GenerateGraspPose::onNewSolution(const SolutionBase& s) {
 	const std::string& object = props.get<std::string>("object");
 	if (!scene->knowsFrameTransform(object)) {
 		const std::string msg = "object '" + object + "' not in scene";
-		if (storeFailures()) {
-			InterfaceState state(scene);
-			SubTrajectory solution;
-			solution.markAsFailure();
-			solution.setComment(msg);
-			spawn(std::move(state), std::move(solution));
-		} else
-			ROS_WARN_STREAM_NAMED("GenerateGraspPose", msg);
+		spawn(InterfaceState{ scene }, SubTrajectory::failure(msg));
 		return;
 	}
 
@@ -154,9 +147,7 @@ void GenerateGraspPose::compute() {
 	try {
 		applyPreGrasp(robot_state, jmg, props.property("pregrasp"));
 	} catch (const moveit::Exception& e) {
-		SubTrajectory failure;
-		failure.markAsFailure(std::string{ "invalid pregrasp: " } + e.what());
-		spawn(InterfaceState{ scene }, std::move(failure));
+		spawn(InterfaceState{ scene }, SubTrajectory::failure(std::string{ "invalid pregrasp: " } + e.what()));
 		return;
 	}
 


### PR DESCRIPTION
The `pregrasp` property segfaults when a RobotState.msg is passed to the GenerateGraspPose stage like so:

```cpp
moveit_msgs::RobotState robot_state;
robot_state.is_diff = true;
robot_state.joint_state.name.resize(1);
robot_state.joint_state.name[0] = "panda_finger_joint1";
robot_state.joint_state.position.resize(1);
robot_state.joint_state.position[0] = 0.0;

{
	// Sample grasp pose
	auto stage = std::make_unique<stages::GenerateGraspPose>("generate grasp pose");
	stage->properties().configureInitFrom(Stage::PARENT);
	stage->properties().set("marker_ns", "grasp_pose");
	stage->setPreGraspPose(robot_state);
        ...
}
```
This PR may not be the best way to report the bad_any_cast. Also the robot state could fail silently in the `compute` section but is dealt with in the init section. Not sure if a property can be change after the init section.