### PR TITLE
Fallbacks reworked: Factorize FallbacksPrivate into 3 separate classes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
             DOCKER_RUN_OPTS: >-
               -e PRELOAD=libasan.so.5
               -e LSAN_OPTIONS="suppressions=$PWD/.github/workflows/lsan.suppressions"
-            TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1"
+            TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1 -g"
 
     env:
       CATKIN_LINT: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.11b1
     hooks:
       - id: black
 

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -159,6 +159,8 @@ class FallbacksPrivate;
  */
 class Fallbacks : public ParallelContainerBase
 {
+	inline void replaceImpl();
+
 public:
 	PRIVATE_CLASS(Fallbacks);
 	Fallbacks(const std::string& name = "fallbacks");

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -167,12 +167,15 @@ public:
 
 	void reset() override;
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
-	bool canCompute() const override;
-	void compute() override;
 
 protected:
 	Fallbacks(FallbacksPrivate* impl);
 	void onNewSolution(const SolutionBase& s) override;
+
+private:
+	// not needed, we directly use corresponding virtual methods of FallbacksPrivate
+	bool canCompute() const final { return false; }
+	void compute() final {}
 };
 
 class MergerPrivate;

--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -150,6 +150,7 @@ public:
 	void onNewSolution(const SolutionBase& s) override;
 };
 
+class FallbacksPrivate;
 /** Plan for different alternatives in sequence.
  *
  * Try to find feasible solutions using first child. Only if this fails,
@@ -158,16 +159,17 @@ public:
  */
 class Fallbacks : public ParallelContainerBase
 {
-	mutable Stage* active_child_ = nullptr;
-
 public:
-	Fallbacks(const std::string& name = "fallbacks") : ParallelContainerBase(name) {}
+	PRIVATE_CLASS(Fallbacks);
+	Fallbacks(const std::string& name = "fallbacks");
 
 	void reset() override;
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 	bool canCompute() const override;
 	void compute() override;
 
+protected:
+	Fallbacks(FallbacksPrivate* impl);
 	void onNewSolution(const SolutionBase& s) override;
 };
 

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -76,7 +76,6 @@ namespace task_constructor {
 class ContainerBasePrivate : public StagePrivate
 {
 	friend class ContainerBase;
-	friend void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 public:
 	using container_type = StagePrivate::container_type;
@@ -135,6 +134,7 @@ public:
 
 protected:
 	ContainerBasePrivate(ContainerBase* me, const std::string& name);
+	ContainerBasePrivate& operator=(ContainerBasePrivate&& other);
 
 	// Set child's push interfaces: allow pushing if child requires it.
 	inline void setChildsPushBackwardInterface(StagePrivate* child) {

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -233,7 +233,7 @@ protected:
 
 	/// callback for new externally received states
 	template <typename Interface::Direction>
-	void propagateStateToChildren(Interface::iterator external, bool updated);
+	void propagateStateToAllChildren(Interface::iterator external, bool updated);
 
 private:
 	// override for custom behavior on received interface states

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -261,8 +261,11 @@ public:
 	// virtual method specific to each variant
 	/// Advance to the next job, assuming that the current child is exhausted on the current job.
 	virtual bool nextJob() { return false; }
+	/// Reset data structures
+	virtual void reset();
 
 	container_type::const_iterator current_;  // currently active child generator
+	bool job_has_solutions_;  // flag indicating whether the current job generated solutions
 };
 PIMPL_FUNCTIONS(Fallbacks)
 
@@ -278,7 +281,7 @@ struct FallbacksPrivatePropagator : FallbacksPrivate
 {
 	FallbacksPrivatePropagator(FallbacksPrivate&& old);
 	bool nextJob() override;
-	bool jobHasSolutions() const;
+	void reset() override;
 
 	Interface::Direction dir_;  // propagation direction
 	Interface::iterator job_;  // pointer to currently processed external state

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -250,15 +250,18 @@ protected:
 	void computeFromExternal();
 	struct ExternalState
 	{
+		ExternalState() = default;
 		ExternalState(Interface::iterator e, Interface::Direction d, container_type::const_iterator c)
 		  : external_state(e), dir(d), stage(c) {}
 
 		Interface::iterator external_state;
 		Interface::Direction dir;
 		container_type::const_iterator stage;
+
+		inline bool operator<(const ExternalState& other) const { return *external_state < *other.external_state; }
 	};
-	std::deque<ExternalState> pending_states_;
-	StagePrivate* current_stage_;
+	ordered<ExternalState> pending_states_;
+	ExternalState current_external_state_;
 
 	void computeGenerate();
 	container_type::const_iterator current_generator_;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -272,6 +272,8 @@ private:
 	template <typename Interface::Direction>
 	void onNewExternalState(Interface::iterator external, bool updated);
 	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
+	// print pending states for debugging
+	void printPending(const char* comment = "pending: ") const;
 };
 PIMPL_FUNCTIONS(Fallbacks)
 

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -227,10 +227,13 @@ public:
 protected:
 	void validateInterfaces(const StagePrivate& child, InterfaceFlags& external, bool first = false) const;
 
-private:
 	/// callback for new externally received states
 	template <typename Interface::Direction>
-	void onNewExternalState(Interface::iterator external, bool updated);
+	void propagateStateToChildren(Interface::iterator external, bool updated);
+
+private:
+	// override for custom behavior on received interface states
+	virtual void initializeExternalInterfaces(InterfaceFlags expected);
 };
 PIMPL_FUNCTIONS(ParallelContainerBase)
 

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -247,7 +247,7 @@ public:
 	FallbacksPrivate(Fallbacks* me, const std::string& name);
 
 protected:
-	void computeFromExternal();
+	void computePropagate();
 	struct ExternalState
 	{
 		ExternalState() = default;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -302,6 +302,21 @@ struct FallbacksPrivatePropagator : FallbacksPrivateCommon
 	bool job_has_solutions_;  // flag indicating whether the current job generated solutions
 };
 
+/// Fallbacks implementation for CONNECT interface
+struct FallbacksPrivateConnect : FallbacksPrivate
+{
+	FallbacksPrivateConnect(FallbacksPrivate&& old);
+	void reset() override;
+	bool canCompute() const override;
+	void compute() override;
+	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
+
+	template <Interface::Direction dir>
+	void propagateStateUpdate(Interface::iterator external, bool updated);
+
+	mutable container_type::const_iterator active_;  // child picked for compute()
+};
+
 class WrapperBasePrivate : public ParallelContainerBasePrivate
 {
 	friend class WrapperBase;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -263,7 +263,7 @@ protected:
 		inline bool operator<(const ExternalState& other) const { return *external_state < *other.external_state; }
 	};
 	ordered<ExternalState> pending_states_;  // pending external states for a PROPAGATE interface
-
+	ordered<ExternalState>::iterator current_pending_;  // currently active pending state
 	inline void computeGenerate();
 	mutable container_type::const_iterator current_generator_;
 

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -263,8 +263,8 @@ protected:
 	ordered<ExternalState> pending_states_;
 	ExternalState current_external_state_;
 
-	void computeGenerate();
-	container_type::const_iterator current_generator_;
+	inline void computeGenerate();
+	mutable container_type::const_iterator current_generator_;
 
 private:
 	void initializeExternalInterfaces() override;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -248,8 +248,6 @@ public:
 
 protected:
 	void computeFromExternal();
-	void computeGenerate();
-
 	struct ExternalState
 	{
 		ExternalState(Interface::iterator e, Interface::Direction d, container_type::const_iterator c)
@@ -260,6 +258,9 @@ protected:
 		container_type::const_iterator stage;
 	};
 	std::deque<ExternalState> pending_states_;
+	StagePrivate* current_stage_;
+
+	void computeGenerate();
 	container_type::const_iterator current_generator_;
 
 private:

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -257,6 +257,7 @@ public:
 	// methods common to all variants
 	void initializeExternalInterfaces() final;
 	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
+	void nextChild();  /// << Advance to next child
 
 	// virtual methods specific to each variant
 	/// Advance to the next job, assuming that the current child is exhausted on the current job.

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -235,7 +235,7 @@ protected:
 
 private:
 	// override for custom behavior on received interface states
-	virtual void initializeExternalInterfaces(InterfaceFlags expected);
+	virtual void initializeExternalInterfaces();
 };
 PIMPL_FUNCTIONS(ParallelContainerBase)
 
