### PR TITLE
Fix Pruning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
             DOCKER_RUN_OPTS: >-
               -e PRELOAD=libasan.so.5
               -e LSAN_OPTIONS="suppressions=$PWD/.github/workflows/lsan.suppressions"
-            TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1"
+            TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1 -g"
 
     env:
       CATKIN_LINT: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.11b1
     hooks:
       - id: black
 

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -150,6 +150,7 @@ public:
 	void onNewSolution(const SolutionBase& s) override;
 };
 
+class FallbacksPrivate;
 /** Plan for different alternatives in sequence.
  *
  * Try to find feasible solutions using first child. Only if this fails,
@@ -158,17 +159,23 @@ public:
  */
 class Fallbacks : public ParallelContainerBase
 {
-	mutable Stage* active_child_ = nullptr;
+	inline void replaceImpl();
 
 public:
-	Fallbacks(const std::string& name = "fallbacks") : ParallelContainerBase(name) {}
+	PRIVATE_CLASS(Fallbacks);
+	Fallbacks(const std::string& name = "fallbacks");
 
 	void reset() override;
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-	bool canCompute() const override;
-	void compute() override;
 
+protected:
+	Fallbacks(FallbacksPrivate* impl);
 	void onNewSolution(const SolutionBase& s) override;
+
+private:
+	// not needed, we directly use corresponding virtual methods of FallbacksPrivate
+	bool canCompute() const final { return false; }
+	void compute() final {}
 };
 
 class MergerPrivate;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -76,8 +76,7 @@ namespace task_constructor {
 class ContainerBasePrivate : public StagePrivate
 {
 	friend class ContainerBase;
-	friend class ConnectingPrivate;  // needs to call protected setStatus()
-	friend void swap(StagePrivate*& lhs, StagePrivate*& rhs);
+	friend class ConnectingPrivate;  // needed propagate setStatus() in newState()
 
 public:
 	using container_type = StagePrivate::container_type;
@@ -132,10 +131,11 @@ public:
 	inline const auto& externalToInternalMap() const { return internal_external_.by<EXTERNAL>(); }
 
 	/// called by a (direct) child when a solution failed
-	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to);
+	virtual void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to);
 
 protected:
 	ContainerBasePrivate(ContainerBase* me, const std::string& name);
+	ContainerBasePrivate& operator=(ContainerBasePrivate&& other);
 
 	// Set child's push interfaces: allow pushing if child requires it.
 	inline void setChildsPushBackwardInterface(StagePrivate* child) {
@@ -154,10 +154,14 @@ protected:
 	void setStatus(const Stage* creator, const InterfaceState* source, const InterfaceState* target,
 	               InterfaceState::Status status);
 
-	/// copy external_state to a child's interface and remember the link in internal_external map
+	/// Copy external_state to a child's interface and remember the link in internal_external map
 	template <Interface::Direction>
 	void copyState(Interface::iterator external, const InterfacePtr& target, Interface::UpdateFlags updated);
-	/// lift solution from internal to external level
+	// non-template version
+	void copyState(Interface::Direction dir, Interface::iterator external, const InterfacePtr& target,
+	               Interface::UpdateFlags updated);
+
+	/// Lift solution from internal to external level
 	void liftSolution(const SolutionBasePtr& solution, const InterfaceState* internal_from,
 	                  const InterfaceState* internal_to);
 
@@ -230,11 +234,90 @@ protected:
 	void validateInterfaces(const StagePrivate& child, InterfaceFlags& external, bool first = false) const;
 
 private:
-	/// notify callback for new externally received states
+	/// notify callback for new externally received interface states
 	template <typename Interface::Direction>
-	void onNewExternalState(Interface::iterator external, Interface::UpdateFlags updated);
+	void propagateStateToAllChildren(Interface::iterator external, Interface::UpdateFlags updated);
+
+	// override to customize behavior on received interface states (default: propagateStateToAllChildren())
+	virtual void initializeExternalInterfaces();
 };
 PIMPL_FUNCTIONS(ParallelContainerBase)
+
+/* The Fallbacks container needs to implement different behaviour based on its interface.
+ * Thus, we implement 3 different classes: for Generator, Propagator, and Connect-like interfaces.
+ * FallbacksPrivate is the common base class for all of them, defining the common API
+ * to be used by the Fallbacks container.
+ * The actual interface-specific class is instantiated in initializeExternalInterfaces()
+ * resp. Fallbacks::replaceImpl() when the actual interface is known.
+ * The key difference between the 3 variants is how they advance to the next job. */
+class FallbacksPrivate : public ParallelContainerBasePrivate
+{
+public:
+	FallbacksPrivate(Fallbacks* me, const std::string& name);
+	FallbacksPrivate(FallbacksPrivate&& other);
+
+	void initializeExternalInterfaces() final;
+	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
+
+	// virtual methods specific to each variant
+	virtual void onNewSolution(const SolutionBase& s);
+	virtual void reset() {}
+};
+PIMPL_FUNCTIONS(Fallbacks)
+
+/* Class shared between FallbacksPrivateGenerator and FallbacksPrivatePropagator,
+   which both have the notion of a currently active child stage */
+class FallbacksPrivateCommon : public FallbacksPrivate
+{
+public:
+	FallbacksPrivateCommon(FallbacksPrivate&& other) : FallbacksPrivate(std::move(other)) {}
+
+	/// Advance to next child
+	inline void nextChild();
+	/// Advance to the next job, assuming that the current child is exhausted on the current job.
+	virtual bool nextJob() = 0;
+
+	void reset() override;
+	bool canCompute() const override;
+	void compute() override;
+
+	container_type::const_iterator current_;  // currently active child
+};
+
+/// Fallbacks implementation for GENERATOR interface
+struct FallbacksPrivateGenerator : FallbacksPrivateCommon
+{
+	FallbacksPrivateGenerator(FallbacksPrivate&& old);
+	bool nextJob() override;
+};
+
+/// Fallbacks implementation for FORWARD or BACKWARD interface
+struct FallbacksPrivatePropagator : FallbacksPrivateCommon
+{
+	FallbacksPrivatePropagator(FallbacksPrivate&& old);
+	void reset() override;
+	void onNewSolution(const SolutionBase& s) override;
+	bool nextJob() override;
+
+	Interface::Direction dir_;  // propagation direction
+	Interface::iterator job_;  // pointer to currently processed external state
+	bool job_has_solutions_;  // flag indicating whether the current job generated solutions
+};
+
+/// Fallbacks implementation for CONNECT interface
+struct FallbacksPrivateConnect : FallbacksPrivate
+{
+	FallbacksPrivateConnect(FallbacksPrivate&& old);
+	void reset() override;
+	bool canCompute() const override;
+	void compute() override;
+	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
+
+	template <Interface::Direction dir>
+	void propagateStateUpdate(Interface::iterator external, Interface::UpdateFlags updated);
+
+	mutable container_type::const_iterator active_;  // child picked for compute()
+};
 
 class WrapperBasePrivate : public ParallelContainerBasePrivate
 {

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -156,7 +156,7 @@ protected:
 
 	/// copy external_state to a child's interface and remember the link in internal_external map
 	template <Interface::Direction>
-	void copyState(Interface::iterator external, const InterfacePtr& target, bool updated);
+	void copyState(Interface::iterator external, const InterfacePtr& target, Interface::UpdateFlags updated);
 	/// lift solution from internal to external level
 	void liftSolution(const SolutionBasePtr& solution, const InterfaceState* internal_from,
 	                  const InterfaceState* internal_to);
@@ -230,9 +230,9 @@ protected:
 	void validateInterfaces(const StagePrivate& child, InterfaceFlags& external, bool first = false) const;
 
 private:
-	/// callback for new externally received states
+	/// notify callback for new externally received states
 	template <typename Interface::Direction>
-	void onNewExternalState(Interface::iterator external, bool updated);
+	void onNewExternalState(Interface::iterator external, Interface::UpdateFlags updated);
 };
 PIMPL_FUNCTIONS(ParallelContainerBase)
 

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -148,9 +148,10 @@ protected:
 		child->setNextStarts(allowed ? pending_forward_ : InterfacePtr());
 	}
 
