### PR TITLE
Update main scene node's pose on updates of robot's model frame

### DIFF
--- a/visualization/motion_planning_tasks/src/task_display.cpp
+++ b/visualization/motion_planning_tasks/src/task_display.cpp
@@ -179,6 +179,7 @@ void TaskDisplay::calculateOffsetPosition() {
 void TaskDisplay::update(float wall_dt, float ros_dt) {
 	requestPanel();
 	Display::update(wall_dt, ros_dt);
+	calculateOffsetPosition();
 	trajectory_visual_->update(wall_dt, ros_dt);
 }
 


### PR DESCRIPTION
That's the same fix as https://github.com/ros-planning/moveit/pull/2876.
This fixes #291 in a naive way: 
If the map changes over time, I would actually expect the solution display to use the robot frame transform at the time of planning - not the most recent one as implemented here. However, this timestamp isn't conveyed with our messages yet.
@v4hn @YannickRiou any opinions?