### PR TITLE
move constructor deletes implicitly declared copy assignment operator

### DIFF
--- a/core/include/moveit/task_constructor/storage.h
+++ b/core/include/moveit/task_constructor/storage.h
@@ -127,7 +127,6 @@ public:
 
 	/// copy an existing InterfaceState, but not including incoming/outgoing trajectories
 	InterfaceState(const InterfaceState& other);
-	InterfaceState(InterfaceState&& other) = default;
 
 	inline const planning_scene::PlanningSceneConstPtr& scene() const { return scene_; }
 	inline const Solutions& incomingTrajectories() const { return incoming_trajectories_; }


### PR DESCRIPTION
Not sure why a move constructor was explicitly declared but it has the side effect of declaring the implicitly-declared copy assignment operator as deleted.  See here for reference https://en.cppreference.com/w/cpp/language/copy_assignment 