### PR TITLE
setIKFrame() supports subframes

### DIFF
--- a/core/src/stages/move_to.cpp
+++ b/core/src/stages/move_to.cpp
@@ -220,6 +220,21 @@ bool MoveTo::compute(const InterfaceState& state, planning_scene::PlanningSceneP
 			ik_pose_msg.pose.orientation.w = 1.0;
 		} else {
 			ik_pose_msg = boost::any_cast<geometry_msgs::PoseStamped>(value);
+			if (scene->knowsFrameTransform(ik_pose_msg.header.frame_id)) {
+				// get IK frame in planning frame
+				Eigen::Isometry3d ik_frame_eigen_world = scene->getFrameTransform(ik_pose_msg.header.frame_id);
+				// determine IK link from group
+				if (!(link = jmg->getOnlyOneEndEffectorTip())) {
+					solution.markAsFailure("missing ik_frame");
+					return false;
+				}
+				ik_pose_msg.header.frame_id = link->getName();
+				// get planning group tip frame in planning frame
+				Eigen::Isometry3d link_pose_eigen = scene->getCurrentState().getGlobalLinkTransform(link);
+				// get IK frame in planning group tip frame
+				Eigen::Isometry3d ik_pose_eigen = link_pose_eigen.inverse() * ik_frame_eigen_world;
+				tf::poseEigenToMsg(ik_pose_eigen, ik_pose_msg.pose);
+			}
 			if (!(link = robot_model->getLinkModel(ik_pose_msg.header.frame_id))) {
 				solution.markAsFailure("unknown link for ik_frame: " + ik_pose_msg.header.frame_id);
 				return false;


### PR DESCRIPTION
Currently only Robot links can be set as IKFrame for planning with a `moveTo` stage. 
This PR allows to use the function `setIKFrame()` with a subframe of an attached collision object. 
This allows to support [this idea](https://github.com/ros-planning/moveit/issues/2866)

TODO: 
- [ ] Be able to set the IKframe with an offset from the subframe.
- [ ] Discuss if having something similar to `move_group.setEndEffectorLink()` would be possible. Setting path (or goal) constraints with this approach based on transforming the target pose is still difficult.