### PR TITLE
Gracefully handle execution_type

### DIFF
--- a/demo/test/pick_place.test
+++ b/demo/test/pick_place.test
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <launch>
-    <include file="$(find moveit_resources_panda_moveit_config)/launch/demo.launch">
+    <include file="$(find moveit_resources_panda_moveit_config)/launch/demo.launch" pass_all_args="true">
         <arg name="use_rviz" value="false" />
-        <arg name="execution_type" value="last point" />
+        <arg name="execution_type" value="last point" /> <!-- arg name in 0.8 -->
+        <arg name="fake_execution_type" value="last point" /> <!-- arg name in 0.8.1 -->
         <env name="LD_PRELOAD" value="$(optenv PRELOAD)" />
     </include>
 


### PR DESCRIPTION
In `moveit_resources` 0.8.1 the arg `execution_type` was renamed to `fake_execution_type`.
Thus, unit tests that set the old argument [fail](https://github.com/ros-planning/moveit_task_constructor/actions/runs/1436970425).
To support both, Melodic and Noetic versions of `moveit_resources`, provide both name variants.
Additionally, disable  roslaunch's checking via `pass_all_args="true"`.

An even better approach would be to set the arg `fake_execution_type="last point"` in moveit_resources' test_environment.launch directly - the one or the other way.