### PR TITLE
new set of fallback tests

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (CATKIN_ENABLE_TESTING)
 	catkin_add_gtest(${PROJECT_NAME}-test-serial test_serial.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-serial ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
 
-	catkin_add_gtest(${PROJECT_NAME}-test-fallback test_fallback.cpp)
+	catkin_add_gmock(${PROJECT_NAME}-test-fallback test_fallback.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-fallback ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
 
 	catkin_add_gtest(${PROJECT_NAME}-test-properties test_properties.cpp)
@@ -27,7 +27,7 @@ if (CATKIN_ENABLE_TESTING)
 	catkin_add_gmock(${PROJECT_NAME}-test-cost_queue test_cost_queue.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-cost_queue ${PROJECT_NAME} gtest_main)
 
-	catkin_add_gtest(${PROJECT_NAME}-test-interface_state test_interface_state.cpp)
+	catkin_add_gmock(${PROJECT_NAME}-test-interface_state test_interface_state.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-interface_state ${PROJECT_NAME} gtest_utils gtest_main)
 
 	catkin_add_gtest(${PROJECT_NAME}-test-cost_terms test_cost_terms.cpp)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -18,6 +18,9 @@ if (CATKIN_ENABLE_TESTING)
 	catkin_add_gtest(${PROJECT_NAME}-test-serial test_serial.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-serial ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
 
+	catkin_add_gtest(${PROJECT_NAME}-test-fallback test_fallback.cpp)
+	target_link_libraries(${PROJECT_NAME}-test-fallback ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
+
 	catkin_add_gtest(${PROJECT_NAME}-test-properties test_properties.cpp)
 	target_link_libraries(${PROJECT_NAME}-test-properties ${PROJECT_NAME} gtest_main)
 

--- a/core/test/stage_mockups.h
+++ b/core/test/stage_mockups.h
@@ -1,7 +1,12 @@
 #pragma once
 
-#include <moveit/task_constructor/stage_p.h>
+#include <moveit/task_constructor/task.h>
+
 #include <moveit/planning_scene/planning_scene.h>
+
+#include "models.h"
+
+#include <gtest/gtest.h>
 
 namespace moveit {
 namespace task_constructor {
@@ -112,6 +117,16 @@ struct BackwardMockup : public PropagatorMockup
 
 // reset ids of all Mockup types (used to generate unique stage names)
 void resetMockupIds();
+
+// provide a basic test fixture that prepares a Task
+struct TaskTestBase : public testing::Test
+{
+	Task t;
+	TaskTestBase() {
+		resetMockupIds();
+		t.setRobotModel(getModel());
+	}
+};
 
 }  // namespace task_constructor
 }  // namespace moveit

--- a/core/test/stage_mockups.h
+++ b/core/test/stage_mockups.h
@@ -7,6 +7,7 @@
 #include "models.h"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 namespace moveit {
 namespace task_constructor {
@@ -127,6 +128,14 @@ struct TaskTestBase : public testing::Test
 		t.setRobotModel(getModel());
 	}
 };
+
+#define EXPECT_COSTS(value, matcher)                                           \
+	{                                                                           \
+		std ::vector<double> costs;                                              \
+		std::transform(value.begin(), value.end(), std::back_inserter(costs),    \
+		               [](const SolutionBaseConstPtr& s) { return s->cost(); }); \
+		EXPECT_THAT(costs, matcher);                                             \
+	}
 
 }  // namespace task_constructor
 }  // namespace moveit

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -44,7 +44,6 @@ void append(ContainerBase& c, const std::initializer_list<StageType>& types) {
 		}
 	}
 }
