### PR TITLE
Make TimeParamerization configurable

### DIFF
--- a/core/include/moveit/task_constructor/merge.h
+++ b/core/include/moveit/task_constructor/merge.h
@@ -39,6 +39,7 @@
 #include <moveit/task_constructor/storage.h>
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
+#include <moveit/trajectory_processing/time_parameterization.h>
 
 namespace moveit {
 namespace task_constructor {
@@ -57,6 +58,7 @@ moveit::core::JointModelGroup* merge(const std::vector<const moveit::core::Joint
  */
 robot_trajectory::RobotTrajectoryPtr
 merge(const std::vector<robot_trajectory::RobotTrajectoryConstPtr>& sub_trajectories,
-      const moveit::core::RobotState& base_state, moveit::core::JointModelGroup*& merged_group);
+      const moveit::core::RobotState& base_state, moveit::core::JointModelGroup*& merged_group,
+      const trajectory_processing::TimeParameterization& time_parameterization);
 }  // namespace task_constructor
 }  // namespace moveit

--- a/core/include/moveit/task_constructor/moveit_compat.h
+++ b/core/include/moveit/task_constructor/moveit_compat.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <moveit/version.h>
+#include <moveit/macros/class_forward.h>
 
 #define MOVEIT_VERSION_GE(major, minor, patch)                                                \
 	(MOVEIT_VERSION_MAJOR * 1'000'000 + MOVEIT_VERSION_MINOR * 1'000 + MOVEIT_VERSION_PATCH >= \
@@ -57,3 +58,9 @@
 #define MOVEIT_HAS_OBJECT_POSE MOVEIT_VERSION_GE(1, 1, 6)
 
 #define MOVEIT_HAS_STATE_RIGID_PARENT_LINK MOVEIT_VERSION_GE(1, 1, 6)
+
+#if !MOVEIT_VERSION_GE(1, 1, 9)
+namespace trajectory_processing {
+MOVEIT_CLASS_FORWARD(TimeParameterization);
+}
+#endif

--- a/core/include/moveit/task_constructor/moveit_compat.h
+++ b/core/include/moveit/task_constructor/moveit_compat.h
@@ -60,6 +60,7 @@
 #define MOVEIT_HAS_STATE_RIGID_PARENT_LINK MOVEIT_VERSION_GE(1, 1, 6)
 
 #if !MOVEIT_VERSION_GE(1, 1, 9)
+// the pointers are not yet available
 namespace trajectory_processing {
 MOVEIT_CLASS_FORWARD(TimeParameterization);
 }

--- a/core/src/merge.cpp
+++ b/core/src/merge.cpp
@@ -36,7 +36,6 @@
 /* Authors: Luca Lach, Robert Haschke */
 
 #include <moveit/task_constructor/merge.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -106,7 +105,8 @@ moveit::core::JointModelGroup* merge(const std::vector<const moveit::core::Joint
 
 robot_trajectory::RobotTrajectoryPtr
 merge(const std::vector<robot_trajectory::RobotTrajectoryConstPtr>& sub_trajectories,
-      const robot_state::RobotState& base_state, moveit::core::JointModelGroup*& merged_group) {
+      const robot_state::RobotState& base_state, moveit::core::JointModelGroup*& merged_group,
+      const trajectory_processing::TimeParameterization& time_parameterization) {
 	if (sub_trajectories.size() <= 1)
 		throw std::runtime_error("Expected multiple sub solutions");
 
@@ -166,8 +166,7 @@ merge(const std::vector<robot_trajectory::RobotTrajectoryConstPtr>& sub_trajecto
 	}
 
 	// add timing
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
-	timing.computeTimeStamps(*merged_traj, 1.0, 1.0);
+	time_parameterization.computeTimeStamps(*merged_traj, 1.0, 1.0);
 	return merged_traj;
 }
 }  // namespace task_constructor

--- a/core/src/solvers/cartesian_path.cpp
+++ b/core/src/solvers/cartesian_path.cpp
@@ -40,10 +40,12 @@
 #include <moveit/task_constructor/moveit_compat.h>
 
 #include <moveit/planning_scene/planning_scene.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/time_parameterization.h>
 #if MOVEIT_HAS_CARTESIAN_INTERPOLATOR
 #include <moveit/robot_state/cartesian_interpolator.h>
 #endif
+
+using namespace trajectory_processing;
 
 namespace moveit {
 namespace task_constructor {
@@ -107,9 +109,9 @@ bool CartesianPath::plan(const planning_scene::PlanningSceneConstPtr& from, cons
 	for (const auto& waypoint : trajectory)
 		result->addSuffixWayPoint(waypoint, 0.0);
 
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
-	timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
-	                         props.get<double>("max_acceleration_scaling_factor"));
+	auto timing = props.get<TimeParameterizationPtr>("time_parameterization");
+	timing->computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
+	                          props.get<double>("max_acceleration_scaling_factor"));
 
 	return achieved_fraction >= props.get<double>("min_fraction");
 }

--- a/core/src/solvers/joint_interpolation.cpp
+++ b/core/src/solvers/joint_interpolation.cpp
@@ -37,14 +37,17 @@
 */
 
 #include <moveit/task_constructor/solvers/joint_interpolation.h>