@@ -263,7 +263,7 @@ protected:
 	container_type::const_iterator current_generator_;
 
 private:
-	void initializeExternalInterfaces(InterfaceFlags expected) override;
+	void initializeExternalInterfaces() override;
 	template <typename Interface::Direction>
 	void onNewExternalState(Interface::iterator external, bool updated);
 	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -243,22 +243,22 @@ PIMPL_FUNCTIONS(ParallelContainerBase)
 
 /* The Fallbacks container needs to implement different behaviour based on its interface.
  * Thus, we implement 3 different classes: for Generator, Propagator, and Connect-like interfaces.
- * FallbacksPrivate is the common base class for all of them, defining the common API to be used
- * by the Fallbacks container.
+ * FallbacksPrivate is the common base class for all of them, defining the common API
+ * to be used by the Fallbacks container.
  * The actual interface-specific class is instantiated in initializeExternalInterfaces()
  * resp. Fallbacks::replaceImpl() when the actual interface is known.
- * The key difference between the 3 variants is how the advance to the next job. */
+ * The key difference between the 3 variants is how they advance to the next job. */
 class FallbacksPrivate : public ParallelContainerBasePrivate
 {
 public:
 	FallbacksPrivate(Fallbacks* me, const std::string& name);
 	FallbacksPrivate(FallbacksPrivate&& other);
 
-	// method overrides common to 3 variants
+	// methods common to all variants
 	void initializeExternalInterfaces() final;
 	void onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) override;
 
-	// virtual method specific to each variant
+	// virtual methods specific to each variant
 	/// Advance to the next job, assuming that the current child is exhausted on the current job.
 	virtual bool nextJob() { return false; }
 	/// Reset data structures

