### PR TITLE
Task: findChild() and operator[] should directly operate on stages()

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -85,6 +85,9 @@ public:
 	const std::string& name() const { return stages()->name(); }
 	void setName(const std::string& name) { stages()->setName(name); }
 
+	Stage* findChild(const std::string& name) const { return stages()->findChild(name); }
+	Stage* operator[](int index) const { return stages()->operator[](index); }
+
 	const moveit::core::RobotModelConstPtr& getRobotModel() const;
 	/// setting the robot model also resets the task
 	void setRobotModel(const moveit::core::RobotModelConstPtr& robot_model);

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -79,20 +79,27 @@ TEST(ContainerBase, positionForInsert) {
 
 /* TODO: remove interface as it returns raw pointers */
 TEST(ContainerBase, findChild) {
-	SerialContainer s;
+	auto s = std::make_unique<SerialContainer>();
 	Stage *a, *b, *c1, *d;
-	s.add(Stage::pointer(a = new NamedStage("a")));
-	s.add(Stage::pointer(b = new NamedStage("b")));
-	s.add(Stage::pointer(c1 = new NamedStage("c")));
+	s->add(Stage::pointer(a = new NamedStage("a")));
+	s->add(Stage::pointer(b = new NamedStage("b")));
+	s->add(Stage::pointer(c1 = new NamedStage("c")));
 	auto sub = ContainerBase::pointer(new SerialContainer("c"));
 	sub->add(Stage::pointer(d = new NamedStage("d")));
-	s.add(std::move(sub));
+	s->add(std::move(sub));
 
-	EXPECT_EQ(s.findChild("a"), a);
-	EXPECT_EQ(s.findChild("b"), b);
-	EXPECT_EQ(s.findChild("c"), c1);
-	EXPECT_EQ(s.findChild("d"), nullptr);
-	EXPECT_EQ(s.findChild("c/d"), d);
+	EXPECT_EQ(s->findChild("a"), a);
+	EXPECT_EQ(s->findChild("b"), b);
+	EXPECT_EQ(s->findChild("c"), c1);
+	EXPECT_EQ(s->findChild("d"), nullptr);
+	EXPECT_EQ(s->findChild("c/d"), d);
+
+	Task t("", false, std::move(s));
+	EXPECT_EQ(t.findChild("a"), a);
+	EXPECT_EQ(t.findChild("b"), b);
+	EXPECT_EQ(t.findChild("c"), c1);
+	EXPECT_EQ(t.findChild("d"), nullptr);
+	EXPECT_EQ(t.findChild("c/d"), d);
 }
 
 template <typename Container>


### PR DESCRIPTION
Considering the (fixed) name of the top-level container is meaningless. The search should start at the wrapped container level.