### PR TITLE
[ros2] Add Stage property to assign a list of controllers to use when executing the planned trajectory

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -171,6 +171,12 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		exec_traj.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
 		exec_traj.trajectory->setRobotTrajectoryMsg(state, sub_traj.trajectory);
 
+		if (!sub_traj.controller_names.empty()) {
+			for (auto cn : sub_traj.controller_names) {
+				exec_traj.controller_names_.push_back(cn.data.data());
+			}
+		}
+
 		/* TODO add action feedback and markers */
 		exec_traj.effect_on_success = [this, sub_traj,
 		                               description](const plan_execution::ExecutableMotionPlan* /*plan*/) {

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -170,12 +170,7 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		}
 		exec_traj.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
 		exec_traj.trajectory->setRobotTrajectoryMsg(state, sub_traj.trajectory);
-
-		if (!sub_traj.controller_names.empty()) {
-			for (auto cn : sub_traj.controller_names) {
-				exec_traj.controller_names_.push_back(cn.data.data());
-			}
-		}
+		exec_traj.controller_name = sub_traj.execution_info.controller_names;
 
 		/* TODO add action feedback and markers */
 		exec_traj.effect_on_success = [this, sub_traj,

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -201,6 +201,9 @@ public:
 	/// marker namespace of solution markers
 	const std::string& markerNS() { return properties().get<std::string>("marker_ns"); }
 
+	void setControllers(std::vector<std::string> controllers) { setProperty("controllers", controllers); }
+	std::vector<std::string> controllers() { return properties().get<std::vector<std::string>>("controllers"); }
+
 	/// forwarding of properties between interface states
 	void forwardProperties(const InterfaceState& source, InterfaceState& dest);
 	std::set<std::string> forwardedProperties() const {

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "trajectory_execution_info.h"
 #include "utils.h"
 #include <moveit/macros/class_forward.h>
 #include <moveit/task_constructor/storage.h>
@@ -201,8 +202,13 @@ public:
 	/// marker namespace of solution markers
 	const std::string& markerNS() { return properties().get<std::string>("marker_ns"); }
 
-	void setControllers(std::vector<std::string> controllers) { setProperty("controllers", controllers); }
-	std::vector<std::string> controllers() { return properties().get<std::vector<std::string>>("controllers"); }
+	/// Set and get info to use when executing the stage's trajectory
+	void setTrajectoryExecutionInfo(TrajectoryExecutionInfo trajectory_execution_info) {
+		setProperty("trajectory_execution_info", trajectory_execution_info);
+	}
+	TrajectoryExecutionInfo trajectoryExecutionInfo() {
+		return properties().get<TrajectoryExecutionInfo>("trajectory_execution_info");
+	}
 
 	/// forwarding of properties between interface states
 	void forwardProperties(const InterfaceState& source, InterfaceState& dest);

--- a/core/include/moveit/task_constructor/trajectory_execution_info.h
+++ b/core/include/moveit/task_constructor/trajectory_execution_info.h
@@ -1,0 +1,47 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Joe Schornak, Sebastian Jahr */
+
+#pragma once
+
+#include <moveit_task_constructor_msgs/msg/trajectory_execution_info.hpp>
+#include <string>
+#include <vector>
+
+namespace moveit {
+namespace task_constructor {
+using TrajectoryExecutionInfo = moveit_task_constructor_msgs::msg::TrajectoryExecutionInfo;
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -367,6 +367,9 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);
+	if (!this->controllers().empty())
+		stage->setControllers(this->controllers());
+
 	ContainerBasePrivate::const_iterator where = pimpl()->childByIndex(before, true);
 	ContainerBasePrivate::iterator it = pimpl()->children_.insert(where, std::move(stage));
 	impl->setParentPosition(it);

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -365,10 +365,12 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
+	if (stage->trajectoryExecutionInfo().controller_names.empty()) {
+		stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	}
+
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);
-	if (!this->controllers().empty())
-		stage->setControllers(this->controllers());
 
 	ContainerBasePrivate::const_iterator where = pimpl()->childByIndex(before, true);
 	ContainerBasePrivate::iterator it = pimpl()->children_.insert(where, std::move(stage));

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -308,7 +308,8 @@ Stage::Stage(StagePrivate* impl) : pimpl_(impl) {
 	auto& p = properties();
 	p.declare<double>("timeout", "timeout per run (s)");
 	p.declare<std::string>("marker_ns", name(), "marker namespace");
-	p.declare<std::vector<std::string>>("controllers", {}, "list of controllers to use for execution");
+	p.declare<TrajectoryExecutionInfo>("trajectory_execution_info", TrajectoryExecutionInfo(),
+	                                   "settings used when executing the trajectory");
 
 	p.declare<std::set<std::string>>("forwarded_properties", std::set<std::string>(),
 	                                 "set of interface properties to forward");

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -308,6 +308,7 @@ Stage::Stage(StagePrivate* impl) : pimpl_(impl) {
 	auto& p = properties();
 	p.declare<double>("timeout", "timeout per run (s)");
 	p.declare<std::string>("marker_ns", name(), "marker namespace");
+	p.declare<std::vector<std::string>>("controllers", {}, "list of controllers to use for execution");
 
 	p.declare<std::set<std::string>>("forwarded_properties", std::set<std::string>(),
 	                                 "set of interface properties to forward");

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -229,6 +229,15 @@ void SubTrajectory::appendTo(moveit_task_constructor_msgs::msg::Solution& msg, I
 	moveit_task_constructor_msgs::msg::SubTrajectory& t = msg.sub_trajectory.back();
 	SolutionBase::fillInfo(t.info, introspection);
 
+	std::vector<std::string> controllers = creator()->me()->properties().get<std::vector<std::string>>("controllers");
+	if (!controllers.empty()) {
+		for (auto cn : controllers) {
+			std_msgs::String s;
+			s.data = cn;
+			t.controller_names.push_back(s);
+		}
+	}
+
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -229,14 +229,9 @@ void SubTrajectory::appendTo(moveit_task_constructor_msgs::msg::Solution& msg, I
 	moveit_task_constructor_msgs::msg::SubTrajectory& t = msg.sub_trajectory.back();
 	SolutionBase::fillInfo(t.info, introspection);
 
-	std::vector<std::string> controllers = creator()->me()->properties().get<std::vector<std::string>>("controllers");
-	if (!controllers.empty()) {
-		for (auto cn : controllers) {
-			std_msgs::String s;
-			s.data = cn;
-			t.controller_names.push_back(s);
-		}
-	}
+	const auto trajectory_execution_info =
+	    creator()->properties().get<TrajectoryExecutionInfo>("trajectory_execution_info");
+	t.execution_info = trajectory_execution_info;
 
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ set(msg_files
 	"msg/SubTrajectory.msg"
 	"msg/TaskDescription.msg"
 	"msg/TaskStatistics.msg"
+        "msg/TrajectoryExecutionInfo.msg"
 )
 
 set(srv_files

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -6,3 +6,6 @@ moveit_msgs/RobotTrajectory trajectory
 
 # planning scene of end state as diff w.r.t. start state
 moveit_msgs/PlanningScene scene_diff
+
+# list of controllers to use for execution
+std_msgs/String[] controller_names

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -1,11 +1,11 @@
 # generic solution information
 SolutionInfo info
 
+# trajectory execution information, like controller configuration
+TrajectoryExecutionInfo execution_info
+
 # trajectory
 moveit_msgs/RobotTrajectory trajectory
 
 # planning scene of end state as diff w.r.t. start state
 moveit_msgs/PlanningScene scene_diff
-
-# list of controllers to use for execution
-std_msgs/String[] controller_names

--- a/msgs/msg/TrajectoryExecutionInfo.msg
+++ b/msgs/msg/TrajectoryExecutionInfo.msg
@@ -1,0 +1,2 @@
+# List of controllers to use when executing the trajectory
+string[] controller_names


### PR DESCRIPTION
This is essentially a ROS2 version of the work in #123, plus some additions based on @henningkayser's review of that PR.

- Add a new `TrajectoryExecutionInfo` ROS message to hold info used when executing the trajectory. Right now it just contains a vector of strings to define controller names used with the trajectory. Add an instance of this message as a field in the `SubTrajectory` message.
- Add a new `TrajectoryExecutionInfo` struct to hold this info as an MTC property.
- Propagate the `"trajectory_execution_info"` property from each stage into the `SubTrajectory` messages output when the task is planned.
- Modify the `ExecuteTaskSolution` capability to copy the controller names into the `RobotTrajectory` prior to execution.