### PR TITLE
remove extra semicolon that triggers compiler warning

### DIFF
--- a/core/include/moveit/task_constructor/container.h
+++ b/core/include/moveit/task_constructor/container.h
@@ -163,7 +163,7 @@ class Fallbacks : public ParallelContainerBase
 	inline void replaceImpl();
 
 public:
-	PRIVATE_CLASS(Fallbacks);
+	PRIVATE_CLASS(Fallbacks)
 	Fallbacks(const std::string& name = "fallbacks");
 
 	void reset() override;


### PR DESCRIPTION
This is a minor change to fix a warning / error when compiling with -Wpedantic.