-constexpr double INF = std::numeric_limits<double>::infinity();
 
 class NamedStage : public GeneratorMockup
 {
@@ -669,87 +668,4 @@ TEST(Task, timeout) {
 	t.setTimeout(std::chrono::duration<double>(2 * timeout).count());
 	EXPECT_TRUE(t.plan());
 	EXPECT_EQ(t.solutions().size(), 2u);
-}
-
-TEST(Fallback, failingNoSolutions) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
-	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
-
-	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
-	t.add(std::move(fallback));
-
-	EXPECT_FALSE(t.plan());
-	EXPECT_EQ(t.solutions().size(), 0u);
-}
-
-TEST(Fallback, failingWithFailedSolutions) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
-	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
-
-	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
-	t.add(std::move(fallback));
-
-	EXPECT_FALSE(t.plan());
-	EXPECT_EQ(t.solutions().size(), 0u);
-}
-
-TEST(Fallback, DISABLED_ConnectStageInsideFallbacks) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
-	t.add(std::make_unique<GeneratorMockup>());
-
-	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ConnectMockup>());
-	t.add(std::move(fallbacks));
-
-	t.add(std::make_unique<GeneratorMockup>());
-
-	EXPECT_TRUE(t.plan());
-	EXPECT_EQ(t.numSolutions(), 1u);
-}
-
-TEST(Fallback, ComputeFirstSuccessfulStageOnly) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
-	t.add(std::make_unique<GeneratorMockup>());
-
-	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
-	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
-	t.add(std::move(fallbacks));
-
-	EXPECT_TRUE(t.plan());
-	EXPECT_EQ(t.numSolutions(), 1u);
-}
-
-TEST(Fallback, ActiveChildReset) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
-	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 0.0, INF, 0.0 } }));
-
-	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
-	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
-	auto first = fallbacks->findChild("FWD1");
-	t.add(std::move(fallbacks));
-
-	EXPECT_TRUE(t.plan());
-	EXPECT_EQ(t.numSolutions(), 2u);
-	EXPECT_EQ(first->solutions().size(), 2u);
 }

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -687,7 +687,7 @@ TEST(Fallback, failing) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST(Fallback, ConnectStageInsideFallbacks) {
+TEST(Fallback, DISABLED_ConnectStageInsideFallbacks) {
 	resetMockupIds();
 	Task t;
 	t.setRobotModel(getModel());

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -730,8 +730,10 @@ TEST(Fallback, ActiveChildReset) {
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
 	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
 	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	auto first = fallbacks->findChild("FWD1");
 	t.add(std::move(fallbacks));
 
 	EXPECT_TRUE(t.plan());
-	EXPECT_EQ(t.numSolutions(), 4u);
+	EXPECT_EQ(t.numSolutions(), 2u);
+	EXPECT_EQ(first->solutions().size(), 2u);
 }

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -671,7 +671,7 @@ TEST(Task, timeout) {
 	EXPECT_EQ(t.solutions().size(), 2u);
 }
 
-TEST(Fallback, failing) {
+TEST(Fallback, failingNoSolutions) {
 	resetMockupIds();
 	Task t;
 	t.setRobotModel(getModel());
@@ -681,6 +681,22 @@ TEST(Fallback, failing) {
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
 	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
 	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
+	t.add(std::move(fallback));
+
+	EXPECT_FALSE(t.plan());
+	EXPECT_EQ(t.solutions().size(), 0u);
+}
+
+TEST(Fallback, failingWithFailedSolutions) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
 	t.add(std::move(fallback));
 
 	EXPECT_FALSE(t.plan());

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -1,0 +1,101 @@
+#include <moveit/task_constructor/container_p.h>
+#include <moveit/task_constructor/stage_p.h>
+#include <moveit/task_constructor/task_p.h>
+#include <moveit/task_constructor/stages/fixed_state.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include "stage_mockups.h"
+#include "models.h"
+#include "gtest_value_printers.h"
+
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <chrono>
+#include <thread>
+
+using namespace moveit::task_constructor;
+
+constexpr double INF = std::numeric_limits<double>::infinity();
+
+TEST(Fallback, failingNoSolutions) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
+	t.add(std::move(fallback));
+
+	EXPECT_FALSE(t.plan());
+	EXPECT_EQ(t.solutions().size(), 0u);
+}
+
+TEST(Fallback, failingWithFailedSolutions) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(INF)));
+	t.add(std::move(fallback));
+
+	EXPECT_FALSE(t.plan());
+	EXPECT_EQ(t.solutions().size(), 0u);
+}
+
+TEST(Fallback, DISABLED_ConnectStageInsideFallbacks) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	fallbacks->add(std::make_unique<ConnectMockup>());
+	t.add(std::move(fallbacks));
+
+	t.add(std::make_unique<GeneratorMockup>());
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.numSolutions(), 1u);
+}
+
+TEST(Fallback, ComputeFirstSuccessfulStageOnly) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	t.add(std::move(fallbacks));
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.numSolutions(), 1u);
+}
+
+TEST(Fallback, ActiveChildReset) {
+	resetMockupIds();
+	Task t;
+	t.setRobotModel(getModel());
+
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 0.0, INF, 0.0 } }));
+
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	auto first = fallbacks->findChild("FWD1");
+	t.add(std::move(fallbacks));
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.numSolutions(), 2u);
+	EXPECT_EQ(first->solutions().size(), 2u);
+}

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -57,19 +57,6 @@ TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
-	t.add(std::make_unique<GeneratorMockup>());
-
-	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 1.0 }, 2));
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
-	t.add(std::move(fallback));
-
-	EXPECT_TRUE(t.plan());
-	ASSERT_EQ(t.solutions().size(), 1u);
-	EXPECT_EQ(t.solutions().front()->cost(), 1.0);
-}
-
 TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