--- a/core/include/moveit/task_constructor/container_p.h
+++ b/core/include/moveit/task_constructor/container_p.h
@@ -151,6 +151,8 @@ protected:
 	/// Set ENABLED / PRUNED status of the solution tree starting from s into given direction
 	template <Interface::Direction dir>
 	void setStatus(const InterfaceState* s, InterfaceState::Status status);
+	/// non-template version
+	void setStatus(Interface::Direction dir, const InterfaceState* s, InterfaceState::Status status);
 
 	/// copy external_state to a child's interface and remember the link in internal_external map
 	template <Interface::Direction>
@@ -260,8 +262,7 @@ protected:
 
 		inline bool operator<(const ExternalState& other) const { return *external_state < *other.external_state; }
 	};
-	ordered<ExternalState> pending_states_;
-	ExternalState current_external_state_;
+	ordered<ExternalState> pending_states_;  // pending external states for a PROPAGATE interface
 
 	inline void computeGenerate();
 	mutable container_type::const_iterator current_generator_;

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -61,7 +61,6 @@ class StagePrivate
 {
 	friend class Stage;
 	friend std::ostream& operator<<(std::ostream& os, const StagePrivate& stage);
-	friend void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 public:
 	/// container type used to store children
@@ -165,6 +164,8 @@ public:
 	void computeCost(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 
 protected:
+	StagePrivate& operator=(StagePrivate&& other);
+
 	// associated/owning Stage instance
 	Stage* me_;
 

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -301,6 +301,7 @@ PIMPL_FUNCTIONS(MonitoringGenerator)
 class ConnectingPrivate : public ComputeBasePrivate
 {
 	friend class Connecting;
+	friend struct FallbacksPrivateConnect;
 
 public:
 	struct StatePair : std::pair<Interface::const_iterator, Interface::const_iterator>

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -85,6 +85,8 @@ public:
 		PRUNED,  // state is disabled because a required connected state failed
 		FAILED,  // state that failed, causing the whole partial solution to be disabled
 	};
+	static const char* STATUS_COLOR[];
+
 	/** InterfaceStates are ordered according to two values:
 	 *  Depth of interlinked trajectory parts and accumulated trajectory costs along that path.
 	 *  Preference ordering considers high-depth first and within same depth, minimal cost paths.
@@ -220,6 +222,16 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio);
 std::ostream& operator<<(std::ostream& os, const Interface& interface);
+
+/// Find index of the iterator in the container. Counting starts at 1. Zero corresponds to not found.
+template <typename T>
+size_t getIndex(const T& container, typename T::const_iterator search) {
+	size_t index = 1;
+	for (typename T::const_iterator it = container.begin(), end = container.end(); it != end; ++it, ++index)
+		if (it == search)
+			return index;
+	return 0;
+}
 
 class CostTerm;
 class StagePrivate;

--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -169,6 +169,7 @@ public:
 	class iterator : public base_type::iterator
 	{
 	public:
+		iterator() = default;
 		iterator(base_type::iterator other) : base_type::iterator(other) {}
 
 		InterfaceState& operator*() const noexcept { return *base_type::iterator::operator*(); }

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -51,14 +51,13 @@ namespace task_constructor {
 class TaskPrivate : public WrapperBasePrivate
 {
 	friend class Task;
+	TaskPrivate& operator=(TaskPrivate&& other);
 
 public:
 	TaskPrivate(Task* me, const std::string& ns);
+
 	const std::string& ns() const { return ns_; }
 	const ContainerBase* stages() const;
-
-protected:
-	static void swap(StagePrivate*& lhs, StagePrivate*& rhs);
 
 private:
 	std::string ns_;

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -944,9 +944,9 @@ void FallbacksPrivate::computePropagate(){
 		}
 		else {
 			ROS_DEBUG_STREAM_NAMED("Fallbacks", "State failed to extend through any child, prune path");
-			ContainerBasePrivate::onNewFailure(*children().back(),
-			                                   dir == Interface::FORWARD ? &*state : nullptr,
-			                                   dir == Interface::BACKWARD ? nullptr : &*state);
+			parent()->pimpl()->onNewFailure(*me(),
+			                                dir == Interface::FORWARD ? &*state : nullptr,
+			                                dir == Interface::BACKWARD ? nullptr : &*state);
 		}
 	}
 	else {

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -883,11 +883,7 @@ void FallbacksPrivate::computeGenerate() {
 	if(current_generator_ == children().end())
 		return;
 
-	// run ALL possible computations (on new state)
-	// this is needed to decide whether it should be passed to the next child too
-	while ((*current_generator_)->pimpl()->canCompute()){
-		(*current_generator_)->pimpl()->runCompute();
-	}
+	(*current_generator_)->pimpl()->runCompute();
 }
 
 template <typename Interface::Direction dir>

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -606,9 +606,9 @@ void SerialContainerPrivate::resolveInterface(InterfaceFlags expected) {
 		validateInterface<START_IF_MASK>(*first.pimpl(), expected);
 		// connect first child's (start) pull interface
 		if (const InterfacePtr& target = first.pimpl()->starts())
-			starts_.reset(new Interface([this, target](Interface::iterator it, bool updated) {
+			starts_ = std::make_shared<Interface>([this, target](Interface::iterator it, bool updated) {
 				this->copyState<Interface::FORWARD>(it, target, updated);
-			}));
+			});
 	} catch (InitStageException& e) {
 		exceptions.append(e);
 	}
@@ -632,9 +632,9 @@ void SerialContainerPrivate::resolveInterface(InterfaceFlags expected) {
 		validateInterface<END_IF_MASK>(*last.pimpl(), expected);
 		// connect last child's (end) pull interface
 		if (const InterfacePtr& target = last.pimpl()->ends())
-			ends_.reset(new Interface([this, target](Interface::iterator it, bool updated) {
+			ends_ = std::make_shared<Interface>([this, target](Interface::iterator it, bool updated) {
 				this->copyState<Interface::BACKWARD>(it, target, updated);
-			}));
+			});
 	} catch (InitStageException& e) {
 		exceptions.append(e);
 	}
@@ -733,13 +733,13 @@ void ParallelContainerBasePrivate::resolveInterface(InterfaceFlags expected) {
 void ParallelContainerBasePrivate::initializeExternalInterfaces() {
 	// States received by the container need to be copied to all children's pull interfaces.
 	if (requiredInterface() & READS_START)
-		starts().reset(new Interface([this](Interface::iterator external, bool updated) {
+		starts() = std::make_shared<Interface>([this](Interface::iterator external, bool updated) {
 		   this->propagateStateToChildren<Interface::FORWARD>(external, updated);
-		}));
+		});
 	if (requiredInterface() & READS_END)
-		ends().reset(new Interface([this](Interface::iterator external, bool updated) {
+		ends() = std::make_shared<Interface>([this](Interface::iterator external, bool updated) {
 		   this->propagateStateToChildren<Interface::BACKWARD>(external, updated);
-		}));
+		});
 }
 
 void ParallelContainerBasePrivate::validateInterfaces(const StagePrivate& child, InterfaceFlags& external,

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -686,18 +686,18 @@ void ParallelContainerBasePrivate::resolveInterface(InterfaceFlags expected) {
 	if (exceptions)
 		throw exceptions;
 
-	initializeExternalInterfaces(expected);
-
 	required_interface_ = expected;
+
+	initializeExternalInterfaces();
 }
 
-void ParallelContainerBasePrivate::initializeExternalInterfaces(InterfaceFlags expected) {
+void ParallelContainerBasePrivate::initializeExternalInterfaces() {
 	// States received by the container need to be copied to all children's pull interfaces.
-	if (expected & READS_START)
+	if (requiredInterface() & READS_START)
 		starts().reset(new Interface([this](Interface::iterator external, bool updated) {
 		   this->propagateStateToChildren<Interface::FORWARD>(external, updated);
 		}));
-	if (expected & READS_END)
+	if (requiredInterface() & READS_END)
 		ends().reset(new Interface([this](Interface::iterator external, bool updated) {
 		   this->propagateStateToChildren<Interface::BACKWARD>(external, updated);
 		}));
@@ -851,19 +851,19 @@ void Fallbacks::onNewSolution(const SolutionBase& s) {
 FallbacksPrivate::FallbacksPrivate(Fallbacks* me, const std::string& name)
    : ParallelContainerBasePrivate(me, name) {}
 
-void FallbacksPrivate::initializeExternalInterfaces(InterfaceFlags expected) {
-	if (expected & READS_START)
+void FallbacksPrivate::initializeExternalInterfaces() {
+	if (requiredInterface() & READS_START)
 		starts().reset(new Interface([this](Interface::iterator external, bool updated) {
 		   this->onNewExternalState<Interface::FORWARD>(external, updated);
 		}));
-	if (expected & READS_END)
+	if (requiredInterface() & READS_END)
 		ends().reset(new Interface([this](Interface::iterator external, bool updated) {
 		   this->onNewExternalState<Interface::BACKWARD>(external, updated);
 		}));
 
 	// we've got to set this somewhere once the interface flags are known.
 	// so we might as well do it here
-	if(expected == GENERATE)
+	if(requiredInterface() == GENERATE)
 		current_generator_ = children().begin();
 }
 

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -260,7 +260,7 @@ void ContainerBasePrivate::copyState(Interface::iterator external, const Interfa
 		auto internals{ externalToInternalMap().equal_range(&*external) };
 		for (auto& i = internals.first; i != internals.second; ++i) {
 			// TODO: Not only update status, but full priority!
-			setStatus<dir>(i->second, external->priority().status());
+			setStatus<dir>(i->get<INTERNAL>(), external->priority().status());
 		}
 		return;
 	}
@@ -690,9 +690,8 @@ bool SerialContainer::canCompute() const {
 
 void SerialContainer::compute() {
 	for (const auto& stage : pimpl()->children()) {
-		if (!stage->pimpl()->canCompute())
-			continue;
-		stage->pimpl()->runCompute();
+		if (stage->pimpl()->canCompute())
+			stage->pimpl()->runCompute();
 	}
 }
 

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -734,11 +734,11 @@ void ParallelContainerBasePrivate::initializeExternalInterfaces() {
 	// States received by the container need to be copied to all children's pull interfaces.
 	if (requiredInterface() & READS_START)
 		starts() = std::make_shared<Interface>([this](Interface::iterator external, bool updated) {
-		   this->propagateStateToChildren<Interface::FORWARD>(external, updated);
+		   this->propagateStateToAllChildren<Interface::FORWARD>(external, updated);
 		});
 	if (requiredInterface() & READS_END)
 		ends() = std::make_shared<Interface>([this](Interface::iterator external, bool updated) {
-		   this->propagateStateToChildren<Interface::BACKWARD>(external, updated);
+		   this->propagateStateToAllChildren<Interface::BACKWARD>(external, updated);
 		});
 }
 
@@ -774,7 +774,7 @@ void ParallelContainerBasePrivate::validateConnectivity() const {
 }
 
 template <Interface::Direction dir>
-void ParallelContainerBasePrivate::propagateStateToChildren(Interface::iterator external, bool updated) {
+void ParallelContainerBasePrivate::propagateStateToAllChildren(Interface::iterator external, bool updated) {
 	for (const Stage::pointer& stage : children())
 		copyState<dir>(external, stage->pimpl()->pullInterface(dir), updated);
 }

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -867,11 +867,11 @@ void FallbacksPrivate::initializeExternalInterfaces(InterfaceFlags expected) {
 		current_generator_ = children().begin();
 }
 
-void FallbacksPrivate::onNewFailure(const Stage& child, const InterfaceState* from, const InterfaceState* to) {
-	// only react to failure if it's the last possible candidate failing
-	// otherwise there might still be a feasible solution
-	if(&child == &*children().back())
-		ContainerBasePrivate::onNewFailure(child, from, to);
+void FallbacksPrivate::onNewFailure(const Stage& /*child*/, const InterfaceState* /*from*/, const InterfaceState* /*to*/) {
+	// This override is deliberately empty.
+	// The method prunes solution paths when a child failed to find a valid solution for it,
+	// but in Fallbacks the next child might still yield a successful solution
+	// Thus pruning must only occur once the last child is exhausted (inside computeFromExternal)
 }
 
 void FallbacksPrivate::computeGenerate() {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -106,6 +106,33 @@ StagePrivate::StagePrivate(Stage* me, const std::string& name)
   , parent_{ nullptr }
   , introspection_{ nullptr } {}
 
+StagePrivate& StagePrivate::operator=(StagePrivate&& other) {
+	assert(typeid(*this) == typeid(other));
+
+	assert(states_.empty() && other.states_.empty());
+	assert((!starts_ || starts_->empty()) && (!other.starts_ || other.starts_->empty()));
+	assert((!ends_ || ends_->empty()) && (!other.ends_ || other.ends_->empty()));
+	assert(solutions_.empty() && other.solutions_.empty());
+	assert(failures_.empty() && other.failures_.empty());
+
+	// me_ must not be changed!
+	name_ = std::move(other.name_);
+	properties_ = std::move(other.properties_);
+	cost_term_ = std::move(other.cost_term_);
+	solution_cbs_ = std::move(other.solution_cbs_);
+
+	starts_ = std::move(other.starts_);
+	ends_ = std::move(other.ends_);
+	prev_ends_ = std::move(other.prev_ends_);
+	next_starts_ = std::move(other.next_starts_);
+
+	parent_ = std::move(other.parent_);
+	it_ = std::move(other.it_);
+	other.unparent();
+
+	return *this;
+}
+
 InterfaceFlags StagePrivate::interfaceFlags() const {
 	InterfaceFlags f;
 	if (starts())

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -510,14 +510,14 @@ void PropagatingEitherWayPrivate::initInterface(PropagatingEitherWay::Direction 
 		case PropagatingEitherWay::FORWARD:
 			required_interface_ = PROPAGATE_FORWARDS;
 			if (!starts_)  // keep existing interface if possible
-				starts_.reset(new Interface());
+				starts_ = std::make_shared<Interface>();
 			ends_.reset();
 			return;
 		case PropagatingEitherWay::BACKWARD:
 			required_interface_ = PROPAGATE_BACKWARDS;
 			starts_.reset();
 			if (!ends_)  // keep existing interface if possible
-				ends_.reset(new Interface());
+				ends_ = std::make_shared<Interface>();
 			return;
 		case PropagatingEitherWay::AUTO:
 			required_interface_ = UNKNOWN;
@@ -715,10 +715,10 @@ void MonitoringGeneratorPrivate::solutionCB(const SolutionBase& s) {
 }
 
 ConnectingPrivate::ConnectingPrivate(Connecting* me, const std::string& name) : ComputeBasePrivate(me, name) {
-	starts_.reset(new Interface(std::bind(&ConnectingPrivate::newState<Interface::BACKWARD>, this, std::placeholders::_1,
-	                                      std::placeholders::_2)));
-	ends_.reset(new Interface(std::bind(&ConnectingPrivate::newState<Interface::FORWARD>, this, std::placeholders::_1,
-	                                    std::placeholders::_2)));
+	starts_ = std::make_shared<Interface>(std::bind(&ConnectingPrivate::newState<Interface::BACKWARD>, this,
+	                                                std::placeholders::_1, std::placeholders::_2));
+	ends_ = std::make_shared<Interface>(
+	    std::bind(&ConnectingPrivate::newState<Interface::FORWARD>, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 InterfaceFlags ConnectingPrivate::requiredInterface() const {

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -144,15 +144,16 @@ std::ostream& operator<<(std::ostream& os, const Interface& interface) {
 		os << istate->priority() << "  ";
 	return os;
 }
+const char* InterfaceState::STATUS_COLOR[] = {
+	"\033[32m",  // ENABLED - green
+	"\033[33m",  // PRUNED - yellow
+	"\033[31m",  // FAILED - red
+	"\033[m"  // reset
+};
 std::ostream& operator<<(std::ostream& os, const InterfaceState::Priority& prio) {
 	// maps InterfaceState::Status values to output (color-changing) prefix
-	static const char* prefix[] = {
-		"\033[32me:",  // ENABLED - green
-		"\033[33md:",  // PRUNED - yellow
-		"\033[31mf:",  // FAILED - red
-	};
-	static const char* color_reset = "\033[m";
-	os << prefix[prio.status()] << prio.depth() << ":" << prio.cost() << color_reset;
+	os << InterfaceState::STATUS_COLOR[prio.status()] << prio.depth() << ":" << prio.cost()
+	   << InterfaceState::STATUS_COLOR[3];
 	return os;
 }
 

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -586,10 +586,6 @@ TEST(Task, move) {
 	Task t2 = std::move(t1);
 	EXPECT_EQ(t2.stages()->numChildren(), 2u);
 	EXPECT_EQ(t1.stages()->numChildren(), 0u);  // NOLINT(clang-analyzer-cplusplus.Move)
-
-	t1 = std::move(t2);
-	EXPECT_EQ(t1.stages()->numChildren(), 2u);
-	EXPECT_EQ(t2.stages()->numChildren(), 0u);  // NOLINT(clang-analyzer-cplusplus.Move)
 }
 
 TEST(Task, reuse) {

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -67,7 +67,7 @@ TEST_F(FallbacksFixturePropagate, computeFirstSuccessfulStageOnly) {
 	EXPECT_EQ(t.numSolutions(), 1u);
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStagePerSolutionOnly) {
+TEST_F(FallbacksFixturePropagate, computeFirstSuccessfulStagePerSolutionOnly) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0 })));
 	// duplicate generator solutions with resulting costs: 4, 2 | 3, 1
 	t.add(std::make_unique<ForwardMockup>(PredefinedCosts({ 2.0, 0.0, 2.0, 0.0 }), 2));
@@ -78,10 +78,11 @@ TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStagePerSolutio
 	t.add(std::move(fallbacks));
 
 	EXPECT_TRUE(t.plan());
-	EXPECT_COSTS(t.solutions(), testing::ElementsAre(113, 124, 211, 222));
+	EXPECT_COSTS(t.solutions(), testing::ElementsAre(113, 124, 212, 221));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_UpdateSolutionOrder) {
+// requires individual job control in Fallbacks's children
+TEST_F(FallbacksFixturePropagate, DISABLED_updateSolutionOrder) {
 	t.add(std::make_unique<BackwardMockup>(PredefinedCosts({ 10.0, 0.0 })));
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 	// available solutions (sorted) in individual runs of fallbacks: 1 | 11, 2 | 2, 11
@@ -100,7 +101,8 @@ TEST_F(FallbacksFixturePropagate, DISABLED_UpdateSolutionOrder) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(2));  // expecting less costly solution as result
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_MultipleActivePendingStates) {
+// requires individual job control in Fallbacks's children
+TEST_F(FallbacksFixturePropagate, DISABLED_multipleActivePendingStates) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 2.0, 1.0, 3.0 })));
 	// use a fallback container to delay computation: the 1st child never succeeds, but only the 2nd
 	auto inner = std::make_unique<Fallbacks>("Inner");
@@ -159,7 +161,7 @@ TEST_F(FallbacksFixturePropagate, activeChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, DISABLED_ConnectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -161,16 +161,16 @@ TEST_F(FallbacksFixturePropagate, activeChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, DISABLED_connectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
-	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts::constant(0.0)));
+	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts({ 0.0, 0.0, INF, 0.0 })));
 	fallbacks->add(std::make_unique<ConnectMockup>(PredefinedCosts::constant(100.0)));
 	t.add(std::move(fallbacks));
 
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 10.0, 20.0 })));
 
 	EXPECT_TRUE(t.plan());
