### PR TITLE
execute_task_solution_capability: check for canceling request before canceling the goal handle

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -119,7 +119,7 @@ void ExecuteTaskSolutionCapability::goalCallback(
 
 	if (result->error_code.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS)
 		goal_handle->succeed(result);
-	else if (result->error_code.val == moveit_msgs::msg::MoveItErrorCodes::PREEMPTED)
+	else if (result->error_code.val == moveit_msgs::msg::MoveItErrorCodes::PREEMPTED && goal_handle->is_canceling())
 		goal_handle->canceled(result);
 	else
 		goal_handle->abort(result);


### PR DESCRIPTION
Fix the following exception

```
[move_group-1] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[move_group-1]   what():  goal_handle attempted invalid transition from state EXECUTING with event CANCELED
```