@@ -95,9 +82,35 @@ TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStagePerSolutionOnly) {
 	EXPECT_TRUE(t.plan());
 	EXPECT_EQ(t.numSolutions(), 2u);
 	ASSERT_EQ(fwd1->solutions().size(), 1u);
-	EXPECT_EQ(fwd1->solutions().front()->cost(), 1.0);
+	EXPECT_EQ(fwd1->solutions().front()->start()->priority().cost(), 1.0);
 	ASSERT_EQ(fwd2->solutions().size(), 1u);
-	EXPECT_EQ(fwd2->solutions().front()->cost(), 0.0);
+	EXPECT_EQ(fwd2->solutions().front()->start()->priority().cost(), 0.0);
+}
+
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 1.0 }, 2));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
+	t.add(std::move(fallback));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 1u);
+	EXPECT_EQ(t.solutions().front()->cost(), 1.0);
+}
+
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ 1.0, INF }, 2));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
+	t.add(std::move(fallback));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 1u);
+	EXPECT_EQ(t.solutions().front()->cost(), 1.0);
 }
 
 TEST_F(FallbacksFixturePropagate, ActiveChildReset) {

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -19,7 +19,7 @@ constexpr double INF = std::numeric_limits<double>::infinity();
 
 using FallbacksFixtureGenerator = TaskTestBase;
 
-TEST_F(FallbacksFixtureGenerator, stayWithFirstSuccessful) {
+TEST_F(FallbacksFixtureGenerator, DISABLED_stayWithFirstSuccessful) {
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(INF)));
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(1.0)));
@@ -57,7 +57,7 @@ TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
+TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -69,7 +69,7 @@ TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStagePerSolutionOnly) {
+TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStagePerSolutionOnly) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0 })));
 	// duplicate generator solutions with resulting costs: 4, 2 | 3, 1
 	t.add(std::make_unique<ForwardMockup>(PredefinedCosts({ 2.0, 0.0, 2.0, 0.0 }), 2));
@@ -83,7 +83,7 @@ TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStagePerSolutionOnly) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(113, 124, 211, 222));
 }
 
-TEST_F(FallbacksFixturePropagate, UpdateSolutionOrder) {
+TEST_F(FallbacksFixturePropagate, DISABLED_UpdateSolutionOrder) {
 	t.add(std::make_unique<BackwardMockup>(PredefinedCosts({ 10.0, 0.0 })));
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 	// available solutions (sorted) in individual runs of fallbacks: 1 | 11, 2 | 2, 11
@@ -102,7 +102,7 @@ TEST_F(FallbacksFixturePropagate, UpdateSolutionOrder) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(2));  // expecting less costly solution as result
 }
 
-TEST_F(FallbacksFixturePropagate, MultipleActivePendingStates) {
+TEST_F(FallbacksFixturePropagate, DISABLED_MultipleActivePendingStates) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0, 3.0 })));
 	// use a fallback container to delay computation: the 1st child never succeeds, but only the 2nd
 	auto inner = std::make_unique<Fallbacks>("Inner");
