### PR TITLE
Some simple code simplifications

### DIFF
--- a/core/src/solvers/cartesian_path.cpp
+++ b/core/src/solvers/cartesian_path.cpp
@@ -102,15 +102,14 @@ bool CartesianPath::plan(const planning_scene::PlanningSceneConstPtr& from, cons
 	    is_valid);
 #endif
 
-	if (!trajectory.empty()) {
-		result.reset(new robot_trajectory::RobotTrajectory(sandbox_scene->getRobotModel(), jmg));
-		for (const auto& waypoint : trajectory)
-			result->addSuffixWayPoint(waypoint, 0.0);
+	assert(!trajectory.empty());  // there should be at least the start state
+	result = std::make_shared<robot_trajectory::RobotTrajectory>(sandbox_scene->getRobotModel(), jmg);
+	for (const auto& waypoint : trajectory)
+		result->addSuffixWayPoint(waypoint, 0.0);
 
-		trajectory_processing::IterativeParabolicTimeParameterization timing;
-		timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
-		                         props.get<double>("max_acceleration_scaling_factor"));
-	}
+	trajectory_processing::IterativeParabolicTimeParameterization timing;
+	timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
+	                         props.get<double>("max_acceleration_scaling_factor"));
 
 	return achieved_fraction >= props.get<double>("min_fraction");
 }

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -302,13 +302,11 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 		const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link);
 
 		double distance = 0.0;
-		if (robot_trajectory && robot_trajectory->getWayPointCount() > 0) {
-			if (use_rotation_distance) {
-				Eigen::AngleAxisd rotation(reached_pose.linear() * link_pose.linear().transpose());
-				distance = rotation.angle();
-			} else
-				distance = (reached_pose.translation() - link_pose.translation()).norm();
-		}
+		if (use_rotation_distance) {
+			Eigen::AngleAxisd rotation(reached_pose.linear() * link_pose.linear().transpose());
+			distance = rotation.angle();
+		} else
+			distance = (reached_pose.translation() - link_pose.translation()).norm();
 
 		// min_distance reached?
 		if (min_distance > 0.0) {

--- a/demo/src/pick_place_task.cpp
+++ b/demo/src/pick_place_task.cpp
@@ -429,9 +429,7 @@ bool PickPlaceTask::init() {
 		 *****************************************************/
 		{
 			auto stage = std::make_unique<stages::ModifyPlanningScene>("forbid collision (hand,object)");
-			stage->allowCollisions(
-			    object_name_,
-			    t.getRobotModel()->getJointModelGroup(hand_group_name_)->getLinkModelNamesWithCollisionGeometry(), false);
+			stage->allowCollisions(object_name_, *t.getRobotModel()->getJointModelGroup(hand_group_name_), false);
 			place->insert(std::move(stage));
 		}
 


### PR DESCRIPTION
I came across those when debugging a failing `MoveRelative` stage. Essentially we don't need the sanity check for a non-empty trajectory, because we ensure that there is always the start state in there. By the way, we access this first way point a few lines before - without a sanity check:
https://github.com/ros-planning/moveit_task_constructor/blob/5e78622e297b8420195ef83c91ed2784891e7e41/core/src/stages/move_relative.cpp#L300