-	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 21, 22));
+	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 22, 121));
 }

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -161,7 +161,7 @@ TEST_F(FallbacksFixturePropagate, activeChildReset) {
 
 using FallbacksFixtureConnect = TaskTestBase;
 
-TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
+TEST_F(FallbacksFixtureConnect, DISABLED_connectStageInsideFallbacks) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, 2.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -17,7 +17,7 @@ using namespace moveit::task_constructor;
 
 using FallbacksFixtureGenerator = TaskTestBase;
 
-TEST_F(FallbacksFixtureGenerator, DISABLED_stayWithFirstSuccessful) {
+TEST_F(FallbacksFixtureGenerator, stayWithFirstSuccessful) {
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(INF)));
 	fallback->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(1.0)));
@@ -55,7 +55,7 @@ TEST_F(FallbacksFixturePropagate, failingWithFailedSolutions) {
 	EXPECT_EQ(t.solutions().size(), 0u);
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ComputeFirstSuccessfulStageOnly) {
+TEST_F(FallbacksFixturePropagate, computeFirstSuccessfulStageOnly) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
@@ -117,7 +117,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_MultipleActivePendingStates) {
 	// check that first solution is not marked as pruned
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions) {
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -129,7 +129,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions2) {
+TEST_F(FallbacksFixturePropagate, successfulWithMixedSolutions2) {
 	t.add(std::make_unique<GeneratorMockup>());
 
 	auto fallback = std::make_unique<Fallbacks>("Fallbacks");
@@ -141,7 +141,7 @@ TEST_F(FallbacksFixturePropagate, DISABLED_successfulWithMixedSolutions2) {
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(1.0));
 }
 
-TEST_F(FallbacksFixturePropagate, DISABLED_ActiveChildReset) {
+TEST_F(FallbacksFixturePropagate, activeChildReset) {
 	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 1.0, INF, 3.0 })));
 
 	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -174,16 +174,3 @@ TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
 	EXPECT_TRUE(t.plan());
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 21, 22));
 }
