### PR TITLE
Stage::reset() should reset total_compute_time_

### DIFF
--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -316,6 +316,7 @@ void Stage::reset() {
 	impl->next_starts_.reset();
 	// reset inherited properties
 	impl->properties_.reset();
+	impl->total_compute_time_ = std::chrono::duration<double>::zero();
 }
 
 void Stage::init(const moveit::core::RobotModelConstPtr& /* robot_model */) {


### PR DESCRIPTION
@JafarAbdi, I think you introduced `total_compute_time_`. Did you omit to reset `total_compute_time_` on purpose or was it just missed? I would expect that the total compute time count restarts after a `reset()`.