### PR TITLE
use pluginlib consistently

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -191,5 +191,5 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 
 }  // namespace move_group
 
-#include <class_loader/class_loader.hpp>
-CLASS_LOADER_REGISTER_CLASS(move_group::ExecuteTaskSolutionCapability, move_group::MoveGroupCapability)
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(move_group::ExecuteTaskSolutionCapability, move_group::MoveGroupCapability)

--- a/core/src/stages/plugins.cpp
+++ b/core/src/stages/plugins.cpp
@@ -1,6 +1,6 @@
 #include <moveit/task_constructor/stages/current_state.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 /// register plugins to use with ClassLoader
 

--- a/visualization/motion_planning_tasks/src/plugin_init.cpp
+++ b/visualization/motion_planning_tasks/src/plugin_init.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Robert Haschke */
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include "task_display.h"
 #include "task_panel.h"
 

--- a/visualization/motion_planning_tasks/src/pluginlib_factory.h
+++ b/visualization/motion_planning_tasks/src/pluginlib_factory.h
@@ -45,7 +45,7 @@
 #include <vector>
 
 #ifndef Q_MOC_RUN
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 #include <rviz/load_resource.h>
 #include <functional>
 #endif


### PR DESCRIPTION
and include with *.hpp suffix as the old *.h headers have been
forwards for a long time.

Just a tiny cleanup I found on the side.