+#include <moveit/task_constructor/moveit_compat.h>
 #include <moveit/planning_scene/planning_scene.h>
-#include <moveit/trajectory_processing/iterative_time_parameterization.h>
+#include <moveit/trajectory_processing/time_parameterization.h>
 
 #include <chrono>
 
 namespace moveit {
 namespace task_constructor {
 namespace solvers {
+
+using namespace trajectory_processing;
 
 JointInterpolationPlanner::JointInterpolationPlanner() {
 	auto& p = properties();
@@ -89,10 +92,9 @@ bool JointInterpolationPlanner::plan(const planning_scene::PlanningSceneConstPtr
 	if (from->isStateColliding(to_state, jmg->getName()))
 		return false;
 
-	// add timing, TODO: use a generic method to add timing via plugins
-	trajectory_processing::IterativeParabolicTimeParameterization timing;
-	timing.computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
-	                         props.get<double>("max_acceleration_scaling_factor"));
+	auto timing = props.get<TimeParameterizationPtr>("time_parameterization");
+	timing->computeTimeStamps(*result, props.get<double>("max_velocity_scaling_factor"),
+	                          props.get<double>("max_acceleration_scaling_factor"));
 
 	return true;
 }

--- a/core/src/solvers/planner_interface.cpp
+++ b/core/src/solvers/planner_interface.cpp
@@ -37,6 +37,10 @@
 */
 
 #include <moveit/task_constructor/solvers/planner_interface.h>
+#include <moveit/task_constructor/moveit_compat.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+
+using namespace trajectory_processing;
 
 namespace moveit {
 namespace task_constructor {
@@ -46,6 +50,7 @@ PlannerInterface::PlannerInterface() {
 	auto& p = properties();
 	p.declare<double>("max_velocity_scaling_factor", 1.0, "scale down max velocity by this factor");
 	p.declare<double>("max_acceleration_scaling_factor", 1.0, "scale down max acceleration by this factor");
+	p.declare<TimeParameterizationPtr>("time_parameterization", std::make_shared<TimeOptimalTrajectoryGeneration>());
 }
 }  // namespace solvers
 }  // namespace task_constructor

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -58,7 +58,7 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 	p.declare<MergeMode>("merge_mode", WAYPOINTS, "merge mode");
 	p.declare<moveit_msgs::Constraints>("path_constraints", moveit_msgs::Constraints(),
 	                                    "constraints to maintain during trajectory");
-	properties().declare<TimeParameterizationPtr>("time_parameterization",
+	properties().declare<TimeParameterizationPtr>("merge_time_parameterization",
 	                                              std::make_shared<TimeOptimalTrajectoryGeneration>());
 }
 
@@ -225,7 +225,7 @@ SubTrajectoryPtr Connect::merge(const std::vector<robot_trajectory::RobotTraject
 
 	auto jmg = merged_jmg_.get();
 	assert(jmg);
-	auto timing = properties().get<TimeParameterizationPtr>("time_parameterization");
+	auto timing = properties().get<TimeParameterizationPtr>("merge_time_parameterization");
 	robot_trajectory::RobotTrajectoryPtr trajectory = task_constructor::merge(sub_trajectories, state, jmg, *timing);
 	if (!trajectory)
 		return SubTrajectoryPtr();

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -38,9 +38,13 @@
 
 #include <moveit/task_constructor/stages/connect.h>
 #include <moveit/task_constructor/merge.h>
-#include <moveit/planning_scene/planning_scene.h>
-
+#include <moveit/task_constructor/moveit_compat.h>
 #include <moveit/task_constructor/cost_terms.h>
+
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+
+using namespace trajectory_processing;
 
 namespace moveit {
 namespace task_constructor {
@@ -54,6 +58,8 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 	p.declare<MergeMode>("merge_mode", WAYPOINTS, "merge mode");
 	p.declare<moveit_msgs::Constraints>("path_constraints", moveit_msgs::Constraints(),
 	                                    "constraints to maintain during trajectory");
+	properties().declare<TimeParameterizationPtr>("time_parameterization",
+	                                              std::make_shared<TimeOptimalTrajectoryGeneration>());
 }
 
 void Connect::reset() {
@@ -219,7 +225,8 @@ SubTrajectoryPtr Connect::merge(const std::vector<robot_trajectory::RobotTraject
 
 	auto jmg = merged_jmg_.get();
 	assert(jmg);
-	robot_trajectory::RobotTrajectoryPtr trajectory = task_constructor::merge(sub_trajectories, state, jmg);
+	auto timing = properties().get<TimeParameterizationPtr>("time_parameterization");
+	robot_trajectory::RobotTrajectoryPtr trajectory = task_constructor::merge(sub_trajectories, state, jmg, *timing);
 	if (!trajectory)
 		return SubTrajectoryPtr();
 


### PR DESCRIPTION
Replaces #333, implementing https://github.com/ros-planning/moveit_task_constructor/pull/333#pullrequestreview-850576619. Fixes #330.
The TimeParameterization method becomes a property in corresponding stages and PlannerInterfaces.
This allows users to configure them easily.