-
-int main(int argc, char** argv) {
-	for (int i = 1; i < argc; ++i) {
-		if (strcmp(argv[i], "--debug") == 0) {
-			if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
-				ros::console::notifyLoggerLevelsChanged();
-			break;
-		}
-	}
-
-	testing::InitGoogleTest(&argc, argv);
-	return RUN_ALL_TESTS();
-}

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -50,6 +50,7 @@ demo(cartesian)
 demo(modular)
 demo(alternative_path_costs)
 demo(ik_clearance_cost)
+demo(fallbacks_move_to)
 
 demo(pick_place_demo)
 target_link_libraries(${PROJECT_NAME}_pick_place_demo ${PROJECT_NAME}_pick_place_task)

--- a/demo/src/fallbacks_move_to.cpp
+++ b/demo/src/fallbacks_move_to.cpp
@@ -1,0 +1,142 @@
+#include <ros/ros.h>
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <moveit/task_constructor/moveit_compat.h>
+
+#include <moveit/task_constructor/task.h>
+#include <moveit/task_constructor/container.h>
+#include <moveit/task_constructor/solvers/cartesian_path.h>
+#include <moveit/task_constructor/solvers/pipeline_planner.h>
+#include <moveit/task_constructor/stages.h>
+
+constexpr double TAU = 2 * M_PI;
+
+using namespace moveit::task_constructor;
+
+/** CurrentState -> Fallbacks( MoveTo<CartesianPath>, MoveTo<PTP>, MoveTo<OMPL> )*/
+int main(int argc, char** argv) {
+	ros::init(argc, argv, "mtc_tutorial");
+
+	ros::AsyncSpinner spinner{ 1 };
+	spinner.start();
+
+	// setup Task
+	Task t;
+	t.loadRobotModel();
+	const moveit::core::RobotModelConstPtr robot{ t.getRobotModel() };
+
+	assert(robot->getName() == "panda");
+
+	// setup solvers
+	auto cartesian = std::make_shared<solvers::CartesianPath>();
+	cartesian->setJumpThreshold(2.0);
+
+	const auto ptp = []() {
+		auto pp{ std::make_shared<solvers::PipelinePlanner>("pilz_industrial_motion_planner") };
+		pp->setPlannerId("PTP");
+		return pp;
+	}();
+
+	const auto rrtconnect = []() {
+		auto pp{ std::make_shared<solvers::PipelinePlanner>("ompl") };
+		pp->setPlannerId("RRTConnectkConfigDefault");
+		return pp;
+	}();
+
+	// target state for Task
+	std::map<std::string, double> target_state;
+	robot->getJointModelGroup("panda_arm")->getVariableDefaultPositions("ready", target_state);
+	target_state["panda_joint1"] = +TAU / 8;
+
+	// define initial scenes
+	auto initial_scene{ std::make_shared<planning_scene::PlanningScene>(robot) };
+	initial_scene->getCurrentStateNonConst().setToDefaultValues(robot->getJointModelGroup("panda_arm"), "ready");
+
+	auto initial_alternatives = std::make_unique<Alternatives>("initial states");
+
+	{
+		// can reach target with Cartesian motion
+		auto fixed{ std::make_unique<stages::FixedState>("current state") };
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({ { "panda_joint1", -TAU / 8 } });
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+	{
+		// Cartesian motion to target is impossible, but PTP is collision-free
+		auto fixed{ std::make_unique<stages::FixedState>("current state") };
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({
+		    { "panda_joint1", +TAU / 8 },
+		    { "panda_joint4", 0 },
+		});
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+	{
+		// Cartesian and PTP motion to target would be in collision
+		auto fixed = std::make_unique<stages::FixedState>("current state");
+		auto scene{ initial_scene->diff() };
+		scene->getCurrentStateNonConst().setVariablePositions({ { "panda_joint1", -TAU / 8 } });
+		scene->processCollisionObjectMsg([]() {
+			moveit_msgs::CollisionObject co;
+			co.id = "box";
+			co.header.frame_id = "panda_link0";
+			co.operation = co.ADD;
+#if MOVEIT_HAS_OBJECT_POSE
+			auto& pose{ co.pose };
+#else
+			co.primitive_poses.emplace_back();
+			auto& pose{ co.primitive_poses[0] };
+#endif
+			pose = []() {
+				geometry_msgs::Pose p;
+				p.position.x = 0.3;
+				p.position.y = 0.0;
+				p.position.z = 0.64 / 2;
+				p.orientation.w = 1.0;
+				return p;
+			}();
+			co.primitives.push_back([]() {
+				shape_msgs::SolidPrimitive sp;
+				sp.type = sp.BOX;
+				sp.dimensions = { 0.2, 0.05, 0.64 };
+				return sp;
+			}());
+			return co;
+		}());
+		fixed->setState(scene);
+		initial_alternatives->add(std::move(fixed));
+	}
+
+	t.add(std::move(initial_alternatives));
+
+	// fallbacks to reach target_state
+	auto fallbacks = std::make_unique<Fallbacks>("move to other side");
+
+	auto add_to_fallbacks{ [&](auto& solver, auto& name) {
+		auto move_to = std::make_unique<stages::MoveTo>(name, solver);
+		move_to->setGroup("panda_arm");
+		move_to->setGoal(target_state);
+		fallbacks->add(std::move(move_to));
+	} };
+	add_to_fallbacks(cartesian, "Cartesian path");
+	add_to_fallbacks(ptp, "PTP path");
+	add_to_fallbacks(rrtconnect, "RRT path");
+
+	t.add(std::move(fallbacks));
+
+	try {
+		t.init();
+		std::cout << t << std::endl;
+		t.plan();
+	} catch (const InitStageException& e) {
+		std::cout << e << std::endl;
+	}
+
+	ros::waitForShutdown();
+
+	return 0;
+}


### PR DESCRIPTION
This is a new attempt to correctly implement `Fallbacks`. The key insight is that we need to implement different behavior based on the actual interface type (`GENERATE`, `PROPAGATE_*`, `CONNECT`). These types differ on what they consider a `job` that a child stage should run on till exhaustion before advancing to the next child.
- `GENERATE`: A job is essentially identical to the child itself. The generator child runs until it is exhausted. This is the only operation mode I had in mind when originally implementing the `Fallbacks` stage.
- `PROPAGATE_*`: A job is an external input state. As [pointed out by @v4hn](https://github.com/ros-planning/moveit_task_constructor/pull/280#discussion_r676565782) for each new input state, the Fallbacks container should start over from its first child stage. This behavior was added in #287 (but also mistakenly applied for `CONNECT` interfaces).
- `CONNECT`: A job is a single pair of (start, end) states. As we cannot withdraw a state once it was forwarded to a child, we need to disable (and later re-enable) states in the child `starts`/`ends` interfaces to ensure that exactly one specific (start, end) pair is active at a time.

To correctly implement these three behaviors, this PR essentially realizes three different implementations for `FallbacksPrivate`.
Common behavior between these classes is implemented in `FallbacksPrivate`. The actual interface-specific class is instantiated in `initializeExternalInterfaces()` resp. `Fallbacks::replaceImpl()` when the actual interface is known.

### TODOs:
- [x] Simplify implementation based on some more ideas from #287 
- [ ] Implement `FallbacksPrivateConnect` (**WIP**)
  - [x] Basic version available, but with similar bug as before: `CONNECT` pairs cannot easily be treated correctly as separate jobs, causing the issue described in https://github.com/ros-planning/moveit_task_constructor/pull/311#issuecomment-979766156. 
    My plan to solve that issue was to disable inactive pairs (or their solutions).
    However, I now have a coarse idea that Michael's approach, feeding start and end interfaces in an alternating fashion, might work as well. We should definitely talk, Michael :wink:
     EDIT: In the [given example](https://github.com/ros-planning/moveit_task_constructor/pull/311#issuecomment-979766156), the pair `3-4` that failed for the first connecting child, will not be passed on to the next child.
  - [ ] Merge #309 and fix remaining pruning issues with containers
    - [ ] If a single _pair_ of external states receives multiple solutions, only the best should be kept and all worse (partial) solutions should be pruned. Need to sketch a unit test for this...