### PR TITLE
Merge different mockup implementations

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -6,7 +6,7 @@
 if (CATKIN_ENABLE_TESTING)
 	find_package(rostest REQUIRED)
 
-	add_library(gtest_utils gtest_value_printers.cpp models.cpp)
+	add_library(gtest_utils gtest_value_printers.cpp models.cpp stage_mockups.cpp)
 	target_link_libraries(gtest_utils ${PROJECT_NAME})
 
 	catkin_add_gtest(${PROJECT_NAME}-test-stage test_stage.cpp)

--- a/core/test/stage_mockups.cpp
+++ b/core/test/stage_mockups.cpp
@@ -1,0 +1,125 @@
+#include <moveit/task_constructor/stage_p.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include "stage_mockups.h"
+
+#include <gtest/gtest.h>
+
+namespace moveit {
+namespace task_constructor {
+
+unsigned int GeneratorMockup::id_ = 0;
+unsigned int MonitoringGeneratorMockup::id_ = 0;
+unsigned int ConnectMockup::id_ = 0;
+unsigned int PropagatorMockup::id_ = 0;
+unsigned int ForwardMockup::id_ = 0;
+unsigned int BackwardMockup::id_ = 0;
+
+void resetMockupIds() {
+	GeneratorMockup::id_ = 0;
+	MonitoringGeneratorMockup::id_ = 0;
+	ConnectMockup::id_ = 0;
+	PropagatorMockup::id_ = 0;
+	ForwardMockup::id_ = 0;
+	BackwardMockup::id_ = 0;
+}
+
+PredefinedCosts::PredefinedCosts(std::list<double>&& costs, bool finite)
+  : costs_{ std::move(costs) }, finite_{ finite } {}
+
+bool PredefinedCosts::exhausted() const {
+	return costs_.empty();
+}
+
+double PredefinedCosts::cost() const {
+	// keep the tests going, but this should not happen
+	EXPECT_GT(costs_.size(), 0u);
+	if (costs_.empty())
+		return 0.0;
+
+	double c{ costs_.front() };
+
+	if (finite_ || costs_.size() > 1) {
+		costs_.pop_front();
+	}
+
+	return c;
+}
+
+GeneratorMockup::GeneratorMockup(PredefinedCosts&& costs)
+  : Generator{ "GEN" + std::to_string(++id_) }, costs_{ std::move(costs) } {}
+
+void GeneratorMockup::init(const moveit::core::RobotModelConstPtr& robot_model) {
+	ps_.reset(new planning_scene::PlanningScene(robot_model));
+	Generator::init(robot_model);
+}
+
+bool GeneratorMockup::canCompute() const {
+	// check if runs are being used and if there are still runs left (costs are then never exhausted) or if costs
+	// are being used and they are not exhausted yet
+	return !costs_.exhausted();
+}
+
+void GeneratorMockup::compute() {
+	++runs_;
+
+	spawn(InterfaceState(ps_), costs_.cost());
+}
+
+MonitoringGeneratorMockup::MonitoringGeneratorMockup(Stage* monitored, PredefinedCosts&& costs)
+  : MonitoringGenerator{ "MON" + std::to_string(++id_), monitored }, costs_{ std::move(costs) } {}
+
+void MonitoringGeneratorMockup::onNewSolution(const SolutionBase& s) {
+	++runs_;
+
+	spawn(InterfaceState{ s.end()->scene()->diff() }, SubTrajectory{});
+}
+
+ConnectMockup::ConnectMockup(PredefinedCosts&& costs)
+  : Connecting{ "CON" + std::to_string(++id_) }, costs_{ std::move(costs) } {}
+
+void ConnectMockup::compute(const InterfaceState& from, const InterfaceState& to) {
+	++runs_;
+
+	auto solution{ std::make_shared<SubTrajectory>() };
+	solution->setCost(costs_.cost());
+	connect(from, to, solution);
+}
+
+PropagatorMockup::PropagatorMockup(PredefinedCosts&& costs, std::size_t solutions_per_compute)
+  : PropagatingEitherWay{ "PRO" + std::to_string(++id_) }
+  , costs_{ std::move(costs) }
+  , solutions_per_compute_{ solutions_per_compute } {}
+
+void PropagatorMockup::computeForward(const InterfaceState& from) {
+	++runs_;
+
+	for (std::size_t i = 0; i < solutions_per_compute_; ++i) {
+		SubTrajectory solution{ robot_trajectory::RobotTrajectoryConstPtr(), costs_.cost() };
+		sendForward(from, InterfaceState{ from.scene()->diff() }, std::move(solution));
+	}
+}
+
+void PropagatorMockup::computeBackward(const InterfaceState& to) {
+	++runs_;
+
+	for (std::size_t i = 0; i < solutions_per_compute_; ++i) {
+		SubTrajectory solution(robot_trajectory::RobotTrajectoryConstPtr(), costs_.cost());
+		sendBackward(InterfaceState(to.scene()->diff()), to, std::move(solution));
+	}
+}
+
+ForwardMockup::ForwardMockup(PredefinedCosts&& costs, std::size_t solutions_per_compute)
+  : PropagatorMockup{ std::move(costs), solutions_per_compute } {
+	restrictDirection(FORWARD);
+	setName("FWD" + std::to_string(++id_));
+}
+
+BackwardMockup::BackwardMockup(PredefinedCosts&& costs, std::size_t solutions_per_compute)
+  : PropagatorMockup{ std::move(costs), solutions_per_compute } {
+	restrictDirection(BACKWARD);
+	setName("BWD" + std::to_string(++id_));
+}
+
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/test/stage_mockups.h
+++ b/core/test/stage_mockups.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <moveit/task_constructor/stage_p.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+namespace moveit {
+namespace task_constructor {
+
+MOVEIT_STRUCT_FORWARD(PredefinedCosts);
+struct PredefinedCosts : CostTerm
+{
+	mutable std::list<double> costs_;  // list of costs to assign
+	mutable bool finite_;
+
+	PredefinedCosts(std::list<double>&& costs, bool finite = true);
+
+	static PredefinedCosts constant(double c) { return PredefinedCosts{ std::list<double>{ c }, false }; }
+	static PredefinedCosts single(double c) { return PredefinedCosts{ std::list<double>{ c }, true }; }
+
+	bool exhausted() const;
+	double cost() const;
+
+	double operator()(const SubTrajectory& /*s*/, std::string& /*comment*/) const override { return cost(); }
+	double operator()(const SolutionSequence& /*s*/, std::string& /*comment*/) const override { return cost(); }
+	double operator()(const WrappedSolution& /*s*/, std::string& /*comment*/) const override { return cost(); }
+};
+
+struct GeneratorMockup : public Generator
+{
+	planning_scene::PlanningScenePtr ps_;
+
+	PredefinedCosts costs_;
+	size_t runs_{ 0 };
+
+	static unsigned int id_;
+
+	// default to one solution to avoid infinity loops
+	GeneratorMockup(PredefinedCosts&& costs = PredefinedCosts{ std::list<double>{ 0.0 }, true });
+	GeneratorMockup(std::initializer_list<double> costs)
+	  : GeneratorMockup{ PredefinedCosts{ std::list<double>{ costs }, true } } {}
+
+	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
+	bool canCompute() const override;
+	void compute() override;
+};
+
+struct MonitoringGeneratorMockup : public MonitoringGenerator
+{
+	PredefinedCosts costs_;
+	size_t runs_{ 0 };
+
+	static unsigned int id_;
+
+	MonitoringGeneratorMockup(Stage* monitored, PredefinedCosts&& costs = PredefinedCosts::constant(0.0));
+	MonitoringGeneratorMockup(Stage* monitored, std::initializer_list<double> costs)
+	  : MonitoringGeneratorMockup{ monitored, PredefinedCosts{ std::list<double>{ costs }, true } } {}
+
+	bool canCompute() const override { return false; }
+	void compute() override {}
+	void onNewSolution(const SolutionBase& s) override;
+};
+
+struct ConnectMockup : public Connecting
+{
+	PredefinedCosts costs_;
+	size_t runs_{ 0 };
+
+	static unsigned int id_;
+
+	ConnectMockup(PredefinedCosts&& costs = PredefinedCosts::constant(0.0));
+	ConnectMockup(std::initializer_list<double> costs)
+	  : ConnectMockup{ PredefinedCosts{ std::list<double>{ costs }, true } } {}
+
+	using Connecting::compatible;  // make this accessible for testing
+
+	void compute(const InterfaceState& from, const InterfaceState& to) override;
+};
+
+struct PropagatorMockup : public PropagatingEitherWay
+{
+	PredefinedCosts costs_;
+	size_t runs_{ 0 };
+	std::size_t solutions_per_compute_;
+
+	static unsigned int id_;
+
+	PropagatorMockup(PredefinedCosts&& costs = PredefinedCosts::constant(0.0), std::size_t solutions_per_compute = 1);
+	PropagatorMockup(std::initializer_list<double> costs)
+	  : PropagatorMockup{ PredefinedCosts{ std::list<double>{ costs }, true } } {}
+
+	void computeForward(const InterfaceState& from) override;
+	void computeBackward(const InterfaceState& to) override;
+};
+
+struct ForwardMockup : public PropagatorMockup
+{
+	static unsigned int id_;
+
+	ForwardMockup(PredefinedCosts&& costs = PredefinedCosts::constant(0.0), std::size_t solutions_per_compute = 1);
+	ForwardMockup(std::initializer_list<double> costs)
+	  : ForwardMockup{ PredefinedCosts{ std::list<double>{ costs }, true } } {}
+};
+
+struct BackwardMockup : public PropagatorMockup
+{
+	static unsigned int id_;
+
+	BackwardMockup(PredefinedCosts&& costs = PredefinedCosts::constant(0.0), std::size_t solutions_per_compute = 1);
+	BackwardMockup(std::initializer_list<double> costs)
+	  : BackwardMockup{ PredefinedCosts{ std::list<double>{ costs }, true } } {}
+};
+
+// reset ids of all Mockup types (used to generate unique stage names)
+void resetMockupIds();
+
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -196,7 +196,7 @@ protected:
 	Container container;
 	InterfacePtr dummy;
 
-	InitTest() : ::testing::Test(), dummy(new Interface) {}
+	InitTest() : ::testing::Test{}, robot_model{ getModel() }, dummy{ new Interface } {}
 
 	void pushInterface(bool start = true, bool end = true) {
 		// pretend, that the container is connected

--- a/core/test/test_serial.cpp
+++ b/core/test/test_serial.cpp
@@ -5,6 +5,7 @@
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
+#include "stage_mockups.h"
 #include "models.h"
 #include <list>
 #include <memory>
@@ -13,105 +14,11 @@
 using namespace moveit::task_constructor;
 using namespace planning_scene;
 
-MOVEIT_STRUCT_FORWARD(PredefinedCosts);
-struct PredefinedCosts : CostTerm
-{
-	mutable std::list<double> costs_;  // list of costs to assign
-	mutable double cost_ = 0.0;  // last assigned cost
-	bool finite_;  // finite number of compute() attempts?
-
-	PredefinedCosts(bool finite, std::list<double>&& costs) : costs_(std::move(costs)), finite_(finite) {}
-	bool exhausted() const { return finite_ && costs_.empty(); }
-	double cost() const {
-		if (!costs_.empty()) {
-			cost_ = costs_.front();
-			costs_.pop_front();
-		}
-		return cost_;
-	}
-
-	double operator()(const SubTrajectory& /*s*/, std::string& /*comment*/) const override { return cost(); }
-	double operator()(const SolutionSequence& /*s*/, std::string& /*comment*/) const override { return cost(); }
-	double operator()(const WrappedSolution& /*s*/, std::string& /*comment*/) const override { return cost(); }
-};
-
-/** Generator creating solutions with given costs */
-struct GeneratorMockup : Generator
-{
-	PlanningScenePtr ps_;
-	PredefinedCosts costs_;
-	static unsigned int id_;
-
-	GeneratorMockup(std::initializer_list<double> costs = { 0.0 })
-	  : Generator("GEN" + std::to_string(++id_)), costs_(true, costs) {}
-
-	void init(const moveit::core::RobotModelConstPtr& robot_model) override {
-		ps_.reset(new PlanningScene(robot_model));
-		Generator::init(robot_model);
-	}
-
-	bool canCompute() const override { return !costs_.exhausted(); }
-	void compute() override { spawn(InterfaceState(ps_), costs_.cost()); }
-};
-
-struct PropagatorMockup : public PropagatingEitherWay
-{
-	PredefinedCosts costs_;
-	std::size_t solutions_per_compute_;
-
-	unsigned int calls_ = 0;
-
-	PropagatorMockup(std::initializer_list<double> costs = { 0.0 }, std::size_t solutions_per_compute = 1)
-	  : PropagatingEitherWay(), costs_(false, costs), solutions_per_compute_(solutions_per_compute) {}
-
-	void computeForward(const InterfaceState& from) override {
-		++calls_;
-		for (std::size_t i = 0; i < solutions_per_compute_; ++i) {
-			SubTrajectory solution(robot_trajectory::RobotTrajectoryConstPtr(), costs_.cost());
-			sendForward(from, InterfaceState(from.scene()->diff()), std::move(solution));
-		}
-	}
-	void computeBackward(const InterfaceState& to) override {
-		++calls_;
-		for (std::size_t i = 0; i < solutions_per_compute_; ++i) {
-			SubTrajectory solution(robot_trajectory::RobotTrajectoryConstPtr(), costs_.cost());
-			sendBackward(InterfaceState(to.scene()->diff()), to, std::move(solution));
-		}
-	}
-};
-struct ForwardMockup : public PropagatorMockup
-{
-	static unsigned int id_;
-
-	ForwardMockup(std::initializer_list<double> costs = { 0.0 }, std::size_t solutions_per_compute = 1)
-	  : PropagatorMockup(costs, solutions_per_compute) {
-		restrictDirection(FORWARD);
-		setName("FW" + std::to_string(++id_));
-	}
-};
-struct BackwardMockup : public PropagatorMockup
-{
-	static unsigned int id_;
-
-	BackwardMockup(std::initializer_list<double> costs = { 0.0 }) : PropagatorMockup(costs) {
-		restrictDirection(BACKWARD);
-		setName("BW" + std::to_string(++id_));
-	}
-};
-
-/* Forward propagator, contributing no solutions at all */
-struct ForwardDummy : PropagatingForward
-{
-	using PropagatingForward::PropagatingForward;
-	void computeForward(const InterfaceState& /*from*/) override {}
-};
-
 /* Connect creating solutions with given costs */
 struct Connect : stages::Connect
 {
-	PlanningScenePtr ps_;
 	PredefinedCostsPtr costs_;
-	unsigned int calls_ = 0;
+	unsigned int calls_{ 0 };
 	static unsigned int id_;
 
 	static GroupPlannerVector getPlanners() {
@@ -119,9 +26,9 @@ struct Connect : stages::Connect
 		return { { "group", planner }, { "eef_group", planner } };
 	}
 
-	Connect(std::initializer_list<double> costs = {}, bool enforce_sequential = false)
+	Connect(std::initializer_list<double> costs = { 0.0 }, bool enforce_sequential = false)
 	  : stages::Connect("CON" + std::to_string(++id_), getPlanners()) {
-		costs_ = std::make_shared<PredefinedCosts>(false, costs);
+		costs_ = std::make_shared<PredefinedCosts>(costs, false);
 		setCostTerm(costs_);
 		if (enforce_sequential)
 			setProperty("merge_mode", SEQUENTIAL);
@@ -133,25 +40,17 @@ struct Connect : stages::Connect
 };
 
 constexpr double INF = std::numeric_limits<double>::infinity();
-unsigned int GeneratorMockup::id_ = 0;
-unsigned int ForwardMockup::id_ = 0;
-unsigned int BackwardMockup::id_ = 0;
 unsigned int Connect::id_ = 0;
 
 struct TestBase : public testing::Test
 {
 	Task task;
 	TestBase() {
-		resetIds();
+		resetMockupIds();
+		Connect::id_ = 0;
 		task.setRobotModel(getModel());
 	}
 
-	void resetIds() {
-		GeneratorMockup::id_ = 0;
-		ForwardMockup::id_ = 0;
-		BackwardMockup::id_ = 0;
-		Connect::id_ = 0;
-	}
 	template <typename C, typename S>
 	auto add(C& container, S* stage) -> S* {
 		container.add(Stage::pointer(stage));
@@ -162,11 +61,11 @@ struct TestBase : public testing::Test
 using ConnectConnect = TestBase;
 // https://github.com/ros-planning/moveit_task_constructor/issues/182
 TEST_F(ConnectConnect, SuccSucc) {
-	add(task, new GeneratorMockup({ 1, 2, 3 }));
+	add(task, new GeneratorMockup({ 1.0, 2.0, 3.0 }));
 	add(task, new Connect());
-	add(task, new GeneratorMockup({ 10, 20 }));
+	add(task, new GeneratorMockup({ 10.0, 20.0 }));
 	add(task, new Connect());
-	add(task, new GeneratorMockup());
+	add(task, new GeneratorMockup({ 0.0 }));
 
 	EXPECT_TRUE(task.plan());
 	ASSERT_EQ(task.solutions().size(), 3u * 2u);
@@ -185,7 +84,7 @@ TEST_F(ConnectConnect, FailSucc) {
 	add(task, new GeneratorMockup());
 	add(task, new Connect());
 	add(task, new GeneratorMockup());
-	add(task, new ForwardDummy());
+	add(task, new ForwardMockup(PredefinedCosts::constant(0.0), 0));
 
 	EXPECT_FALSE(task.plan());
 }
@@ -199,7 +98,7 @@ TEST_F(Pruning, PropagatorFailure) {
 	EXPECT_FALSE(task.plan());
 	ASSERT_EQ(task.solutions().size(), 0u);
 	// ForwardMockup fails, so the backward stage should never compute
-	EXPECT_EQ(back->calls_, 0u);
+	EXPECT_EQ(back->runs_, 0u);
 }
 
 TEST_F(Pruning, PruningMultiForward) {
@@ -207,7 +106,7 @@ TEST_F(Pruning, PruningMultiForward) {
 	add(task, new BackwardMockup());
 	add(task, new GeneratorMockup());
 	// spawn two solutions for the only incoming state
-	add(task, new ForwardMockup({ 0, 0 }, 2));
+	add(task, new ForwardMockup(PredefinedCosts{ { 0.0, 0.0 } }, 2));
 	// fail to extend the second solution
 	add(task, new ForwardMockup({ 0, INF }));
 
@@ -288,7 +187,7 @@ TEST_F(Pruning, PropagateFromContainerPull) {
 	EXPECT_FALSE(task.plan());
 
 	// the failure inside the container should prune computing of back
-	EXPECT_EQ(back->calls_, 0u);
+	EXPECT_EQ(back->runs_, 0u);
 }
 
 TEST_F(Pruning, PropagateFromContainerPush) {
@@ -318,5 +217,5 @@ TEST_F(Pruning, PropagateFromParallelContainerMultiplePaths) {
 	EXPECT_TRUE(task.plan());
 
 	// the failure in one branch of Alternatives must not prune computing back
-	EXPECT_EQ(back->calls_, 1u);
+	EXPECT_EQ(back->runs_, 1u);
 }


### PR DESCRIPTION
Makes a lot of sense in general and simplifies independent future tests.

I guess we could unify more of the infrastructure
(TestBase, Standalone<>, append...)
but this is the most important part to have around.

Also fix an unnoticed bug that was triggered during development on the side.

Thanks to @j-kuehn for the initial effort.