### PR TITLE
Fix task's move constructor

### DIFF
--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -211,17 +211,17 @@ void Task::init() {
 	stages()->pimpl()->resolveInterface(InterfaceFlags({ GENERATE }));
 
 	// provide introspection instance to all stages
-	impl->setIntrospection(impl->introspection_.get());
+	auto* introspection = impl->introspection_.get();
 	impl->traverseStages(
-	    [impl](Stage& stage, int /*depth*/) {
-		    stage.pimpl()->setIntrospection(impl->introspection_.get());
+	    [introspection](Stage& stage, int /*depth*/) {
+		    stage.pimpl()->setIntrospection(introspection);
 		    return true;
 	    },
 	    1, UINT_MAX);
 
 	// first time publish task
-	if (impl->introspection_)
-		impl->introspection_->publishTaskDescription();
+	if (introspection)
+		introspection->publishTaskDescription();
 }
 
 bool Task::canCompute() const {

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -80,6 +80,9 @@ TaskPrivate& TaskPrivate::operator=(TaskPrivate&& other) {
 	robot_model_ = std::move(other.robot_model_);
 	robot_model_loader_ = std::move(other.robot_model_loader_);
 	task_cbs_ = std::move(other.task_cbs_);
+	// Ensure same introspection status, but keep the existing introspection instance,
+	// which stores this task pointer and includes it in its task_id_
+	static_cast<Task*>(me_)->enableIntrospection(static_cast<bool>(other.introspection_));
 	return *this;
 }
 

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -77,7 +77,6 @@ TaskPrivate::TaskPrivate(Task* me, const std::string& ns)
 TaskPrivate& TaskPrivate::operator=(TaskPrivate&& other) {
 	this->WrapperBasePrivate::operator=(std::move(other));
 	ns_ = std::move(other.ns_);
-	introspection_ = std::move(other.introspection_);
 	robot_model_ = std::move(other.robot_model_);
 	robot_model_loader_ = std::move(other.robot_model_loader_);
 	task_cbs_ = std::move(other.task_cbs_);


### PR DESCRIPTION
Fix https://github.com/ros-planning/moveit2_tutorials/pull/426


Backtrace:

```
#1  0x00007ffff7e50972 in moveit::task_constructor::Property::typeName[abi:cxx11]() const () from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#2  0x00007ffff7e3ca71 in moveit::task_constructor::Introspection::fillTaskDescription(moveit_task_constructor_msgs::TaskDescription_<std::allocator<void> >&)::{lambda(moveit::task_constructor::Stage const&, unsigned int)#1}::operator()(moveit::task_constructor::Stage const&, unsigned int) const [clone .isra.0] ()
   from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#3  0x00007ffff7e17cad in moveit::task_constructor::ContainerBase::traverseRecursively(std::function<bool (moveit::task_constructor::Stage const&, unsigned int)> const&) const ()
   from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#4  0x00007ffff7e3bce9 in moveit::task_constructor::Introspection::fillTaskDescription(moveit_task_constructor_msgs::TaskDescription_<std::allocator<void> >&) ()
   from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#5  0x00007ffff7e3bf1e in moveit::task_constructor::Introspection::publishTaskDescription() () from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#6  0x00007ffff7e6918a in moveit::task_constructor::Task::init() () from /home/jafar/workspaces/ros/ws_moveit/devel/lib/libmoveit_task_constructor_core.so
#7  0x000055555556541e in Task_taskMoveConstructor_Test::TestBody() ()
#8  0x00007ffff79fa151 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
   from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#9  0x00007ffff79ee2c6 in testing::Test::Run() () from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#10 0x00007ffff79ee425 in testing::TestInfo::Run() () from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#11 0x00007ffff79ee54d in testing::TestSuite::Run() () from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#12 0x00007ffff79eeb03 in testing::internal::UnitTestImpl::RunAllTests() () from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#13 0x00007ffff79eed68 in testing::UnitTest::Run() () from /home/jafar/workspaces/ros/ws_moveit/build/moveit_task_constructor_core/gtest/lib/libgtest.so
#14 0x0000555555560c00 in main ()
```
