### PR TITLE
Rework execution

### DIFF
--- a/core/include/moveit/task_constructor/execution.h
+++ b/core/include/moveit/task_constructor/execution.h
@@ -35,6 +35,7 @@
 /* Authors: Robert Haschke */
 
 #pragma once
+#include <list>
 
 #include <actionlib/client/simple_action_client.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
@@ -57,11 +58,13 @@ struct ExecutableTrajectory
 	std::string description;
 	robot_trajectory::RobotTrajectoryConstPtr trajectory;
 	std::vector<std::string> controller_names;
-	std::vector<EffectFn> start_effects;
-	std::vector<EffectFn> end_effects;
+	// std::list doesn't invalidate iterators upon insertion/deletion
+	std::list<EffectFn> start_effects;
+	std::list<EffectFn> end_effects;
 	bool stop = false;
 };
-using ExecutableMotionPlan = std::vector<ExecutableTrajectory>;
+// std::list doesn't invalidate iterators upon insertion/deletion
+using ExecutableMotionPlan = std::list<ExecutableTrajectory>;
 
 class PlanExecution
 {
@@ -70,7 +73,7 @@ class PlanExecution
 	ExecutableMotionPlan components_;
 	ExecutableMotionPlan::iterator next_;
 
-	void call(const std::vector<ExecutableTrajectory::EffectFn>& effects, const char* name);
+	void call(const std::list<ExecutableTrajectory::EffectFn>& effects, const char* name);
 	void onDone(const moveit_controller_manager::ExecutionStatus& status);
 	void onSuccessfulComponent();
 

--- a/core/include/moveit/task_constructor/execution.h
+++ b/core/include/moveit/task_constructor/execution.h
@@ -39,6 +39,8 @@
 #include <moveit/task_constructor/storage.h>
 #include <actionlib/client/simple_action_client.h>
 #include <moveit_task_constructor_msgs/ExecuteTaskSolutionAction.h>
+#include <moveit/moveit_cpp/moveit_cpp.h>
+#include <moveit/plan_execution/plan_execution.h>
 
 namespace moveit {
 namespace task_constructor {
@@ -47,6 +49,9 @@ namespace task_constructor {
 using ExecuteTaskSolutionSimpleActionClient =
     actionlib::SimpleActionClient<moveit_task_constructor_msgs::ExecuteTaskSolutionAction>;
 bool execute(const SolutionBase& s, ExecuteTaskSolutionSimpleActionClient* ac = nullptr, bool wait = true);
+
+/// Construct a motion plan for execution with MoveIt's PlanExecution
+plan_execution::ExecutableMotionPlan executableMotionPlan(const SolutionBase& s);
 
 }  // namespace task_constructor
 }  // namespace moveit

--- a/core/include/moveit/task_constructor/execution.h
+++ b/core/include/moveit/task_constructor/execution.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke */
+
+#pragma once
+
+#include <moveit/task_constructor/storage.h>
+#include <actionlib/client/simple_action_client.h>
+#include <moveit_task_constructor_msgs/ExecuteTaskSolutionAction.h>
+
+namespace moveit {
+namespace task_constructor {
+
+/// Execute trajectory using ExecuteTaskSolution provided as move_group capability
+using ExecuteTaskSolutionSimpleActionClient =
+    actionlib::SimpleActionClient<moveit_task_constructor_msgs::ExecuteTaskSolutionAction>;
+bool execute(const SolutionBase& s, ExecuteTaskSolutionSimpleActionClient* ac = nullptr, bool wait = true);
+
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -123,8 +123,8 @@ public:
 	moveit::core::MoveItErrorCode plan(size_t max_solutions = 0);
 	/// interrupt current planning (or execution)
 	void preempt();
-	/// execute solution, return the result
-	moveit::core::MoveItErrorCode execute(const SolutionBase& s);
+	/// execute solution (blocking), returns success
+	[[deprecated("Use plain function execute(SolutionBase) instead")]] bool execute(const SolutionBase& s);
 
 	/// print current task state (number of found solutions and propagated states) to std::cout
 	void printState(std::ostream& os = std::cout) const;

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(${PROJECT_NAME}
 
 	container.cpp
 	cost_terms.cpp
+	execution.cpp
 	introspection.cpp
 	marker_tools.cpp
 	merge.cpp

--- a/core/src/execution.cpp
+++ b/core/src/execution.cpp
@@ -64,8 +64,9 @@ moveit::core::MoveItErrorCode PlanExecution::run() {
 	// push components to TEM
 	for (auto it = next_, end = components_.end(); it != end; ++it) {
 		moveit_msgs::RobotTrajectory msg;
-		if (it->trajectory)
+		if (it->trajectory && !it->trajectory->empty() && (it->trajectory->getDuration() > 0.0))
 			it->trajectory->getRobotTrajectoryMsg(msg);
+
 		if (!tem_->push(msg, it->controller_names)) {
 			ROS_ERROR_STREAM_NAMED(LOGGER, "Trajectory initialization failed");
 			tem_->clear();

--- a/core/src/execution.cpp
+++ b/core/src/execution.cpp
@@ -61,6 +61,10 @@ moveit::core::MoveItErrorCode PlanExecution::run() {
 	if (next_ == components_.end())  // empty / already done
 		return moveit_msgs::MoveItErrorCodes::SUCCESS;
 
+	// TODO: Only stop our own execution
+	tem_->stopExecution();  // preempt any running trajectory sequence
+	// TODO: shorten next trajectory segment such that the start point deviation from current is minimized
+
 	// push components to TEM
 	for (auto it = next_, end = components_.end(); it != end; ++it) {
 		moveit_msgs::RobotTrajectory msg;

--- a/core/src/execution.cpp
+++ b/core/src/execution.cpp
@@ -1,0 +1,65 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Bielefeld University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Robert Haschke */
+
+#include <moveit/task_constructor/execution.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <moveit_msgs/MoveItErrorCodes.h>
+
+namespace moveit {
+namespace task_constructor {
+
+bool execute(const SolutionBase& s, ExecuteTaskSolutionSimpleActionClient* ac, bool wait) {
+	std::unique_ptr<ExecuteTaskSolutionSimpleActionClient> fallback;
+	if (!ac) {
+		fallback = std::make_unique<ExecuteTaskSolutionSimpleActionClient>("execute_task_solution");
+		ac = fallback.get();
+	}
+	ac->waitForServer();
+
+	moveit_task_constructor_msgs::ExecuteTaskSolutionGoal goal;
+	s.fillMessage(goal.solution);
+	s.start()->scene()->getPlanningSceneMsg(goal.solution.start_scene);
+
+	ac->sendGoal(goal);
+	if (wait) {
+		ac->waitForResult();
+		return ac->getResult()->error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
+	}
+	return true;
+}
+
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/src/execution.cpp
+++ b/core/src/execution.cpp
@@ -96,7 +96,7 @@ moveit::core::MoveItErrorCode PlanExecution::run() {
 	}
 }
 
-void PlanExecution::call(const std::vector<ExecutableTrajectory::EffectFn>& effects, const char* name) {
+void PlanExecution::call(const std::list<ExecutableTrajectory::EffectFn>& effects, const char* name) {
 	ROS_DEBUG_STREAM_NAMED(LOGGER + ".apply", effects.size() << " " << name << " effects of: " << next_->description);
 	for (const auto& f : effects)
 		f(this);

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -216,6 +216,10 @@ void SolutionBase::fillInfo(moveit_task_constructor_msgs::SolutionInfo& info, In
 	std::copy(markers.begin(), markers.end(), info.markers.begin());
 }
 
+void SubTrajectory::visitSubTrajectories(const std::function<void(const SubTrajectory&)>& f) const {
+	f(*this);
+}
+
 void SubTrajectory::fillMessage(moveit_task_constructor_msgs::Solution& msg, Introspection* introspection) const {
 	msg.sub_trajectory.emplace_back();
 	moveit_task_constructor_msgs::SubTrajectory& t = msg.sub_trajectory.back();
@@ -233,6 +237,11 @@ double SubTrajectory::computeCost(const CostTerm& f, std::string& comment) const
 
 void SolutionSequence::push_back(const SolutionBase& solution) {
 	subsolutions_.push_back(&solution);
+}
+
+void SolutionSequence::visitSubTrajectories(const std::function<void(const SubTrajectory&)>& f) const {
+	for (const SolutionBase* s : subsolutions_)
+		s->visitSubTrajectories(f);
 }
 
 void SolutionSequence::fillMessage(moveit_task_constructor_msgs::Solution& msg, Introspection* introspection) const {
@@ -272,6 +281,10 @@ void SolutionSequence::fillMessage(moveit_task_constructor_msgs::Solution& msg, 
 
 double SolutionSequence::computeCost(const CostTerm& f, std::string& comment) const {
 	return f(*this, comment);
+}
+
+void WrappedSolution::visitSubTrajectories(const std::function<void(const SubTrajectory&)>& f) const {
+	wrapped_->visitSubTrajectories(f);
 }
 
 void WrappedSolution::fillMessage(moveit_task_constructor_msgs::Solution& solution,

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -38,10 +38,8 @@
 #include <moveit/task_constructor/container_p.h>
 #include <moveit/task_constructor/task_p.h>
 #include <moveit/task_constructor/introspection.h>
-#include <moveit_task_constructor_msgs/ExecuteTaskSolutionAction.h>
-
+#include <moveit/task_constructor/execution.h>
 #include <ros/ros.h>
-#include <actionlib/client/simple_action_client.h>
 
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_pipeline/planning_pipeline.h>
@@ -262,17 +260,8 @@ void Task::preempt() {
 	pimpl()->preempt_requested_ = true;
 }
 
-moveit::core::MoveItErrorCode Task::execute(const SolutionBase& s) {
-	actionlib::SimpleActionClient<moveit_task_constructor_msgs::ExecuteTaskSolutionAction> ac("execute_task_solution");
-	ac.waitForServer();
-
-	moveit_task_constructor_msgs::ExecuteTaskSolutionGoal goal;
-	s.fillMessage(goal.solution, pimpl()->introspection_.get());
-	s.start()->scene()->getPlanningSceneMsg(goal.solution.start_scene);
-
-	ac.sendGoal(goal);
-	ac.waitForResult();
-	return ac.getResult()->error_code;
+bool Task::execute(const SolutionBase& s) {
+	return ::moveit::task_constructor::execute(s);
 }
 
 void Task::publishAllSolutions(bool wait) {


### PR DESCRIPTION
This is a draft I had lying around for a while to rework MTC solution execution. Instead of calling the move_group's capability, the idea is to directly interface MoveIt's `TrajectoryExecutionManager` and thus allow callbacks for each sub-trajectory segment. To this end, this PR reimplements MoveIt's `PlanExecution` to:
- allow for both start and end callbacks for each segment in an `ExecutableMotionPlan` (the [original PlanExecution only allowed for end effects](https://github.com/ros-planning/moveit/blob/8635f82e4823b970479f360216bbe8292f79e8e4/moveit_ros/planning/plan_execution/include/moveit/plan_execution/plan_representation.h#L68))
  Of course, in principle it would suffice to have start _or_ end effects only. However, I found it simpler to define preparatory and cleanup tasks of a specific segment within that segment instead of shifting one or the other to the previous/next segment.
- to run a sequence of related trajectories without risking interference with another caller

The latter functionality was also implemented by https://github.com/ros-planning/moveit/pull/3243 meanwhile.

The old Task::execute() method was moved into a free function `execute()`, still calling the move_group capability.
However, a new free function `executableMotionPlan(SolutionBase)` is provided to create the `ExecutableMotionPlan` for use with the new `PlanExecution`.

This needs to be consolidated with https://github.com/ros-planning/moveit/pull/3243. 
@cambel and @v4hn: Can we organize a video conference to discuss open TODOs?
