### PR TITLE
Remove task size in task_id

### DIFF
--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -59,7 +59,7 @@ std::string getTaskId(const TaskPrivate* task) {
 	gethostname(our_hostname, sizeof(our_hostname) - 1);
 	// Hostname could have `-` as a character but this is an invalid character in ROS so we replace it with `_`
 	std::replace(std::begin(our_hostname), std::end(our_hostname), '-', '_');
-	oss << our_hostname << "_" << getpid() << "_" << reinterpret_cast<std::size_t>(task);
+	oss << our_hostname << "_" << getpid();
 	return oss.str();
 }
 }  // namespace


### PR DESCRIPTION
For dynamic tasks (where the stages can change between builds) the task_id changes as well.
This causes the GUI to show a different task.
Fix by removing the task size in the task_id string.