-	/// Set ENABLED / PRUNED status of the solution tree starting from s into given direction
+	/// Set ENABLED/PRUNED/FAILED status of a solution branch starting from target into the given direction
 	template <Interface::Direction dir>
-	void setStatus(const InterfaceState* s, InterfaceState::Status status);
+	void setStatus(const Stage* creator, const InterfaceState* source, const InterfaceState* target,
+	               InterfaceState::Status status);
 
 	/// copy external_state to a child's interface and remember the link in internal_external map
 	template <Interface::Direction>

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -148,7 +148,7 @@ protected:
 		child->setNextStarts(allowed ? pending_forward_ : InterfacePtr());
 	}
 
-	/// Set ENABLED/PRUNED/FAILED status of a solution branch starting from target into the given direction
+	/// Set ENABLED/PRUNED status of a solution branch starting from target into the given direction
 	template <Interface::Direction dir>
 	void setStatus(const Stage* creator, const InterfaceState* source, const InterfaceState* target,
 	               InterfaceState::Status status);

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -76,6 +76,7 @@ namespace task_constructor {
 class ContainerBasePrivate : public StagePrivate
 {
 	friend class ContainerBase;
+	friend class ConnectingPrivate;  // needs to call protected setStatus()
 	friend void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 public:

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -310,18 +310,15 @@ public:
 		}
 		static inline bool less(const InterfaceState::Priority& lhsA, const InterfaceState::Priority& lhsB,
 		                        const InterfaceState::Priority& rhsA, const InterfaceState::Priority& rhsB) {
-			unsigned char lhs = (lhsA.enabled() << 1) | lhsB.enabled();  // combine bits into two-digit binary number
-			unsigned char rhs = (rhsA.enabled() << 1) | rhsB.enabled();
+			bool lhs = lhsA.enabled() && lhsB.enabled();
+			bool rhs = rhsA.enabled() && rhsB.enabled();
+
 			if (lhs == rhs)  // if enabled status is identical
 				return lhsA + lhsB < rhsA + rhsB;  // compare the sums of both contributions
-			// one of the states in each pair should be enabled
-			assert(lhs != 0b00 && rhs != 0b00);
-			// both states valid (b11)
-			if (lhs == 0b11)
-				return true;
-			if (rhs == 0b11)
-				return false;
-			return lhs < rhs;  // disabled states in 1st component go before disabled states in 2nd component
+
+			// sort both-enabled pairs first
+			static_assert(true > false, "Comparing enabled states requires true > false");
+			return lhs > rhs;
 		}
 	};
 

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -340,9 +340,9 @@ private:
 	template <Interface::Direction other>
 	inline StatePair make_pair(Interface::const_iterator first, Interface::const_iterator second);
 
-	// get informed when new start or end state becomes available
+	// notify callback to get informed about newly inserted (or updated) start or end states
 	template <Interface::Direction other>