@@ -119,7 +119,7 @@ TEST_F(FallbacksFixturePropagate, MultipleActivePendingStates) {
 	// check that first solution is not marked as pruned
 }
 
-TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
+TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -131,7 +131,7 @@ TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
+TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions2) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -143,7 +143,7 @@ TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
+TEST_F(FallbacksFixturePropagate, DISABLED_ActiveChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, INF, 3.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -161,7 +161,7 @@ TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, ConnectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, DISABLED_ConnectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -57,6 +57,19 @@ TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 1.0 }, 2));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
+	t.add(std::move(fallback));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 1u);
+	EXPECT_EQ(t.solutions().front()->cost(), 1.0);
+}
+
 TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -17,11 +17,18 @@ using namespace moveit::task_constructor;
 
 constexpr double INF = std::numeric_limits<double>::infinity();
 
-TEST(Fallback, failingNoSolutions) {
-	resetMockupIds();
+struct TestBase : public testing::Test
+{
 	Task t;
-	t.setRobotModel(getModel());
+	TestBase() {
+		resetMockupIds();
+		t.setRobotModel(getModel());
+	}
+};
 
+using FallbacksFixture = TestBase;
+
+TEST_F(FallbacksFixture, failingNoSolutions) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -33,11 +40,7 @@ TEST(Fallback, failingNoSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST(Fallback, failingWithFailedSolutions) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
+TEST_F(FallbacksFixture, failingWithFailedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -49,11 +52,7 @@ TEST(Fallback, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST(Fallback, DISABLED_ConnectStageInsideFallbacks) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
+TEST_F(FallbacksFixture, DISABLED_ConnectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -66,11 +65,7 @@ TEST(Fallback, DISABLED_ConnectStageInsideFallbacks) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST(Fallback, ComputeFirstSuccessfulStageOnly) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
+TEST_F(FallbacksFixture, ComputeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -82,11 +77,7 @@ TEST(Fallback, ComputeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST(Fallback, ActiveChildReset) {
-	resetMockupIds();
-	Task t;
-	t.setRobotModel(getModel());
-
+TEST_F(FallbacksFixture, ActiveChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 0.0, INF, 0.0 } }));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -37,8 +37,8 @@ TEST_F(FallbacksFixturePropagate, failingNoSolutions) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
-	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0), 0));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts({}), 0));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts({}), 0));
 	t.add(std::move(fallback));
 
 	EXPECT_FALSE(t.plan());
@@ -70,11 +70,11 @@ TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 }
 
 TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStagePerSolutionOnly) {
-	t.add(std::make_unique<GeneratorMockup>(std::list<double>{ 1.0, 2.0 }));
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 10.0 }));
-	fallbacks->add(std::make_unique<ForwardMockup>(std::list<double>{ 20.0, INF }));
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts({ INF, 10.0 })));
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts({ 20.0, INF })));
 	auto fwd1 = fallbacks->findChild("FWD1");
 	auto fwd2 = fallbacks->findChild("FWD2");
 	t.add(std::move(fallbacks));
@@ -89,7 +89,7 @@ TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 1.0 }, 2));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts({ INF, 1.0 }), 2));
 	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
 	t.add(std::move(fallback));
 
@@ -101,7 +101,7 @@ TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
-	fallback->add(std::make_unique<ForwardMockup>(std::list<double>{ 1.0, INF }, 2));
+	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts({ 1.0, INF }), 2));
 	fallback->add(std::make_unique<ForwardMockup>(PredefinedCosts::single(2.0)));
 	t.add(std::move(fallback));
 
@@ -110,7 +110,7 @@ TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
 }
 
 TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
