### PR TITLE
Make move relative stage handle planning failure

### DIFF
--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -287,38 +287,38 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 		success =
 		    planner_->plan(state.scene(), *link, offset, target_eigen, jmg, timeout, robot_trajectory, path_constraints);
 
-    if (success) {
-      moveit::core::RobotStatePtr& reached_state = robot_trajectory->getLastWayPointPtr();
-      reached_state->updateLinkTransforms();
-      const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link) * offset;
+		if (success) {
+			moveit::core::RobotStatePtr& reached_state = robot_trajectory->getLastWayPointPtr();
+			reached_state->updateLinkTransforms();
+			const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link) * offset;
 
-      double distance = 0.0;
-      if (use_rotation_distance) {
-        Eigen::AngleAxisd rotation(reached_pose.linear() * ik_pose_world.linear().transpose());
-        distance = rotation.angle();
-      } else
-        distance = (reached_pose.translation() - ik_pose_world.translation()).norm();
+			double distance = 0.0;
+			if (use_rotation_distance) {
+				Eigen::AngleAxisd rotation(reached_pose.linear() * ik_pose_world.linear().transpose());
+				distance = rotation.angle();
+			} else
+				distance = (reached_pose.translation() - ik_pose_world.translation()).norm();
 
-      // min_distance reached?
-      if (min_distance > 0.0) {
-        success = distance >= min_distance;
-        if (!success) {
-          char msg[100];
-          snprintf(msg, sizeof(msg), "min_distance not reached (%.3g < %.3g)", distance, min_distance);
-          solution.setComment(msg);
-        }
-      } else if (min_distance == 0.0) {  // if min_distance is zero, we succeed in any case
-        success = true;
-      } else if (!success)
-        solution.setComment("failed to move full distance");
+			// min_distance reached?
+			if (min_distance > 0.0) {
+				success = distance >= min_distance;
+				if (!success) {
+					char msg[100];
+					snprintf(msg, sizeof(msg), "min_distance not reached (%.3g < %.3g)", distance, min_distance);
+					solution.setComment(msg);
+				}
+			} else if (min_distance == 0.0) {	// if min_distance is zero, we succeed in any case
+				success = true;
+			} else if (!success)
+				solution.setComment("failed to move full distance");
 
-      // visualize plan
-      auto ns = props.get<std::string>("marker_ns");
-      if (!ns.empty() && linear_norm > 0) {  // ensures that 'distance' is the norm of the reached distance
-        visualizePlan(solution.markers(), dir, success, ns, scene->getPlanningFrame(), ik_pose_world, reached_pose,
-                      linear, distance);
-      }
-    }
+			// visualize plan
+			auto ns = props.get<std::string>("marker_ns");
+			if (!ns.empty() && linear_norm > 0) {	// ensures that 'distance' is the norm of the reached distance
+				visualizePlan(solution.markers(), dir, success, ns, scene->getPlanningFrame(), ik_pose_world, reached_pose,
+				              linear, distance);
+			}
+		}
 	}
 
 	// store result

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -287,36 +287,38 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 		success =
 		    planner_->plan(state.scene(), *link, offset, target_eigen, jmg, timeout, robot_trajectory, path_constraints);
 
-		moveit::core::RobotStatePtr& reached_state = robot_trajectory->getLastWayPointPtr();
-		reached_state->updateLinkTransforms();
-		const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link) * offset;
+    if (success) {
+      moveit::core::RobotStatePtr& reached_state = robot_trajectory->getLastWayPointPtr();
+      reached_state->updateLinkTransforms();
+      const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link) * offset;
 
-		double distance = 0.0;
-		if (use_rotation_distance) {
-			Eigen::AngleAxisd rotation(reached_pose.linear() * ik_pose_world.linear().transpose());
-			distance = rotation.angle();
-		} else
-			distance = (reached_pose.translation() - ik_pose_world.translation()).norm();
+      double distance = 0.0;
+      if (use_rotation_distance) {
+        Eigen::AngleAxisd rotation(reached_pose.linear() * ik_pose_world.linear().transpose());
+        distance = rotation.angle();
+      } else
+        distance = (reached_pose.translation() - ik_pose_world.translation()).norm();
 
-		// min_distance reached?
-		if (min_distance > 0.0) {
-			success = distance >= min_distance;
-			if (!success) {
-				char msg[100];
-				snprintf(msg, sizeof(msg), "min_distance not reached (%.3g < %.3g)", distance, min_distance);
-				solution.setComment(msg);
-			}
-		} else if (min_distance == 0.0) {  // if min_distance is zero, we succeed in any case
-			success = true;
-		} else if (!success)
-			solution.setComment("failed to move full distance");
+      // min_distance reached?
+      if (min_distance > 0.0) {
+        success = distance >= min_distance;
+        if (!success) {
+          char msg[100];
+          snprintf(msg, sizeof(msg), "min_distance not reached (%.3g < %.3g)", distance, min_distance);
+          solution.setComment(msg);
+        }
+      } else if (min_distance == 0.0) {  // if min_distance is zero, we succeed in any case
+        success = true;
+      } else if (!success)
+        solution.setComment("failed to move full distance");
 
-		// visualize plan
-		auto ns = props.get<std::string>("marker_ns");
-		if (!ns.empty() && linear_norm > 0) {  // ensures that 'distance' is the norm of the reached distance
-			visualizePlan(solution.markers(), dir, success, ns, scene->getPlanningFrame(), ik_pose_world, reached_pose,
-			              linear, distance);
-		}
+      // visualize plan
+      auto ns = props.get<std::string>("marker_ns");
+      if (!ns.empty() && linear_norm > 0) {  // ensures that 'distance' is the norm of the reached distance
+        visualizePlan(solution.markers(), dir, success, ns, scene->getPlanningFrame(), ik_pose_world, reached_pose,
+                      linear, distance);
+      }
+    }
 	}
 
 	// store result


### PR DESCRIPTION
This PR fixes an issue where the planner fails, but the move relative stage proceeds as if it succeeded.