-	void newState(Interface::iterator it, bool updated);
+	void newState(Interface::iterator it, Interface::UpdateFlags updated);
 
 	// ordered list of pending state pairs
 	ordered<StatePair> pending;

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -61,7 +61,6 @@ class StagePrivate
 {
 	friend class Stage;
 	friend std::ostream& operator<<(std::ostream& os, const StagePrivate& stage);
-	friend void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 public:
 	/// container type used to store children
@@ -103,6 +102,8 @@ public:
 	/// direction-based access to pull interface
 	template <Interface::Direction dir>
 	inline InterfacePtr pullInterface();
+	// non-template version
+	inline InterfacePtr pullInterface(Interface::Direction dir) { return dir == Interface::FORWARD ? starts_ : ends_; }
 
 	/// set parent of stage
 	/// enforce only one parent exists
@@ -157,6 +158,8 @@ public:
 	void computeCost(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 
 protected:
+	StagePrivate& operator=(StagePrivate&& other);
+
 	// associated/owning Stage instance
 	Stage* me_;
 
@@ -301,6 +304,7 @@ PIMPL_FUNCTIONS(MonitoringGenerator)
 class ConnectingPrivate : public ComputeBasePrivate
 {
 	friend class Connecting;
+	friend struct FallbacksPrivateConnect;
 
 public:
 	struct StatePair : std::pair<Interface::const_iterator, Interface::const_iterator>

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -330,7 +330,7 @@ public:
 
 	// Check whether there are pending feasible states that could connect to source
 	template <Interface::Direction dir>
-	bool hasPendingOpposites(const InterfaceState* source) const;
+	bool hasPendingOpposites(const InterfaceState* source, const InterfaceState* target) const;
 
 	std::ostream& printPendingPairs(std::ostream& os = std::cerr) const;
 

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -100,17 +100,9 @@ public:
 	inline InterfaceConstPtr prevEnds() const { return prev_ends_.lock(); }
 	inline InterfaceConstPtr nextStarts() const { return next_starts_.lock(); }
 
-	/// direction-based access to pull/push interfaces
-	inline InterfacePtr& pullInterface(Interface::Direction dir) { return dir == Interface::FORWARD ? starts_ : ends_; }
-	inline InterfacePtr pushInterface(Interface::Direction dir) {
-		return dir == Interface::FORWARD ? next_starts_.lock() : prev_ends_.lock();
-	}
-	inline InterfaceConstPtr pullInterface(Interface::Direction dir) const {
-		return dir == Interface::FORWARD ? starts_ : ends_;
-	}
-	inline InterfaceConstPtr pushInterface(Interface::Direction dir) const {
-		return dir == Interface::FORWARD ? next_starts_.lock() : prev_ends_.lock();
-	}
+	/// direction-based access to pull interface
+	template <Interface::Direction dir>
+	inline InterfacePtr pullInterface();
 
 	/// set parent of stage
 	/// enforce only one parent exists
@@ -203,6 +195,15 @@ private:
 };
 PIMPL_FUNCTIONS(Stage)
 std::ostream& operator<<(std::ostream& os, const StagePrivate& stage);
+
+template <>
+inline InterfacePtr StagePrivate::pullInterface<Interface::FORWARD>() {
+	return starts_;
+}
+template <>
+inline InterfacePtr StagePrivate::pullInterface<Interface::BACKWARD>() {
+	return ends_;
+}
 
 template <>
 inline void StagePrivate::send<Interface::FORWARD>(const InterfaceState& start, InterfaceState&& end,

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -178,6 +178,7 @@ public:
 	class iterator : public base_type::iterator
 	{
 	public:
+		iterator() = default;
 		iterator(base_type::iterator other) : base_type::iterator(other) {}
 
 		InterfaceState& operator*() const noexcept { return *base_type::iterator::operator*(); }
@@ -246,6 +247,16 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio);
 std::ostream& operator<<(std::ostream& os, const Interface& interface);
+
+/// Find index of the iterator in the container. Counting starts at 1. Zero corresponds to not found.
+template <typename T>
+size_t getIndex(const T& container, typename T::const_iterator search) {
+	size_t index = 1;
+	for (typename T::const_iterator it = container.begin(), end = container.end(); it != end; ++it, ++index)
+		if (it == search)
+			return index;
+	return 0;
+}
 
 class CostTerm;
 class StagePrivate;

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -82,8 +82,8 @@ public:
 	enum Status
 	{
 		ENABLED,  // state is actively considered during planning
-		PRUNED,  // state is disabled because a required connected state failed
-		FAILED,  // state that failed, causing the whole partial solution to be disabled
+		ARMED,  // disabled state in a Connecting interface that will become re-enabled with a new opposite state
+		PRUNED,  // disabled state on a pruned solution branch
 	};
 	static const char* STATUS_COLOR[];
 
@@ -102,8 +102,6 @@ public:
 
 		inline Status status() const { return std::get<0>(*this); }
 		inline bool enabled() const { return std::get<0>(*this) == ENABLED; }
-		inline bool failed() const { return std::get<0>(*this) == FAILED; }
-		inline bool pruned() const { return std::get<0>(*this) == PRUNED; }
 
 		inline unsigned int depth() const { return std::get<1>(*this); }
 		inline double cost() const { return std::get<2>(*this); }

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -42,6 +42,7 @@
 #include <moveit/macros/class_forward.h>
 #include <moveit/task_constructor/properties.h>
 #include <moveit/task_constructor/cost_queue.h>
+#include <moveit/task_constructor/utils.h>
 #include <moveit_task_constructor_msgs/Solution.h>
 #include <visualization_msgs/MarkerArray.h>
 
@@ -199,7 +200,14 @@ public:
 		FORWARD,
 		BACKWARD,
 	};
-	using NotifyFunction = std::function<void(iterator, bool)>;
+	enum Update
+	{
+		STATUS = 1 << 0,
+		PRIORITY = 1 << 1,
+		ALL = STATUS | PRIORITY,
+	};
+	using UpdateFlags = utils::Flags<Update>;
+	using NotifyFunction = std::function<void(iterator, UpdateFlags)>;
 
 	class DisableNotify
 	{

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -210,8 +210,6 @@ public:
 
 	/// update state's priority (and call notify_ if it really has changed)
 	void updatePriority(InterfaceState* state, const InterfaceState::Priority& priority);
-	/// more efficient variant of the above, because we can skip searching the state
-	void updatePriority(Interface::iterator it, const InterfaceState::Priority& priority);
 
 private:
 	const NotifyFunction notify_;

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -140,13 +140,21 @@ public:
 
 	/// states are ordered by priority
 	inline bool operator<(const InterfaceState& other) const { return this->priority_ < other.priority_; }
+
 	inline const Priority& priority() const { return priority_; }
+	/// Update priority and call owner's notify() if possible
+	void updatePriority(const InterfaceState::Priority& priority);
+	/// Update status, but keep current priority
+	void updateStatus(Status status);
+
 	Interface* owner() const { return owner_; }
 
 private:
 	// these methods should be only called by SolutionBase::set[Start|End]State()
 	inline void addIncoming(SolutionBase* t) { incoming_trajectories_.push_back(t); }
 	inline void addOutgoing(SolutionBase* t) { outgoing_trajectories_.push_back(t); }
+	// Set new priority without updating the owning interface (USE WITH CARE)
+	inline void setPriority(const Priority& prio) { priority_ = prio; }
 
 private:
 	planning_scene::PlanningSceneConstPtr scene_;
@@ -204,6 +212,8 @@ public:
 
 	/// update state's priority (and call notify_ if it really has changed)
 	void updatePriority(InterfaceState* state, const InterfaceState::Priority& priority);
+	/// more efficient variant of the above, because we can skip searching the state
+	void updatePriority(Interface::iterator it, const InterfaceState::Priority& priority);
 
 private:
 	const NotifyFunction notify_;

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -192,8 +192,6 @@ public:
 	{
 		FORWARD,
 		BACKWARD,
-		START = FORWARD,
-		END = BACKWARD
 	};
 	using NotifyFunction = std::function<void(iterator, bool)>;
 	Interface(const NotifyFunction& notify = NotifyFunction());

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -85,6 +85,8 @@ public:
 		PRUNED,  // state is disabled because a required connected state failed
 		FAILED,  // state that failed, causing the whole partial solution to be disabled
 	};
+	static const char* STATUS_COLOR[];
+
 	/** InterfaceStates are ordered according to two values:
 	 *  Depth of interlinked trajectory parts and accumulated trajectory costs along that path.
 	 *  Preference ordering considers high-depth first and within same depth, minimal cost paths.

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -200,6 +200,18 @@ public:
 		BACKWARD,
 	};
 	using NotifyFunction = std::function<void(iterator, bool)>;
+
+	class DisableNotify
+	{
+		Interface& if_;
+		Interface::NotifyFunction old_;
+
+	public:
+		DisableNotify(Interface& i) : if_(i) { old_.swap(if_.notify_); }
+		~DisableNotify() { old_.swap(if_.notify_); }
+	};
+	friend class DisableNotify;
+
 	Interface(const NotifyFunction& notify = NotifyFunction());
 
 	/// add a new InterfaceState
@@ -210,9 +222,10 @@ public:
 
 	/// update state's priority (and call notify_ if it really has changed)
 	void updatePriority(InterfaceState* state, const InterfaceState::Priority& priority);
+	inline bool notifyEnabled() const { return static_cast<bool>(notify_); }
 
 private:
-	const NotifyFunction notify_;
+	NotifyFunction notify_;
 
 	// restrict access to some functions to ensure consistency
 	// (we need to set/unset InterfaceState::owner_)

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -51,14 +51,13 @@ namespace task_constructor {
 class TaskPrivate : public WrapperBasePrivate
 {
 	friend class Task;
+	TaskPrivate& operator=(TaskPrivate&& other);
 
 public:
 	TaskPrivate(Task* me, const std::string& ns);
+
 	const std::string& ns() const { return ns_; }
 	const ContainerBase* stages() const;
-
-protected:
-	static void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 private:
 	std::string ns_;

--- a/core/include/moveit/task_constructor/utils.h
+++ b/core/include/moveit/task_constructor/utils.h
@@ -140,8 +140,6 @@ private:
 	Int i;
 };
 
-#define DECLARE_FLAGS(Flags, Enum) using Flags = QFlags<Enum>;
-
 const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const moveit::core::RobotState& state,
                                                                   std::string frame);
 

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -53,6 +53,9 @@ using namespace std::placeholders;
 namespace moveit {
 namespace task_constructor {
 
+static void printChildrenInterfaces(const ContainerBasePrivate& container, bool success, const Stage& creator,
+                                    std::ostream& os = std::cerr);
+
 ContainerBasePrivate::ContainerBasePrivate(ContainerBase* me, const std::string& name)
   : StagePrivate(me, name)
   , required_interface_(UNKNOWN)
@@ -375,8 +378,8 @@ std::ostream& operator<<(std::ostream& os, const ContainerBase& container) {
 }
 
 // for debugging of how children interfaces evolve over time
-static void printChildrenInterfaces(const ContainerBase& container, bool success, const Stage& creator,
-                                    std::ostream& os = std::cerr) {
+static void printChildrenInterfaces(const ContainerBasePrivate& container, bool success, const Stage& creator,
+                                    std::ostream& os) {
 	static unsigned int id = 0;
 	const unsigned int width = 10;  // indentation of name
 	os << std::endl << (success ? '+' : '-') << ' ' << creator.name() << ' ';
@@ -386,7 +389,7 @@ static void printChildrenInterfaces(const ContainerBase& container, bool success
 		conn->pimpl()->printPendingPairs(os);
 	os << std::endl;
 
-	for (const auto& child : container.pimpl()->children()) {
+	for (const auto& child : container.children()) {
 		auto cimpl = child->pimpl();
 		os << std::setw(width) << std::left << child->name();
 		if (!cimpl->starts() && !cimpl->ends())

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -443,10 +443,6 @@ void SerialContainer::onNewSolution(const SolutionBase& current) {
 	// failures should never trigger this callback
 	assert(!current.isFailure());
 
-	// states of solution must be active, otherwise this would not have been computed
-	assert(current.start()->priority().enabled());
-	assert(current.end()->priority().enabled());
-
 	auto impl = pimpl();
 	const Stage* creator = current.creator();
 	auto& children = impl->children();

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -148,8 +148,8 @@ void ContainerBasePrivate::setStatus(const InterfaceState* s, InterfaceState::St
 	if (s->priority().status() == status)
 		return;  // nothing changing
 
-	// if we should disable the state, only do so when there is no enabled alternative path
-	if (status == InterfaceState::PRUNED) {
+	// Skip disabling the state, if there are alternative enabled solutions
+	if (status != InterfaceState::ENABLED) {
 		auto solution_is_enabled = [](auto&& solution) {
 			return state<opposite<dir>()>(*solution)->priority().enabled();
 		};

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -715,7 +715,7 @@ void ParallelContainerBasePrivate::validateConnectivity() const {
 template <Interface::Direction dir>
 void ParallelContainerBasePrivate::onNewExternalState(Interface::iterator external, bool updated) {
 	for (const Stage::pointer& stage : children())
-		copyState<dir>(external, stage->pimpl()->pullInterface(dir), updated);
+		copyState<dir>(external, stage->pimpl()->pullInterface<dir>(), updated);
 }
 
 ParallelContainerBase::ParallelContainerBase(ParallelContainerBasePrivate* impl) : ContainerBase(impl) {}

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -775,11 +775,8 @@ void ConnectingPrivate::compute() {
 }
 
 std::ostream& ConnectingPrivate::printPendingPairs(std::ostream& os) const {
-	static const char* red = "\033[31m";
-	static const char* reset = "\033[m";
+	const char* reset = InterfaceState::STATUS_COLOR[3];
 	for (const auto& candidate : pending) {
-		if (!candidate.first->priority().enabled() || !candidate.second->priority().enabled())
-			os << " " << red;
 		// find indeces of InterfaceState pointers in start/end Interfaces
 		unsigned int first = 0, second = 0;
 		std::find_if(starts()->begin(), starts()->end(), [&](const InterfaceState* s) {
@@ -790,9 +787,9 @@ std::ostream& ConnectingPrivate::printPendingPairs(std::ostream& os) const {
 			++second;
 			return &*candidate.second == s;
 		});
-		os << first << ":" << second << " ";
+		os << InterfaceState::STATUS_COLOR[candidate.first->priority().status()] << first << reset << ":"
+		   << InterfaceState::STATUS_COLOR[candidate.second->priority().status()] << second << reset << " ";
 	}
-	os << reset;
 	return os;
 }
 

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -722,7 +722,7 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 				// but don't re-enable states that are marked DISABLED
 				// https://github.com/ros-planning/moveit_task_constructor/pull/221
 				if (oit->priority().status() == InterfaceState::Status::FAILED)
-					oit->owner()->updatePriority(&*oit,
+					oit->owner()->updatePriority(oit,
 					                             InterfaceState::Priority(oit->priority(), InterfaceState::Status::ENABLED));
 				pending.insert(make_pair<other>(it, oit));
 			}

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -713,9 +713,9 @@ ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(In
 template <Interface::Direction dir>
 void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 	auto parent_pimpl = parent()->pimpl();
-	Interface::DisableNotify disable_source_interface(*pullInterface(dir));
+	Interface::DisableNotify disable_source_interface(*pullInterface<dir>());
 	if (updated) {
-		if (pullInterface(opposite<dir>())->notifyEnabled())  // suppress recursive loop
+		if (pullInterface<opposite<dir>()>()->notifyEnabled())  // suppress recursive loop
 		{
 			// If status has changed, propagate the update to the opposite side
 			auto status = it->priority().status();
@@ -747,7 +747,7 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 		pending.sort();
 	} else {  // new state: insert all pairs with other interface
 		assert(it->priority().enabled());  // new solutions are feasible, aren't they?
-		InterfacePtr other_interface = pullInterface(dir);
+		InterfacePtr other_interface = pullInterface<dir>();
 		bool have_enabled_opposites = false;
 		for (Interface::iterator oit = other_interface->begin(), oend = other_interface->end(); oit != oend; ++oit) {
 			if (!static_cast<Connecting*>(me_)->compatible(*it, *oit))

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -711,11 +711,12 @@ ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(In
 
 // TODO: bool updated -> uint_8 updated (bitfield of PRIORITY | STATUS)
 template <Interface::Direction dir>
-void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
+void ConnectingPrivate::newState(Interface::iterator it, Interface::UpdateFlags updated) {
 	auto parent_pimpl = parent()->pimpl();
 	Interface::DisableNotify disable_source_interface(*pullInterface<dir>());
 	if (updated) {
-		if (pullInterface<opposite<dir>()>()->notifyEnabled())  // suppress recursive loop
+		if (updated.testFlag(Interface::STATUS) &&  // only perform these costly operations if needed
+		    pullInterface<opposite<dir>()>()->notifyEnabled())  // suppress recursive loop
 		{
 			// If status has changed, propagate the update to the opposite side
 			auto status = it->priority().status();

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -712,12 +712,7 @@ ConnectingPrivate::StatePair ConnectingPrivate::make_pair<Interface::FORWARD>(In
 template <Interface::Direction other>
 void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 	if (updated) {  // many pairs might be affected: resort
-		if (it->priority().pruned())
-			// remove all pending pairs involving this state
-			pending.remove_if([it](const StatePair& p) { return std::get<opposite<other>()>(p) == it; });
-		else
-			// TODO(v4hn): If a state becomes reenabled, this skips all previously removed pairs, right?
-			pending.sort();
+		pending.sort();
 	} else {  // new state: insert all pairs with other interface
 		assert(it->priority().enabled());  // new solutions are feasible, aren't they?
 		InterfacePtr other_interface = pullInterface(other);
@@ -752,7 +747,7 @@ inline bool ConnectingPrivate::hasPendingOpposites(const InterfaceState* source)
 			return true;
 
 		// early stopping when only infeasible pairs are to come
-		if (!std::get<0>(candidate)->priority().enabled())
+		if (!std::get<0>(candidate)->priority().enabled() || !std::get<1>(candidate)->priority().enabled())
 			break;
 	}
 	return false;

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -718,10 +718,10 @@ void ConnectingPrivate::newState(Interface::iterator it, bool updated) {
 		InterfacePtr other_interface = pullInterface(other);
 		for (Interface::iterator oit = other_interface->begin(), oend = other_interface->end(); oit != oend; ++oit) {
 			if (static_cast<Connecting*>(me_)->compatible(*it, *oit)) {
-				// re-enable the opposing state oit if its status is FAILED,
+				// re-enable the opposing state oit if its status is ARMED,
 				// but don't re-enable states that are marked DISABLED
 				// https://github.com/ros-planning/moveit_task_constructor/pull/221
-				if (oit->priority().status() == InterfaceState::Status::FAILED)
+				if (oit->priority().status() == InterfaceState::Status::ARMED)
 					oit->owner()->updatePriority(oit,
 					                             InterfaceState::Priority(oit->priority(), InterfaceState::Status::ENABLED));
 				pending.insert(make_pair<other>(it, oit));

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -161,8 +161,8 @@ std::ostream& operator<<(std::ostream& os, const Interface& interface) {
 }
 const char* InterfaceState::STATUS_COLOR[] = {
 	"\033[32m",  // ENABLED - green
-	"\033[33m",  // PRUNED - yellow
-	"\033[31m",  // FAILED - red
+	"\033[33m",  // ARMED - yellow
+	"\033[31m",  // PRUNED - red
 	"\033[m"  // reset
 };
 std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio) {

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -144,15 +144,16 @@ std::ostream& operator<<(std::ostream& os, const Interface& interface) {
 		os << istate->priority() << "  ";
 	return os;
 }
+const char* InterfaceState::STATUS_COLOR[] = {
+	"\033[32m",  // ENABLED - green
+	"\033[33m",  // PRUNED - yellow
+	"\033[31m",  // FAILED - red
+	"\033[m"  // reset
+};
 std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio) {
 	// maps InterfaceState::Status values to output (color-changing) prefix
-	static const char* prefix[] = {
-		"\033[32me:",  // ENABLED - green
-		"\033[33md:",  // PRUNED - yellow
-		"\033[31mf:",  // FAILED - red
-	};
-	static const char* color_reset = "\033[m";
-	os << prefix[prio.status()] << prio.depth() << ":" << prio.cost() << color_reset;
+	os << InterfaceState::STATUS_COLOR[prio.status()] << prio.depth() << ":" << prio.cost()
+	   << InterfaceState::STATUS_COLOR[3];
 	return os;
 }
 

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -142,11 +142,8 @@ void Interface::updatePriority(InterfaceState* state, const InterfaceState::Prio
 
 	auto it = std::find(begin(), end(), state);  // find iterator to state
 	assert(it != end());  // state should be part of this interface
-	updatePriority(it, priority);
-}
 
-void Interface::updatePriority(Interface::iterator it, const InterfaceState::Priority& priority) {
-	it->priority_ = priority;  // update priority
+	state->priority_ = priority;  // update priority
 	update(it);  // update position in ordered list
 	if (notify_)
 		notify_(it, true);  // notify callback

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -83,6 +83,9 @@ bool InterfaceState::Priority::operator<(const InterfaceState::Priority& other) 
 }
 
 void InterfaceState::updatePriority(const InterfaceState::Priority& priority) {
+	// Never overwrite ARMED with PRUNED: PRUNED => !ARMED
+	assert(priority.status() != InterfaceState::Status::PRUNED || priority_.status() != InterfaceState::Status::ARMED);
+
 	if (owner()) {
 		owner()->updatePriority(this, priority);
 	} else {

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -82,6 +82,17 @@ bool InterfaceState::Priority::operator<(const InterfaceState::Priority& other) 
 	return cost() < other.cost();
 }
 
+void InterfaceState::updatePriority(const InterfaceState::Priority& priority) {
+	if (owner()) {
+		owner()->updatePriority(this, priority);
+	} else {
+		setPriority(priority);
+	}
+}
+void InterfaceState::updateStatus(Status status) {
+	updatePriority(InterfaceState::Priority(priority_, status));
+}
+
 Interface::Interface(const Interface::NotifyFunction& notify) : notify_(notify) {}
 
 // Announce a new InterfaceState
@@ -131,7 +142,11 @@ void Interface::updatePriority(InterfaceState* state, const InterfaceState::Prio
 
 	auto it = std::find(begin(), end(), state);  // find iterator to state
 	assert(it != end());  // state should be part of this interface
-	state->priority_ = priority;  // update priority
+	updatePriority(it, priority);
+}
+
+void Interface::updatePriority(Interface::iterator it, const InterfaceState::Priority& priority) {
+	it->priority_ = priority;  // update priority
 	update(it);  // update position in ordered list
 	if (notify_)
 		notify_(it, true);  // notify callback

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -586,10 +586,6 @@ TEST(Task, move) {
 	Task t2 = std::move(t1);
 	EXPECT_EQ(t2.stages()->numChildren(), 2u);
 	EXPECT_EQ(t1.stages()->numChildren(), 0u);  // NOLINT(clang-analyzer-cplusplus.Move)
-
-	t1 = std::move(t2);
-	EXPECT_EQ(t1.stages()->numChildren(), 2u);
-	EXPECT_EQ(t2.stages()->numChildren(), 0u);  // NOLINT(clang-analyzer-cplusplus.Move)
 }
 
 TEST(Task, reuse) {

--- a/core/test/test_cost_queue.cpp
+++ b/core/test/test_cost_queue.cpp
@@ -5,6 +5,10 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock-matchers.h>
 
+#ifndef TYPED_TEST_SUITE
+#define TYPED_TEST_SUITE(SUITE, TYPES) TYPED_TEST_CASE(SUITE, TYPES)
+#endif
+
 namespace mtc = moveit::task_constructor;
 
 // type-trait functions for OrderedTest<T>
@@ -62,11 +66,7 @@ protected:
 };
 // set of template types to test for
 using TypeInstances = ::testing::Types<int, int*, mtc::SolutionBasePtr, mtc::SolutionBaseConstPtr>;
-#ifdef TYPED_TEST_SUITE
 TYPED_TEST_SUITE(ValueOrPointeeLessTest, TypeInstances);
-#else
-TYPED_TEST_CASE(ValueOrPointeeLessTest, TypeInstances);
-#endif
 TYPED_TEST(ValueOrPointeeLessTest, less) {
 	EXPECT_TRUE(this->less(2, 3));
 	EXPECT_FALSE(this->less(1, 1));
@@ -105,11 +105,7 @@ protected:
 		SCOPED_TRACE("pushAndValidate(" #cost ", " #__VA_ARGS__ ")"); \
 		this->pushAndValidate(cost, __VA_ARGS__);                     \
 	}
-#ifdef TYPED_TEST_SUITE
 TYPED_TEST_SUITE(OrderedTest, TypeInstances);
-#else
-TYPED_TEST_CASE(OrderedTest, TypeInstances);
-#endif
 TYPED_TEST(OrderedTest, sorting) {
 	pushAndValidate(2, { 2 });
 	pushAndValidate(1, { 1, 2 });

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -17,7 +17,7 @@ using namespace moveit::task_constructor;
 
 using FallbacksFixtureGenerator = TaskTestBase;
 
-TEST_F(FallbacksFixtureGenerator, DISABLED_stayWithFirstSuccessful) {
+TEST_F(FallbacksFixtureGenerator, stayWithFirstSuccessful) {
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(INF)));
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(1.0)));
@@ -55,7 +55,7 @@ TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStageOnly) {
+TEST_F(FallbacksFixturePropagate, computeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -67,7 +67,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStagePerSolutionOnly) {
+TEST_F(FallbacksFixturePropagate, computeFirstSuccessfulStagePerSolutionOnly) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0 })));
 	// duplicate generator solutions with resulting costs: 4, 2 | 3, 1
 	t.add(std::make_unique<ForwardMockup>(PredefinedCosts({ 2.0, 0.0, 2.0, 0.0 }), 2));
@@ -78,10 +78,11 @@ TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStagePerSolutio
 	t.add(std::move(fallbacks));
 
 	EXPECT_TRUE(t.plan());
-	EXPECT_COSTS(t.solutions(), testing::ElementsAre(113, 124, 211, 222));
+	EXPECT_COSTS(t.solutions(), testing::ElementsAre(113, 124, 212, 221));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_UpdateSolutionOrder) {
+// requires individual job control in Fallbacks's children
+TEST_F(FallbacksFixturePropagate, DISABLED_updateSolutionOrder) {
 	t.add(std::make_unique<BackwardMockup>(PredefinedCosts({ 10.0, 0.0 })));
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 	// available solutions (sorted) in individual runs of fallbacks: 1 | 11, 2 | 2, 11
@@ -100,7 +101,8 @@ TEST_F(FallbacksFixturePropagate, DISABLED_UpdateSolutionOrder) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(2));  // expecting less costly solution as result
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_MultipleActivePendingStates) {
+// requires individual job control in Fallbacks's children
+TEST_F(FallbacksFixturePropagate, DISABLED_multipleActivePendingStates) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0, 3.0 })));
 	// use a fallback container to delay computation: the 1st child never succeeds, but only the 2nd
 	auto inner = std::make_unique<Fallbacks>("Inner");
@@ -117,7 +119,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_MultipleActivePendingStates) {
 	// check that first solution is not marked as pruned
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions) {
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -129,7 +131,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions2) {
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -141,7 +143,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions2) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ActiveChildReset) {
+TEST_F(FallbacksFixturePropagate, activeChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, INF, 3.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -159,29 +161,16 @@ TEST_F(FallbacksFixturePropagate, DISABLED_ActiveChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, DISABLED_ConnectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts::constant(0.0)));
+	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts({ 0.0, 0.0, INF, 0.0 })));
 	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts::constant(100.0)));
 	t.add(std::move(fallbacks));
 
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 10.0, 20.0 })));
 
 	EXPECT_TRUE(t.plan());
-	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 21, 22));
-}
-
-int main(int argc, char** argv) {
-	for (int i = 1; i < argc; ++i) {
-		if (strcmp(argv[i], "--debug") == 0) {
-			if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
-				ros::console::notifyLoggerLevelsChanged();
-			break;
-		}
-	}
-
-	testing::InitGoogleTest(&argc, argv);
-	return RUN_ALL_TESTS();
+	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 22, 121));
 }

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -87,8 +87,11 @@ TEST(StatePairs, compare) {
 	EXPECT_TRUE(pair(Prio(1, 1), Prio(1, 1)) < pair(Prio(1, 0), Prio(0, 0)));
 
 	auto good = InterfaceState::Status::ENABLED;
-	auto bad = InterfaceState::Status::FAILED;
-	EXPECT_TRUE(pair(good, good) < pair(good, bad));
-	EXPECT_TRUE(pair(good, good) < pair(bad, good));
-	EXPECT_TRUE(pair(bad, good) < pair(good, bad));
+	auto good_good = pair(Prio(0, 10, good), Prio(0, 0, good));
+	ASSERT_TRUE(good_good > pair(good, good));  // a bad status should reverse this relation
+	for (auto bad : { InterfaceState::Status::FAILED, InterfaceState::Status::PRUNED }) {
+		EXPECT_TRUE(good_good < pair(bad, good));
+		EXPECT_TRUE(good_good < pair(good, bad));
+		EXPECT_TRUE(good_good < pair(bad, bad));
+	}
 }

--- a/core/test/test_interface_state.cpp
+++ b/core/test/test_interface_state.cpp
@@ -19,7 +19,7 @@ TEST(InterfaceStatePriority, compare) {
 	EXPECT_TRUE(Prio(1, 42) < Prio(0, 0));
 	EXPECT_TRUE(Prio(0, 0) < Prio(0, 42));  // at same depth, higher cost is larger
 
-	auto dstart = InterfaceState::Status::FAILED;
+	auto dstart = InterfaceState::Status::ARMED;
 	EXPECT_TRUE(Prio(0, 0, dstart) == Prio(0, 0, dstart));
 	EXPECT_TRUE(Prio(1, 0, dstart) < Prio(0, 0, dstart));
 	EXPECT_TRUE(Prio(1, 42, dstart) < Prio(0, 0, dstart));
@@ -68,7 +68,7 @@ TEST(Interface, update) {
 	i.updatePriority(*i.rbegin(), Prio(5, 0.0));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 5, 3 }));
 
-	i.updatePriority(*i.begin(), Prio(6, 0, InterfaceState::Status::FAILED));
+	i.updatePriority(*i.begin(), Prio(6, 0, InterfaceState::Status::ARMED));
 	EXPECT_THAT(i.depths(), ::testing::ElementsAreArray({ 3, 6 }));
 }
 
@@ -89,7 +89,7 @@ TEST(StatePairs, compare) {
 	auto good = InterfaceState::Status::ENABLED;
 	auto good_good = pair(Prio(0, 10, good), Prio(0, 0, good));
 	ASSERT_TRUE(good_good > pair(good, good));  // a bad status should reverse this relation
-	for (auto bad : { InterfaceState::Status::FAILED, InterfaceState::Status::PRUNED }) {
+	for (auto bad : { InterfaceState::Status::ARMED, InterfaceState::Status::PRUNED }) {
 		EXPECT_TRUE(good_good < pair(bad, good));
 		EXPECT_TRUE(good_good < pair(good, bad));
 		EXPECT_TRUE(good_good < pair(bad, bad));

--- a/core/test/test_pruning.cpp
+++ b/core/test/test_pruning.cpp
@@ -91,6 +91,7 @@ TYPED_TEST(PruningContainerTests, ConnectReactivatesPrunedPaths) {
 }
 
 TEST_F(Pruning, ConnectConnectForward) {
+	add(t, new BackwardMockup());
 	add(t, new GeneratorMockup());
 	auto c1 = add(t, new ConnectMockup({ INF, 0, 0 }));  // 1st attempt is a failue
 	add(t, new GeneratorMockup({ 0, 10, 20 }));
@@ -112,6 +113,7 @@ TEST_F(Pruning, ConnectConnectForward) {
 }
 
 TEST_F(Pruning, ConnectConnectBackward) {
+	add(t, new BackwardMockup());
 	add(t, new GeneratorMockup({ 1, 2, 3 }));
 	auto c1 = add(t, new ConnectMockup());
 	add(t, new BackwardMockup());

--- a/core/test/test_pruning.cpp
+++ b/core/test/test_pruning.cpp
@@ -8,6 +8,10 @@
 
 #include <gtest/gtest.h>
 
+#ifndef TYPED_TEST_SUITE
+#define TYPED_TEST_SUITE(SUITE, TYPES) TYPED_TEST_CASE(SUITE, TYPES)
+#endif
+
 using namespace moveit::task_constructor;
 
 using Pruning = TaskTestBase;
@@ -38,6 +42,52 @@ TEST_F(Pruning, PruningMultiForward) {
 	// the earlier partial solution just because they share stage solutions
 	ASSERT_EQ(t.solutions().size(), 1u);
 	EXPECT_EQ((*t.solutions().begin())->cost(), 0u);
+}
+
+// The 2nd failing FW attempt would prune the path through CON,
+// but shouldn't because there exist two more GEN2 solutions
+TEST_F(Pruning, NoPruningIfAlternativesExist) {
+	add(t, new GeneratorMockup(PredefinedCosts({ 0.0 })));
+	add(t, new ConnectMockup());
+	add(t, new GeneratorMockup(std::list<double>{ 0, 10, 20, 30 }, 2));
+	add(t, new ForwardMockup({ INF, INF, 0.0, INF }));
+
+	t.plan();
+
+	EXPECT_EQ(t.solutions().size(), 1u);
+}
+
+TEST_F(Pruning, ConnectReactivatesPrunedPaths) {
+	add(t, new BackwardMockup);
+	add(t, new GeneratorMockup({ 0 }));
+	add(t, new ConnectMockup());
+	// the solution here should re-activate the initially pruned backward path
+	add(t, new GeneratorMockup({ 0 }));
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.solutions().size(), 1u);
+}
+
+// same as before, but wrapping Connect into a container
+template <typename T>
+struct PruningContainerTests : public Pruning
+{
+	void test() {
+		add(t, new BackwardMockup);
+		add(t, new GeneratorMockup({ 0 }));
+		auto c = new T();
+		add(*c, new ConnectMockup());
+		add(t, c);
+		add(t, new GeneratorMockup({ 0 }));
+
+		EXPECT_TRUE(t.plan());
+		EXPECT_EQ(t.solutions().size(), 1u);
+	}
+};
+using ContainerTypes = ::testing::Types<SerialContainer, Fallbacks>;
+TYPED_TEST_SUITE(PruningContainerTests, ContainerTypes);
+TYPED_TEST(PruningContainerTests, ConnectReactivatesPrunedPaths) {
+	this->test();
 }
 
 TEST_F(Pruning, ConnectConnectForward) {

--- a/core/test/test_pruning.cpp
+++ b/core/test/test_pruning.cpp
@@ -46,7 +46,7 @@ TEST_F(Pruning, PruningMultiForward) {
 
 // The 2nd failing FW attempt would prune the path through CON,
 // but shouldn't because there exist two more GEN2 solutions
-TEST_F(Pruning, NoPruningIfAlternativesExist) {
+TEST_F(Pruning, DISABLED_NoPruningIfAlternativesExist) {
 	add(t, new GeneratorMockup(PredefinedCosts({ 0.0 })));
 	add(t, new ConnectMockup());
 	add(t, new GeneratorMockup(std::list<double>{ 0, 10, 20, 30 }, 2));
@@ -84,7 +84,7 @@ struct PruningContainerTests : public Pruning
 		EXPECT_EQ(t.solutions().size(), 1u);
 	}
 };
-using ContainerTypes = ::testing::Types<SerialContainer, Fallbacks>;
+using ContainerTypes = ::testing::Types<SerialContainer>;  // TODO: fails for Fallbacks!
 TYPED_TEST_SUITE(PruningContainerTests, ContainerTypes);
 TYPED_TEST(PruningContainerTests, ConnectReactivatesPrunedPaths) {
 	this->test();

--- a/core/test/test_pruning.cpp
+++ b/core/test/test_pruning.cpp
@@ -46,7 +46,7 @@ TEST_F(Pruning, PruningMultiForward) {
 
 // The 2nd failing FW attempt would prune the path through CON,
 // but shouldn't because there exist two more GEN2 solutions
-TEST_F(Pruning, DISABLED_NoPruningIfAlternativesExist) {
+TEST_F(Pruning, NoPruningIfAlternativesExist) {
 	add(t, new GeneratorMockup(PredefinedCosts({ 0.0 })));
 	add(t, new ConnectMockup());
 	add(t, new GeneratorMockup(std::list<double>{ 0, 10, 20, 30 }, 2));

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -50,6 +50,7 @@ demo(cartesian)
 demo(modular)
 demo(alternative_path_costs)
 demo(ik_clearance_cost)
+demo(fallbacks_move_to)
 
 demo(pick_place_demo)
 target_link_libraries(${PROJECT_NAME}_pick_place_demo ${PROJECT_NAME}_pick_place_task)

--- a/demo/src/fallbacks_move_to.cpp
+++ b/demo/src/fallbacks_move_to.cpp
@@ -1,0 +1,142 @@
+#include <ros/ros.h>
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <moveit/task_constructor/moveit_compat.h>
+
+#include <moveit/task_constructor/task.h>
+#include <moveit/task_constructor/container.h>
+#include <moveit/task_constructor/solvers/cartesian_path.h>
+#include <moveit/task_constructor/solvers/pipeline_planner.h>
+#include <moveit/task_constructor/stages.h>
+
+constexpr double TAU = 2 * M_PI;
+
+using namespace moveit::task_constructor;
+
+/** CurrentState -> Fallbacks( MoveTo<CartesianPath>, MoveTo<PTP>, MoveTo<OMPL> )*/
+int main(int argc, char** argv) {
+	ros::init(argc, argv, "mtc_tutorial");
+
+	ros::AsyncSpinner spinner{ 1 };
+	spinner.start();
+
+	// setup Task
+	Task t;
+	t.loadRobotModel();
+	const moveit::core::RobotModelConstPtr robot{ t.getRobotModel() };
+
+	assert(robot->getName() == "panda");
+
+	// setup solvers
+	auto cartesian = std::make_shared<solvers::CartesianPath>();
+	cartesian->setJumpThreshold(2.0);
+
+	const auto ptp = []() {
+		auto pp{ std::make_shared<solvers::PipelinePlanner>("pilz_industrial_motion_planner") };
+		pp->setPlannerId("PTP");
+		return pp;
+	}();
+
+	const auto rrtconnect = []() {
+		auto pp{ std::make_shared<solvers::PipelinePlanner>("ompl") };
+		pp->setPlannerId("RRTConnectkConfigDefault");
+		return pp;
+	}();
+
+	// target state for Task
+	std::map<std::string, double> target_state;
+	robot->getJointModelGroup("panda_arm")->getVariableDefaultPositions("ready", target_state);
+	target_state["panda_joint1"] = +TAU / 8;
+
+	// define initial scenes
+	auto initial_scene{ std::make_shared<planning_scene::PlanningScene>(robot) };
+	initial_scene->getCurrentStateNonConst().setToDefaultValues(robot->getJointModelGroup("panda_arm"), "ready");
+
+	auto initial_alternatives = std::make_unique<Alternatives>("initial states");
+
+	{
+		// can reach target with Cartesian motion
+		auto fixed{ std::make_unique<stages::FixedState>("current state") };
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({ { "panda_joint1", -TAU / 8 } });
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+	{
+		// Cartesian motion to target is impossible, but PTP is collision-free
+		auto fixed{ std::make_unique<stages::FixedState>("current state") };
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({
+		    { "panda_joint1", +TAU / 8 },
+		    { "panda_joint4", 0 },
+		});
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+	{
+		// Cartesian and PTP motion to target would be in collision
+		auto fixed = std::make_unique<stages::FixedState>("current state");
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({ { "panda_joint1", -TAU / 8 } });
+		scene->processCollisionObjectMsg([]() {
+			moveit_msgs::CollisionObject co;
+			co.id = "box";
+			co.header.frame_id = "panda_link0";
+			co.operation = co.ADD;
+#if MOVEIT_HAS_OBJECT_POSE
+			auto& pose{ co.pose };
+#else
+			co.primitive_poses.emplace_back();
+			auto& pose{ co.primitive_poses[0] };
+#endif
+			pose = []() {
+				geometry_msgs::Pose p;
+				p.position.x = 0.3;
+				p.position.y = 0.0;
+				p.position.z = 0.64 / 2;
+				p.orientation.w = 1.0;
+				return p;
+			}();
+			co.primitives.push_back([]() {
+				shape_msgs::SolidPrimitive sp;
+				sp.type = sp.BOX;
+				sp.dimensions = { 0.2, 0.05, 0.64 };
+				return sp;
+			}());
+			return co;
+		}());
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+
+	t.add(std::move(initial_alternatives));
+
+	// fallbacks to reach target_state
+	auto fallbacks = std::make_unique<Fallbacks>("move to other side");
+
+	auto add_to_fallbacks{ [&](auto& solver, auto& name) {
+		auto move_to = std::make_unique<stages::MoveTo>(name, solver);
+		move_to->setGroup("panda_arm");
+		move_to->setGoal(target_state);
+		fallbacks->add(std::move(move_to));
+	} };
+	add_to_fallbacks(cartesian, "Cartesian path");
+	add_to_fallbacks(ptp, "PTP path");
+	add_to_fallbacks(rrtconnect, "RRT path");
+
+	t.add(std::move(fallbacks));
+
+	try {
+		t.init();
+		std::cout << t << std::endl;
+		t.plan();
+	} catch (const InitStageException& e) {
+		std::cout << e << std::endl;
+	}
+
+	ros::waitForShutdown();
+
+	return 0;
+}

--- a/visualization/motion_planning_tasks/src/local_task_model.cpp
+++ b/visualization/motion_planning_tasks/src/local_task_model.cpp
@@ -65,7 +65,7 @@ QModelIndex LocalTaskModel::index(Node* n) const {
 	const ContainerBase* parent = n->parent();
 
 	// the internal pointer refers to n
-	int row = 0;
+	size_t row = 0;
 	auto find_row = [n, &row](const Stage& child, int /* depth */) -> bool {
 		if (&child == n)
 			return false;  // found, don't continue traversal


### PR DESCRIPTION
Building on some new (failing) tests introduced by @JafarAbdi and @v4hn, this PR aims to improve (and eventually fix) pruning.
This follows these general ideas:

- If a planning stage fails in a linear pipeline, we can skip all remaining planning stages as well (cols of _left-most_ block)
- However, we need to keep the states in the interfaces as we might re-enable a path later on (left-most cols of _middle_ block)
- A new CONNECT state becomes disabled too (together with its connected branch) (right col of _middle_ block)
- We shouldn‘t prune if there are alternative solutions (_right_ block)

![image](https://user-images.githubusercontent.com/5376030/142723706-19eab26d-1b70-48cd-ab3e-399299a1825e.png)