### PR TITLE
Use TOTG rather than IPTP

### DIFF
--- a/core/src/merge.cpp
+++ b/core/src/merge.cpp
@@ -36,7 +36,7 @@
 /* Authors: Luca Lach, Robert Haschke */
 
 #include <moveit/task_constructor/merge.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -166,7 +166,7 @@ merge(const std::vector<robot_trajectory::RobotTrajectoryConstPtr>& sub_trajecto
 	}
 
 	// add timing
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
+	trajectory_processing::TimeOptimalTrajectoryGeneration timing;
 	timing.computeTimeStamps(*merged_traj, 1.0, 1.0);
 	return merged_traj;
 }

--- a/core/src/solvers/cartesian_path.cpp
+++ b/core/src/solvers/cartesian_path.cpp
@@ -40,7 +40,7 @@
 #include <moveit/task_constructor/moveit_compat.h>
 
 #include <moveit/planning_scene/planning_scene.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <moveit/robot_state/cartesian_interpolator.h>
 
 namespace moveit {
@@ -101,7 +101,7 @@ bool CartesianPath::plan(const planning_scene::PlanningSceneConstPtr& from, cons
 	for (const auto& waypoint : trajectory)
 		result->addSuffixWayPoint(waypoint, 0.0);
 
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
+	trajectory_processing::TimeOptimalTrajectoryGeneration timing;
 	timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
 	                         props.get<double>("max_acceleration_scaling_factor"));
 

--- a/core/src/solvers/joint_interpolation.cpp
+++ b/core/src/solvers/joint_interpolation.cpp
@@ -38,7 +38,7 @@
 
 #include <moveit/task_constructor/solvers/joint_interpolation.h>
 #include <moveit/planning_scene/planning_scene.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 
 #include <chrono>
 
@@ -92,7 +92,7 @@ bool JointInterpolationPlanner::plan(const planning_scene::PlanningSceneConstPtr
 		return false;
 
 	// add timing, TODO: use a generic method to add timing via plugins
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
+	trajectory_processing::TimeOptimalTrajectoryGeneration timing;
 	timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
 	                         props.get<double>("max_acceleration_scaling_factor"));
 


### PR DESCRIPTION
IPTP was causing errors like this:

`Time between points 10 and 11 is not strictly increasing, it is 0.357595 and 0.357595 respectively`

Hat tip to @JafarAbdi for finding the cause.

The only concern I have with this PR is, does the robot ever start from non-zero velocity or acceleration? Because TOTG cannot handle that.

(Jafar mentioned loading a plugin to allow any of the time parameterization algorithms. In my opinion that is not necessary because TOTG is clearly the best option at the moment.)