### PR TITLE
Set max cartesian end-effector speed in planning pipeline

### DIFF
--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -40,6 +40,7 @@
 #include <moveit/task_constructor/task.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_pipeline/planning_pipeline.h>
+#include <moveit/trajectory_processing/cartesian_speed.h>
 #include <moveit_msgs/MotionPlanRequest.h>
 #include <moveit/kinematic_constraints/utils.h>
 #include <eigen_conversions/eigen_msg.h>
@@ -149,6 +150,8 @@ void initMotionPlanRequest(moveit_msgs::MotionPlanRequest& req, const PropertyMa
 	req.num_planning_attempts = p.get<uint>("num_planning_attempts");
 	req.max_velocity_scaling_factor = p.get<double>("max_velocity_scaling_factor");
 	req.max_acceleration_scaling_factor = p.get<double>("max_acceleration_scaling_factor");
+	req.max_cartesian_speed = p.get<double>("max_cartesian_speed");
+	req.cartesian_speed_end_effector_link = p.get<std::string>("cartesian_speed_end_effector_link");
 	req.workspace_parameters = p.get<moveit_msgs::WorkspaceParameters>("workspace_parameters");
 }
 
@@ -168,6 +171,12 @@ bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& from,
 	::planning_interface::MotionPlanResponse res;
 	bool success = planner_->generatePlan(from, req, res);
 	result = res.trajectory_;
+	// optionally compute timing to move the eef with constant speed
+	if (req.max_cartesian_speed > 0.0)
+	{
+	trajectory_processing::setMaxCartesianEndEffectorSpeed(*result, req.max_cartesian_speed,
+															req.cartesian_speed_end_effector_link);
+	}
 	return success;
 }
 
@@ -192,6 +201,12 @@ bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& from, co
 	::planning_interface::MotionPlanResponse res;
 	bool success = planner_->generatePlan(from, req, res);
 	result = res.trajectory_;
+	// optionally compute timing to move the eef with constant speed
+	if (req.max_cartesian_speed > 0.0)
+	{
+	trajectory_processing::setMaxCartesianEndEffectorSpeed(*result, req.max_cartesian_speed,
+															req.cartesian_speed_end_effector_link);
+	}
 	return success;
 }
 }  // namespace solvers

--- a/core/src/solvers/planner_interface.cpp
+++ b/core/src/solvers/planner_interface.cpp
@@ -46,6 +46,8 @@ PlannerInterface::PlannerInterface() {
 	auto& p = properties();
 	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
 	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
+	p.declare<double>("max_cartesian_speed", 0.0, "maximum cartesian end-effector speed");
+	p.declare<std::string>("cartesian_speed_end_effector_link", "end_effector_link", "end-effector link with limited the velocity");
 }
 }  // namespace solvers
 }  // namespace task_constructor


### PR DESCRIPTION
Enable trajectory post-processing in planning pipeline to set maximum cartesian end-effector speed.
Requires following to be merged:
- https://github.com/ros-planning/moveit/pull/2674/
- https://github.com/ros-planning/moveit_msgs/pull/113

How to use? Instead of ``setProperty("max_velocity_scaling_factor", velocity);``, use:
```
pipeline_planner->setProperty("max_cartesian_speed", velocity); // cartesian_velocity
pipeline_planner->setProperty("cartesian_speed_end_effector_link", welding_tcp_frame_);
```
I will also implement it in the cartesian demo.

Solves #276 