### PR TITLE
switch CI ccov job to Debug build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         env:
           - IMAGE: melodic-source
             NAME: ccov
-            TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_FLAGS="--coverage"
+            TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
           - IMAGE: master-source
             CXXFLAGS: >-
              -Werror -Wall -Wextra -Wwrite-strings -Wunreachable-code -Wpointer-arith -Wredundant-decls


### PR DESCRIPTION
To provide accurate coverage information.

It was originally RelWithDebInfo because MoveIt uses it
and Travis's timeout would kick in with the old setup.

According to Robert the timeout should not be a problem anymore with
the GHA ci setup. Actually I don't think the timeout was ever a problem for MTC,
but the config was just copied.