### PR TITLE
workaround: Don't consider empty trajectories

### DIFF
--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -221,7 +221,7 @@ void SubTrajectory::fillMessage(moveit_task_constructor_msgs::Solution& msg, Int
 	moveit_task_constructor_msgs::SubTrajectory& t = msg.sub_trajectory.back();
 	SolutionBase::fillInfo(t.info, introspection);
 
-	if (trajectory())
+	if (trajectory() && trajectory()->getWayPointDurationFromStart(trajectory()->getWayPointCount() - 1) > 0.0)
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 
 	this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);


### PR DESCRIPTION
A quasi-empty trajectory comprising a single waypoint only (of zero duration), the ROS trajectory controller complains:
`Dropping all 1 trajectory point(s), as they occur before the current time. Last point is 0.000000s in the past.`

This is a quick hack for https://github.com/ros-planning/moveit_task_constructor/issues/433#issuecomment-1456178725.
I would rather like to handle that in MoveIt itself, but I don't have the time right now.