### PR TITLE
define core tests through macros

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -9,29 +9,28 @@ if (CATKIN_ENABLE_TESTING)
 	add_library(gtest_utils gtest_value_printers.cpp models.cpp stage_mockups.cpp)
 	target_link_libraries(gtest_utils ${PROJECT_NAME})
 
-	catkin_add_gtest(${PROJECT_NAME}-test-stage test_stage.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-stage ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
+	macro(mtc_add_test TYPE FILE)
+	    string(REGEX REPLACE "\.cpp$" "" TEST_NAME ${FILE})
+	    string(REGEX REPLACE "_" "-" TEST_NAME ${TEST_NAME})
+	    _catkin_add_google_test(${TYPE} ${PROJECT_NAME}-${TEST_NAME} ${FILE})
+	    target_link_libraries(${PROJECT_NAME}-${TEST_NAME} ${PROJECT_NAME} ${PROJECT_NAME}_stages ${ARGN} gtest_utils gtest_main)
+	endmacro()
+	macro(mtc_add_gtest)
+	    mtc_add_test("gtest" ${ARGN})
+	endmacro()
+	macro(mtc_add_gmock)
+	    mtc_add_test("gmock" ${ARGN})
+	endmacro()
 
-	catkin_add_gtest(${PROJECT_NAME}-test-container test_container.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-container ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
+	mtc_add_gtest(test_stage.cpp)
+	mtc_add_gtest(test_container.cpp)
+	mtc_add_gtest(test_serial.cpp)
+	mtc_add_gtest(test_properties.cpp)
+	mtc_add_gtest(test_cost_terms.cpp)
 
-	catkin_add_gtest(${PROJECT_NAME}-test-serial test_serial.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-serial ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
-
-	catkin_add_gmock(${PROJECT_NAME}-test-fallback test_fallback.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-fallback ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
-
-	catkin_add_gtest(${PROJECT_NAME}-test-properties test_properties.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-properties ${PROJECT_NAME} gtest_main)
-
-	catkin_add_gmock(${PROJECT_NAME}-test-cost_queue test_cost_queue.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-cost_queue ${PROJECT_NAME} gtest_main)
-
-	catkin_add_gmock(${PROJECT_NAME}-test-interface_state test_interface_state.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-interface_state ${PROJECT_NAME} gtest_utils gtest_main)
-
-	catkin_add_gtest(${PROJECT_NAME}-test-cost_terms test_cost_terms.cpp)
-	target_link_libraries(${PROJECT_NAME}-test-cost_terms ${PROJECT_NAME} ${PROJECT_NAME}_stages gtest_utils gtest_main)
+	mtc_add_gmock(test_fallback.cpp)
+	mtc_add_gmock(test_cost_queue.cpp)
+	mtc_add_gmock(test_interface_state.cpp)
 
 	# building these integration tests works without moveit config packages
 	add_executable(pick_ur5 pick_ur5.cpp)


### PR DESCRIPTION
Maybe it makes sense to define this in an exported config,
but then why bother until someone needs it.