### PR TITLE
Fix call of computeGeneric

### DIFF
--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -291,8 +291,8 @@ public:
 
 	// Default implementations, using generic compute().
 	// Override if you want to use different code for FORWARD and BACKWARD directions.
-	virtual void computeForward(const InterfaceState& from) { computeGeneric<Interface::FORWARD>(from); }
-	virtual void computeBackward(const InterfaceState& to) { computeGeneric<Interface::BACKWARD>(to); }
+	virtual void computeForward(const InterfaceState& from);
+	virtual void computeBackward(const InterfaceState& to);
 
 protected:
 	// constructor for use in derived classes

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -616,6 +616,14 @@ template void PropagatingEitherWay::send<Interface::FORWARD>(const InterfaceStat
 template void PropagatingEitherWay::send<Interface::BACKWARD>(const InterfaceState& start, InterfaceState&& end,
                                                               SubTrajectory&& trajectory);
 
+void PropagatingEitherWay::computeForward(const InterfaceState& from) {
+	computeGeneric<Interface::FORWARD>(from);
+}
+
+void PropagatingEitherWay::computeBackward(const InterfaceState& to) {
+	computeGeneric<Interface::BACKWARD>(to);
+}
+
 template <Interface::Direction dir>
 void PropagatingEitherWay::computeGeneric(const InterfaceState& start) {
 	planning_scene::PlanningScenePtr end;


### PR DESCRIPTION
computeGeneric is templated and private so it will be undefined in the
shared object and when using the computeForward/Backward functions.