### PR TITLE
explainFailure()

### DIFF
--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -76,6 +76,7 @@ public:
 
 	virtual bool canCompute() const = 0;
 	virtual void compute() = 0;
+	void explainFailure(std::ostream& os) const override;
 
 	/// called by a (direct) child when a new solution becomes available
 	virtual void onNewSolution(const SolutionBase& s) = 0;

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -232,6 +232,8 @@ public:
 	/// Should we generate failure solutions? Note: Always report a failure!
 	bool storeFailures() const;
 
+	virtual void explainFailure(std::ostream& os) const;
+
 	/// Get the stage's property map
 	PropertyMap& properties();
 	const PropertyMap& properties() const { return const_cast<Stage*>(this)->properties(); }

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -129,6 +129,9 @@ public:
 	/// print current task state (number of found solutions and propagated states) to std::cout
 	void printState(std::ostream& os = std::cout) const;
 
+	/// print an explanation for a planning failure to os
+	void explainFailure(std::ostream& os = std::cout) const override;
+
 	size_t numSolutions() const { return solutions().size(); }
 	const ordered<SolutionBaseConstPtr>& solutions() const { return stages()->solutions(); }
 	const std::list<SolutionBaseConstPtr>& failures() const { return stages()->failures(); }

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -428,6 +428,11 @@ bool Stage::storeFailures() const {
 	return pimpl()->storeFailures();
 }
 
+void Stage::explainFailure(std::ostream& os) const {
+	if (!failures().empty())
+		os << ": " << failures().front()->comment();
+}
+
 PropertyMap& Stage::properties() {
 	return pimpl()->properties_;
 }

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -237,9 +237,12 @@ moveit::core::MoveItErrorCode Task::plan(size_t max_solutions) {
 	init();
 
 	// Print state and return success if there are solutions otherwise the input error_code
-	const auto success_or = [this](const int32_t error_code) {
+	const auto success_or = [this](const int32_t error_code) -> int32_t {
+		if (numSolutions() > 0)
+			return moveit::core::MoveItErrorCode::SUCCESS;
 		printState();
-		return numSolutions() > 0 ? moveit::core::MoveItErrorCode::SUCCESS : error_code;
+		explainFailure();
+		return error_code;
 	};
 	impl->preempt_requested_ = false;
 	const double available_time = timeout();
@@ -312,6 +315,11 @@ const core::RobotModelConstPtr& Task::getRobotModel() const {
 
 void Task::printState(std::ostream& os) const {
 	os << *stages();
+}
+
+void Task::explainFailure(std::ostream& os) const {
+	os << "Failing stage(s):\n";
+	stages()->explainFailure(os);
 }
 }  // namespace task_constructor
 }  // namespace moveit


### PR DESCRIPTION
When planning fails, for newbies it's often difficult to spot the offending stage. This utility function prints the stage(s), which have no solution, but only failures.