-	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 1.0, INF, 3.0 } }));
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, INF, 3.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
 	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(10.0)));

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -55,6 +55,24 @@ TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
+TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStagePerSolutionOnly) {
+	t.add(std::make_unique<GeneratorMockup>(std::list<double>{ 0.0, 1.0 }));
+
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	fallbacks->add(std::make_unique<ForwardMockup>(std::list<double>{ INF, 0.0 }));
+	fallbacks->add(std::make_unique<ForwardMockup>(std::list<double>{ 0.0, INF }));
+	auto fwd1 = fallbacks->findChild("FWD1");
+	auto fwd2 = fallbacks->findChild("FWD2");
+	t.add(std::move(fallbacks));
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.numSolutions(), 2u);
+	ASSERT_EQ(fwd1->solutions().size(), 1u);
+	EXPECT_EQ(fwd1->solutions().front()->cost(), 1.0);
+	ASSERT_EQ(fwd2->solutions().size(), 1u);
+	EXPECT_EQ(fwd2->solutions().front()->cost(), 0.0);
+}
+
 TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 0.0, INF, 0.0 } }));
 

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -17,18 +17,9 @@ using namespace moveit::task_constructor;
 
 constexpr double INF = std::numeric_limits<double>::infinity();
 
-struct TestBase : public testing::Test
-{
-	Task t;
-	TestBase() {
-		resetMockupIds();
-		t.setRobotModel(getModel());
-	}
-};
+using FallbacksFixturePropagate = TaskTestBase;
 
-using FallbacksFixture = TestBase;
-
-TEST_F(FallbacksFixture, failingNoSolutions) {
+TEST_F(FallbacksFixturePropagate, failingNoSolutions) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -40,7 +31,7 @@ TEST_F(FallbacksFixture, failingNoSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixture, failingWithFailedSolutions) {
+TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(0.0)));
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -52,20 +43,7 @@ TEST_F(FallbacksFixture, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixture, DISABLED_ConnectStageInsideFallbacks) {
-	t.add(std::make_unique<GeneratorMockup>());
-
-	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ConnectMockup>());
-	t.add(std::move(fallbacks));
-
-	t.add(std::make_unique<GeneratorMockup>());
-
-	EXPECT_TRUE(t.plan());
-	EXPECT_EQ(t.numSolutions(), 1u);
-}
-
-TEST_F(FallbacksFixture, ComputeFirstSuccessfulStageOnly) {
+TEST_F(FallbacksFixturePropagate, ComputeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -77,7 +55,7 @@ TEST_F(FallbacksFixture, ComputeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST_F(FallbacksFixture, ActiveChildReset) {
+TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts{ { 0.0, INF, 0.0 } }));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -89,4 +67,19 @@ TEST_F(FallbacksFixture, ActiveChildReset) {
 	EXPECT_TRUE(t.plan());
 	EXPECT_EQ(t.numSolutions(), 2u);
 	EXPECT_EQ(first->solutions().size(), 2u);
+}
+
+using FallbacksFixtureConnect = TaskTestBase;
+
+TEST_F(FallbacksFixtureConnect, DISABLED_ConnectStageInsideFallbacks) {
+	t.add(std::make_unique<GeneratorMockup>());
+
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	fallbacks->add(std::make_unique<ConnectMockup>());
+	t.add(std::move(fallbacks));
+
+	t.add(std::make_unique<GeneratorMockup>());
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.numSolutions(), 1u);
 }

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -17,6 +17,20 @@ using namespace moveit::task_constructor;
 
 constexpr double INF = std::numeric_limits<double>::infinity();
 
+using FallbacksFixtureGenerator = TaskTestBase;
+
+TEST_F(FallbacksFixtureGenerator, stayWithFirstSuccessful) {
+	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
+	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(INF)));
+	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(1.0)));
+	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(2.0)));
+	t.add(std::move(fallback));
+
+	EXPECT_TRUE(t.plan());
+	ASSERT_EQ(t.solutions().size(), 1u);
+	EXPECT_EQ(t.solutions().front()->cost(), 1.0);
+}
+
 using FallbacksFixturePropagate = TaskTestBase;
 
 TEST_F(FallbacksFixturePropagate, failingNoSolutions) {
@@ -89,7 +103,7 @@ TEST_F(FallbacksFixturePropagate, ActiveChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, DISABLED_ConnectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, ConnectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");


### PR DESCRIPTION
Most of them currently disabled as proposed in
https://github.com/ros-planning/moveit_task_constructor/pull/287#issuecomment-922040435