### PR TITLE
Mark incomplete trajectories as failure

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -144,13 +144,13 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		state = scene->getCurrentState();
 	}
 
-	plan.plan_components_.reserve(solution.sub_trajectory.size());
+	plan.plan_components.reserve(solution.sub_trajectory.size());
 	auto make_executable_trajectory =
 	    [&](const moveit_task_constructor_msgs::msg::SubTrajectory& sub_traj, const std::string& description,
 	        const std::function<bool(const plan_execution::ExecutableMotionPlan*)>& on_success_callback) {
-		    plan.plan_components_.emplace_back();
-		    plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components_.back();
-		    exec_traj.description_ = description;
+		    plan.plan_components.emplace_back();
+		    plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components.back();
+		    exec_traj.description = description;
 		    const moveit::core::JointModelGroup* group = nullptr;
 		    {
 			    std::vector<std::string> joint_names(sub_traj.trajectory.joint_trajectory.joint_names);
@@ -166,12 +166,12 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 				    RCLCPP_DEBUG(LOGGER, "Using JointModelGroup '%s' for execution", group->getName().c_str());
 			    }
 		    }
-		    exec_traj.trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
-		    exec_traj.trajectory_->setRobotTrajectoryMsg(state, sub_traj.trajectory);
-		    exec_traj.controller_names_ = sub_traj.execution_info.controller_names;
+		    exec_traj.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
+		    exec_traj.trajectory->setRobotTrajectoryMsg(state, sub_traj.trajectory);
+		    exec_traj.controller_name = sub_traj.execution_info.controller_names;
 
 		    /* todo add action feedback and markers */
-		    exec_traj.effect_on_success_ = on_success_callback;
+		    exec_traj.effect_on_success = on_success_callback;
 		    return true;
 	    };
 

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -168,8 +168,9 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 				RCLCPP_DEBUG(LOGGER, "Using JointModelGroup '%s' for execution", group->getName().c_str());
 			}
 		}
-		exec_traj.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
-		exec_traj.trajectory->setRobotTrajectoryMsg(state, sub_traj.trajectory);
+		exec_traj.trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
+		exec_traj.trajectory_->setRobotTrajectoryMsg(state, sub_traj.trajectory);
+		exec_traj.controller_names_ = sub_traj.execution_info.controller_names;
 
 		/* TODO add action feedback and markers */
 		exec_traj.effect_on_success = [this, sub_traj,

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -94,8 +94,10 @@ void ExecuteTaskSolutionCapability::initialize() {
 	                                             std::placeholders::_1, std::placeholders::_2)),
 	    ActionServerType::CancelCallback(
 	        std::bind(&ExecuteTaskSolutionCapability::preemptCallback, this, std::placeholders::_1)),
-	    ActionServerType::AcceptedCallback(
-	        std::bind(&ExecuteTaskSolutionCapability::goalCallback, this, std::placeholders::_1)));
+	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>> goal_handle) {
+		    last_goal_future_ =
+		        std::async(std::launch::async, &ExecuteTaskSolutionCapability::goalCallback, this, goal_handle);
+	    });
 }
 
 void ExecuteTaskSolutionCapability::goalCallback(
@@ -142,53 +144,75 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		state = scene->getCurrentState();
 	}
 
-	plan.plan_components.reserve(solution.sub_trajectory.size());
-	for (size_t i = 0; i < solution.sub_trajectory.size(); ++i) {
+	plan.plan_components_.reserve(solution.sub_trajectory.size());
+	auto make_executable_trajectory =
+	    [&](const moveit_task_constructor_msgs::msg::SubTrajectory& sub_traj, const std::string& description,
+	        const std::function<bool(const plan_execution::ExecutableMotionPlan*)>& on_success_callback) {
+		    plan.plan_components_.emplace_back();
+		    plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components_.back();
+		    exec_traj.description_ = description;
+		    const moveit::core::JointModelGroup* group = nullptr;
+		    {
+			    std::vector<std::string> joint_names(sub_traj.trajectory.joint_trajectory.joint_names);
+			    joint_names.insert(joint_names.end(), sub_traj.trajectory.multi_dof_joint_trajectory.joint_names.begin(),
+			                       sub_traj.trajectory.multi_dof_joint_trajectory.joint_names.end());
+			    if (!joint_names.empty()) {
+				    group = findJointModelGroup(*model, joint_names);
+				    if (!group) {
+					    RCLCPP_ERROR_STREAM(LOGGER, "Could not find JointModelGroup that actuates {"
+					                                    << boost::algorithm::join(joint_names, ", ") << "}");
+					    return false;
+				    }
+				    RCLCPP_DEBUG(LOGGER, "Using JointModelGroup '%s' for execution", group->getName().c_str());
+			    }
+		    }
+		    exec_traj.trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
+		    exec_traj.trajectory_->setRobotTrajectoryMsg(state, sub_traj.trajectory);
+		    exec_traj.controller_names_ = sub_traj.execution_info.controller_names;
+
+		    /* todo add action feedback and markers */
+		    exec_traj.effect_on_success_ = on_success_callback;
+		    return true;
+	    };
+
+	auto make_apply_planning_scene_diff_cb = [this](const std::vector<moveit_msgs::msg::PlanningScene>& scene_diffs) {
+		return
+		    [this, scene_diffs = std::move(scene_diffs)](const plan_execution::ExecutableMotionPlan* /*plan*/) mutable {
+			    for (auto& scene_diff : scene_diffs) {
+				    if (!moveit::core::isEmpty(scene_diff)) {
+					    /* RCLCPP_DEBUG_STREAM(LOGGER, "apply effect of " << description); */
+					    scene_diff.robot_state.joint_state = sensor_msgs::msg::JointState();
+					    scene_diff.robot_state.multi_dof_joint_state = sensor_msgs::msg::MultiDOFJointState();
+					    if (!context_->planning_scene_monitor_->newPlanningSceneMessage(scene_diff))
+						    return false;
+				    }
+			    }
+			    return true;
+		    };
+	};
+	auto make_description = [size = solution.sub_trajectory.size()](const std::size_t index) {
+		return std::to_string(index + 1) + "/" + std::to_string(size);
+	};
+	// TODO: Case for only one subtrajectory
+	if (!make_executable_trajectory(solution.sub_trajectory[0], make_description(0),
+	                                make_apply_planning_scene_diff_cb({ solution.sub_trajectory[0].scene_diff,
+	                                                                    solution.sub_trajectory[1].scene_diff })))
+		return false;
+	for (size_t i = 1; i < solution.sub_trajectory.size() - 1; ++i) {
 		const moveit_task_constructor_msgs::msg::SubTrajectory& sub_traj = solution.sub_trajectory[i];
 
-		plan.plan_components.emplace_back();
-		plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components.back();
-
 		// define individual variable for use in closure below
-		const std::string description = std::to_string(i + 1) + "/" + std::to_string(solution.sub_trajectory.size());
-		exec_traj.description = description;
-
-		const moveit::core::JointModelGroup* group = nullptr;
-		{
-			std::vector<std::string> joint_names(sub_traj.trajectory.joint_trajectory.joint_names);
-			joint_names.insert(joint_names.end(), sub_traj.trajectory.multi_dof_joint_trajectory.joint_names.begin(),
-			                   sub_traj.trajectory.multi_dof_joint_trajectory.joint_names.end());
-			if (!joint_names.empty()) {
-				group = findJointModelGroup(*model, joint_names);
-				if (!group) {
-					RCLCPP_ERROR_STREAM(LOGGER, "Could not find JointModelGroup that actuates {"
-					                                << boost::algorithm::join(joint_names, ", ") << "}");
-					return false;
-				}
-				RCLCPP_DEBUG(LOGGER, "Using JointModelGroup '%s' for execution", group->getName().c_str());
-			}
-		}
-		exec_traj.trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
-		exec_traj.trajectory_->setRobotTrajectoryMsg(state, sub_traj.trajectory);
-		exec_traj.controller_names_ = sub_traj.execution_info.controller_names;
-
-		/* TODO add action feedback and markers */
-		exec_traj.effect_on_success = [this, sub_traj,
-		                               description](const plan_execution::ExecutableMotionPlan* /*plan*/) {
-			if (!moveit::core::isEmpty(sub_traj.scene_diff)) {
-				RCLCPP_DEBUG_STREAM(LOGGER, "apply effect of " << description);
-				return context_->planning_scene_monitor_->newPlanningSceneMessage(sub_traj.scene_diff);
-			}
-			return true;
-		};
-
+		const std::string description = make_description(i);
+		if (!make_executable_trajectory(sub_traj, description,
+		                                make_apply_planning_scene_diff_cb({ solution.sub_trajectory[i + 1].scene_diff })))
+			return false;
 		if (!moveit::core::isEmpty(sub_traj.scene_diff.robot_state) &&
 		    !moveit::core::robotStateMsgToRobotState(sub_traj.scene_diff.robot_state, state, true)) {
-			RCLCPP_ERROR_STREAM(LOGGER, "invalid intermediate robot state in scene diff of SubTrajectory " << description);
+			RCLCPP_ERROR_STREAM(LOGGER, "invalid intermediate robot state in scene diff of subtrajectory " << description);
 			return false;
 		}
 	}
-
+	make_executable_trajectory(solution.sub_trajectory.back(), make_description(solution.sub_trajectory.size() - 1), {});
 	return true;
 }
 

--- a/capabilities/src/execute_task_solution_capability.h
+++ b/capabilities/src/execute_task_solution_capability.h
@@ -68,13 +68,17 @@ private:
 	rclcpp_action::CancelResponse
 	preemptCallback(const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle);
 
-	/** Always accept the goal */
+	/** Only accept the goal if we aren't executing one */
 	rclcpp_action::GoalResponse handleNewGoal(const rclcpp_action::GoalUUID& /*uuid*/,
-	                                          const ExecuteTaskSolutionAction::Goal::ConstSharedPtr& /*goal*/) const {
+	                                          const ExecuteTaskSolutionAction::Goal::ConstSharedPtr /*goal*/) const {
+		if (last_goal_future_.valid() &&
+		    last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready)
+			return rclcpp_action::GoalResponse::REJECT;
 		return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 	}
 
 	ActionServerType::SharedPtr as_;
+	std::future<void> last_goal_future_;
 };
 
 }  // namespace move_group

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -34,8 +34,7 @@ install(DIRECTORY include/ DESTINATION include
 
 pluginlib_export_plugin_description_file(${PROJECT_NAME} motion_planning_stages_plugin_description.xml)
 
-ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME} ${PROJECT_NAME}_stages)
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
 ament_export_dependencies(Boost)
 ament_export_dependencies(geometry_msgs)
 ament_export_dependencies(moveit_core)

--- a/core/include/moveit/task_constructor/solvers/pipeline_planner.h
+++ b/core/include/moveit/task_constructor/solvers/pipeline_planner.h
@@ -32,13 +32,16 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Authors: Robert Haschke
-   Desc:    plan using MoveIt's PlanningPipeline
+/* Authors: Robert Haschke, Sebastian Jahr
+   Description: Solver that uses a set of MoveIt PlanningPipelines to solve a given planning problem.
 */
 
 #pragma once
 
 #include <moveit/task_constructor/solvers/planner_interface.h>
+#include <moveit/planning_pipeline_interfaces/planning_pipeline_interfaces.hpp>
+#include <moveit/planning_pipeline_interfaces/solution_selection_functions.hpp>
+#include <moveit/planning_pipeline_interfaces/stopping_criterion_functions.hpp>
 #include <rclcpp/node.hpp>
 #include <moveit/macros/class_forward.h>
 
@@ -56,48 +59,132 @@ MOVEIT_CLASS_FORWARD(PipelinePlanner);
 class PipelinePlanner : public PlannerInterface
 {
 public:
-	struct Specification
-	{
-		moveit::core::RobotModelConstPtr model;
-		std::string ns{ "ompl" };
-		std::string pipeline{ "ompl" };
-		std::string adapter_param{ "request_adapters" };
-	};
+	/** Simple Constructor to use only a single pipeline
+	 * \param [in] node ROS 2 node
+	 * \param [in] pipeline_name Name of the planning pipeline to be used. This is also the assumed namespace where the
+	 * parameters of this pipeline can be found \param [in] planner_id Planner id to be used for planning
+	 */
+	PipelinePlanner(const rclcpp::Node::SharedPtr& node, const std::string& pipeline_name = "ompl",
+	                const std::string& planner_id = "");
 
-	static planning_pipeline::PlanningPipelinePtr create(const rclcpp::Node::SharedPtr& node,
-	                                                     const moveit::core::RobotModelConstPtr& model) {
-		Specification spec;
-		spec.model = model;
-		return create(node, spec);
+	[[deprecated("Deprecated: Use new constructor implementations.")]]  // clang-format off
+	PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& /*planning_pipeline*/){};
+
+	/** \brief Constructor
+	 * \param [in] node ROS 2 node
+	 * \param [in] pipeline_id_planner_id_map A map containing pairs of planning pipeline name and planner plugin name
+	 * for the planning requests
+	 * \param [in] planning_pipelines Optional: A map with the pipeline names and initialized corresponding planning
+	 * pipelines
+	 * \param [in] stopping_criterion_callback Callback function to stop parallel planning pipeline according to a user defined criteria
+	 * \param [in] solution_selection_function Callback function to choose the best solution when multiple pipelines are used
+	 */
+	PipelinePlanner(const rclcpp::Node::SharedPtr& node,
+	                const std::unordered_map<std::string, std::string>& pipeline_id_planner_id_map,
+	                const std::unordered_map<std::string, planning_pipeline::PlanningPipelinePtr>& planning_pipelines =
+	                    std::unordered_map<std::string, planning_pipeline::PlanningPipelinePtr>(),
+					const moveit::planning_pipeline_interfaces::StoppingCriterionFunction& stopping_criterion_callback = nullptr,
+					const moveit::planning_pipeline_interfaces::SolutionSelectionFunction& solution_selection_function =
+						&moveit::planning_pipeline_interfaces::getShortestSolution);
+
+	[[deprecated("Replaced with setPlannerId(pipeline_name, planner_id)")]]  // clang-format off
+	void setPlannerId(const std::string& /*planner*/) { /* Do nothing */
 	}
 
-	static planning_pipeline::PlanningPipelinePtr create(const rclcpp::Node::SharedPtr& node, const Specification& spec);
-
-	/**
-	 *
-	 * @param node used to load the parameters for the planning pipeline
+	/** \brief Set the planner id for a specific planning pipeline for the planning requests
+	 * \param [in] pipeline_name Name of the planning pipeline for which the planner id is set
+	 * \param [in] planner_id Name of the planner ID that should be used by the planning pipeline
+	 * \return true if the pipeline exists and the corresponding ID is set successfully
 	 */
-	PipelinePlanner(const rclcpp::Node::SharedPtr& node, const std::string& pipeline = "ompl");
+	bool setPlannerId(const std::string& pipeline_name, const std::string& planner_id);
 
-	PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline);
+	/** \brief Set stopping criterion function for parallel planning
+	 * \param [in] stopping_criterion_callback New stopping criterion function that will be used
+	*/
+	void setStoppingCriterionFunction(const moveit::planning_pipeline_interfaces::StoppingCriterionFunction& stopping_criterion_callback);
 
-	void setPlannerId(const std::string& planner) { setProperty("planner", planner); }
+	/** \brief Set solution selection function for parallel planning
+	 * \param [in] solution_selection_function New solution selection that will be used
+	*/
+	void setSolutionSelectionFunction(const moveit::planning_pipeline_interfaces::SolutionSelectionFunction& solution_selection_function);
 
+	/** \brief This function is called when an MTC task that uses this solver is initialized. If no pipelines are
+	 * configured when this function is invoked, the planning pipelines named in the 'pipeline_id_planner_id_map' are
+	 * initialized with the given robot model.
+	 * \param [in] robot_model A robot model that is used to initialize the
+	 * planning pipelines of this solver
+	 */
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 
+	/**
+	 * \brief Plan a trajectory from a planning scene 'from' to scene 'to'
+	 * \param [in] from Start planning scene
+	 * \param [in] to Goal planning scene (used to create goal constraints)
+	 * \param [in] joint_model_group Group of joints for which this trajectory is created
+	 * \param [in] timeout ?
+	 * \param [in] result Reference to the location where the created trajectory is stored if planning is successful
+	 * \param [in] path_constraints Path contraints for the planning problem
+	 * \return true If the solver found a successful solution for the given planning problem
+	 */
 	bool plan(const planning_scene::PlanningSceneConstPtr& from, const planning_scene::PlanningSceneConstPtr& to,
-	          const core::JointModelGroup* jmg, double timeout, robot_trajectory::RobotTrajectoryPtr& result,
+	          const core::JointModelGroup* joint_model_group, double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result,
 	          const moveit_msgs::msg::Constraints& path_constraints = moveit_msgs::msg::Constraints()) override;
 
+	/** \brief Plan a trajectory from a planning scene 'from' to a target pose with an offset
+	 * \param [in] from Start planning scene
+	 * \param [in] link Link for which a target pose is given
+	 * \param [in] offset Offset to be applied to a given target pose
+	 * \param [in] target Target pose
+	 * \param [in] joint_model_group Group of joints for which this trajectory is created
+	 * \param [in] timeout ?
+	 * \param [in] result Reference to the location where the created trajectory is stored if planning is successful
+	 * \param [in] path_constraints Path contraints for the planning problem
+	 * \return true If the solver found a successful solution for the given planning problem
+	 */
 	bool plan(const planning_scene::PlanningSceneConstPtr& from, const moveit::core::LinkModel& link,
-	          const Eigen::Isometry3d& offset, const Eigen::Isometry3d& target, const moveit::core::JointModelGroup* jmg,
-	          double timeout, robot_trajectory::RobotTrajectoryPtr& result,
+	          const Eigen::Isometry3d& offset, const Eigen::Isometry3d& target,
+	          const moveit::core::JointModelGroup* joint_model_group, double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result,
 	          const moveit_msgs::msg::Constraints& path_constraints = moveit_msgs::msg::Constraints()) override;
 
 protected:
-	std::string pipeline_name_;
-	planning_pipeline::PlanningPipelinePtr planner_;
+	/** \brief Function that actually uses the planning pipelines to solve the given planning problem. It is called by
+	 * the public plan function after the goal constraints are generated. This function uses a predefined number of
+	 * planning pipelines in parallel to solve the planning problem and choose the automatically the best (user-defined)
+	 * solution.
+	 * \param [in] planning_scene Scene for which the planning should be solved
+	 * \param [in] joint_model_group
+	 * Group of joints for which this trajectory is created
+	 * \param [in] goal_constraints Set of constraints that need to
+	 * be satisfied by the solution
+	 * \param [in] timeout ?
+	 * \param [in] result Reference to the location where the created
+	 * trajectory is stored if planning is successful
+	 * \param [in] path_constraints Path contraints for the planning
+	 * problem
+	 * \return true If the solver found a successful solution for the given planning problem
+	 */
+	bool plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
+	          const moveit::core::JointModelGroup* joint_model_group,
+	          const moveit_msgs::msg::Constraints& goal_constraints, double timeout,
+	          robot_trajectory::RobotTrajectoryPtr& result,
+	          const moveit_msgs::msg::Constraints& path_constraints = moveit_msgs::msg::Constraints());
+
 	rclcpp::Node::SharedPtr node_;
+
+	/** \brief Map of pipeline names (ids) and their corresponding planner ids. The planning problem is solved for every
+	 * pipeline-planner pair in this map. If no pipelines are passed via constructor argument, the pipeline names are
+	 * used to initialize a set of planning pipelines.  */
+	std::unordered_map<std::string, std::string> pipeline_id_planner_id_map_;
+
+	/** \brief Map of pipelines names and planning pipelines. This map is used to quickly search for a requested motion
+	 * planning pipeline when during plan(..) */
+	std::unordered_map<std::string, planning_pipeline::PlanningPipelinePtr> planning_pipelines_;
+
+	moveit::planning_pipeline_interfaces::StoppingCriterionFunction stopping_criterion_callback_;
+	moveit::planning_pipeline_interfaces::SolutionSelectionFunction solution_selection_function_;
+
 };
 }  // namespace solvers
 }  // namespace task_constructor

--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -39,6 +39,7 @@
 
 #pragma once
 
+#include "trajectory_execution_info.h"
 #include "utils.h"
 #include <moveit/macros/class_forward.h>
 #include <moveit/task_constructor/storage.h>
@@ -200,6 +201,14 @@ public:
 	void setMarkerNS(const std::string& marker_ns) { setProperty("marker_ns", marker_ns); }
 	/// marker namespace of solution markers
 	const std::string& markerNS() { return properties().get<std::string>("marker_ns"); }
+
+	/// Set and get info to use when executing the stage's trajectory
+	void setTrajectoryExecutionInfo(TrajectoryExecutionInfo trajectory_execution_info) {
+		setProperty("trajectory_execution_info", trajectory_execution_info);
+	}
+	TrajectoryExecutionInfo trajectoryExecutionInfo() {
+		return properties().get<TrajectoryExecutionInfo>("trajectory_execution_info");
+	}
 
 	/// forwarding of properties between interface states
 	void forwardProperties(const InterfaceState& source, InterfaceState& dest);

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -97,6 +97,8 @@ protected:
 	moveit::core::JointModelGroupPtr merged_jmg_;
 	std::list<SubTrajectory> subsolutions_;
 	std::list<InterfaceState> states_;
+
+	std::string name_;
 };
 }  // namespace stages
 }  // namespace task_constructor

--- a/core/include/moveit/task_constructor/stages/generate_random_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_random_pose.h
@@ -1,0 +1,120 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Henning Kayser
+   Desc:    Generator Stage for randomized poses based on GeneratePose
+*/
+
+#pragma once
+
+#include <moveit/task_constructor/stages/generate_pose.h>
+
+#include <random>
+
+namespace moveit {
+namespace task_constructor {
+namespace stages {
+
+class GenerateRandomPose : public GeneratePose
+{
+public:
+	GenerateRandomPose(const std::string& name = "generate random pose");
+
+	bool canCompute() const override;
+	void compute() override;
+
+	/*
+	 * Function specification for pose dimension samplers.
+	 * The input paramter is the target_pose value used as seed, the returned value is the sampling result.
+	 * */
+	typedef std::function<double(double)> PoseDimensionSampler;
+	enum PoseDimension
+	{
+		X,
+		Y,
+		Z,
+		ROLL,
+		PITCH,
+		YAW
+	};
+
+	/*
+	 * Configure a RandomNumberDistribution (see https://en.cppreference.com/w/cpp/numeric/random) sampler for a
+	 * PoseDimension (X/Y/Z/ROLL/PITCH/YAW) for randomizing the pose.
+	 * The distribution_param is applied to the specified distribution method while the target pose value is used as
+	 * seed. The order in which the PoseDimension samplers are specified matters as the samplers are applied in sequence.
+	* That way it's possible to implement different Euler angles (i.e. XYZ, ZXZ, YXY) or even construct more complex
+	* sampling regions by applying translations after rotations.
+	 * Currently supported distributions are:
+	 * * std::uniform_real_distrubtion: distribution_param specifies the full value range around the target_pose value
+	 * * std::normal_distribution: distribution_param is used as stddev, target_pose value is mean
+	 *
+	 * Other distributions can be used by setting the PoseDimensionSampler directly using the function overload.
+	 */
+	template <template <class Realtype = double> class RandomNumberDistribution>
+	void sampleDimension(const PoseDimension pose_dimension, double distribution_param) {
+		sampleDimension(pose_dimension, getPoseDimensionSampler<RandomNumberDistribution>(distribution_param));
+	}
+
+	/*
+	 * Specify a sampling function of type PoseDimensionSampler for randomizing a pose dimension.
+	 */
+	void sampleDimension(const PoseDimension pose_dimension, const PoseDimensionSampler& pose_dimension_sampler) {
+		pose_dimension_samplers_.emplace_back(std::make_pair(pose_dimension, pose_dimension_sampler));
+	}
+
+	/*
+	 * Limits the number of generated solutions
+	 */
+	void setMaxSolutions(size_t max_solutions) { setProperty("max_solutions", max_solutions); }
+
+private:
+	/* \brief Allocate the sampler function for the specified random distribution */
+	template <template <class Realtype = double> class RandomNumberDistribution>
+	PoseDimensionSampler getPoseDimensionSampler(double /* distribution_param */) {
+		static_assert(sizeof(RandomNumberDistribution<double>) == -1, "This distribution type is not supported!");
+		throw 0;  // suppress -Wreturn-type
+	}
+
+	std::vector<std::pair<PoseDimension, PoseDimensionSampler>> pose_dimension_samplers_;
+};
+template <>
+GenerateRandomPose::PoseDimensionSampler
+GenerateRandomPose::getPoseDimensionSampler<std::normal_distribution>(double stddev);
+template <>
+GenerateRandomPose::PoseDimensionSampler
+GenerateRandomPose::getPoseDimensionSampler<std::uniform_real_distribution>(double range);
+}  // namespace stages
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/include/moveit/task_constructor/stages/generate_random_pose.h
+++ b/core/include/moveit/task_constructor/stages/generate_random_pose.h
@@ -74,8 +74,8 @@ public:
 	 * PoseDimension (X/Y/Z/ROLL/PITCH/YAW) for randomizing the pose.
 	 * The distribution_param is applied to the specified distribution method while the target pose value is used as
 	 * seed. The order in which the PoseDimension samplers are specified matters as the samplers are applied in sequence.
-	* That way it's possible to implement different Euler angles (i.e. XYZ, ZXZ, YXY) or even construct more complex
-	* sampling regions by applying translations after rotations.
+	 * That way it's possible to implement different Euler angles (i.e. XYZ, ZXZ, YXY) or even construct more complex
+	 * sampling regions by applying translations after rotations.
 	 * Currently supported distributions are:
 	 * * std::uniform_real_distrubtion: distribution_param specifies the full value range around the target_pose value
 	 * * std::normal_distribution: distribution_param is used as stddev, target_pose value is mean

--- a/core/include/moveit/task_constructor/trajectory_execution_info.h
+++ b/core/include/moveit/task_constructor/trajectory_execution_info.h
@@ -1,0 +1,66 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Joe Schornak
+   Desc:    Define a struct to hold options used to configure trajectory execution
+*/
+
+#pragma once
+
+#include <moveit_task_constructor_msgs/msg/trajectory_execution_info.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <string>
+#include <vector>
+
+namespace {
+using TrajectoryExecutionInfoMsg = moveit_task_constructor_msgs::msg::TrajectoryExecutionInfo;
+}
+
+namespace moveit {
+namespace task_constructor {
+struct TrajectoryExecutionInfo
+{
+	TrajectoryExecutionInfo() {}
+
+	TrajectoryExecutionInfo(const TrajectoryExecutionInfoMsg& msg) { controller_names = msg.controller_names; }
+
+	TrajectoryExecutionInfoMsg toMsg() const {
+		return moveit_task_constructor_msgs::build<TrajectoryExecutionInfoMsg>().controller_names(controller_names);
+	}
+
+	std::vector<std::string> controller_names;
+};
+
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -47,12 +47,13 @@ ament_target_dependencies(${PROJECT_NAME}
 )
 target_include_directories(${PROJECT_NAME}
 	PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	       $<INSTALL_INTERFACE:include>
 )
 
 add_subdirectory(stages)
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib)

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -365,6 +365,8 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
+	stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);
 	ContainerBasePrivate::const_iterator where = pimpl()->childByIndex(before, true);

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -365,7 +365,9 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
-	stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	if (stage->trajectoryExecutionInfo().controller_names.empty()) {
+		stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	}
 
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);

--- a/core/src/solvers/pipeline_planner.cpp
+++ b/core/src/solvers/pipeline_planner.cpp
@@ -49,164 +49,176 @@
 #include <tf2_eigen/tf2_eigen.h>
 #endif
 
+namespace {
+const std::pair<std::string, std::string> DEFAULT_REQUESTED_PIPELINE =
+    std::pair<std::string, std::string>("ompl", "RRTConnect");
+}
 namespace moveit {
 namespace task_constructor {
 namespace solvers {
 
-struct PlannerCache
-{
-	using PlannerID = std::tuple<std::string, std::string>;
-	using PlannerMap = std::map<PlannerID, std::weak_ptr<planning_pipeline::PlanningPipeline> >;
-	using ModelList = std::list<std::pair<std::weak_ptr<const moveit::core::RobotModel>, PlannerMap> >;
-	ModelList cache_;
+PipelinePlanner::PipelinePlanner(const rclcpp::Node::SharedPtr& node, const std::string& pipeline_name,
+                                 const std::string& planner_id)
+  : PipelinePlanner(node, [&]() {
+	  std::unordered_map<std::string, std::string> pipeline_id_planner_id_map;
+	  pipeline_id_planner_id_map[pipeline_name] = planner_id;
+	  return pipeline_id_planner_id_map;
+  }()) {}
 
-	PlannerMap::mapped_type& retrieve(const moveit::core::RobotModelConstPtr& model, const PlannerID& id) {
-		// find model in cache_ and remove expired entries while doing so
-		ModelList::iterator model_it = cache_.begin();
-		while (model_it != cache_.end()) {
-			if (model_it->first.expired()) {
-				model_it = cache_.erase(model_it);
-				continue;
-			}
-			if (model_it->first.lock() == model)
-				break;
-			++model_it;
-		}
-		if (model_it == cache_.end())  // if not found, create a new PlannerMap for this model
-			model_it = cache_.insert(cache_.begin(), std::make_pair(model, PlannerMap()));
-
-		return model_it->second.insert(std::make_pair(id, PlannerMap::mapped_type())).first->second;
+PipelinePlanner::PipelinePlanner(
+    const rclcpp::Node::SharedPtr& node, const std::unordered_map<std::string, std::string>& pipeline_id_planner_id_map,
+    const std::unordered_map<std::string, planning_pipeline::PlanningPipelinePtr>& planning_pipelines,
+    const moveit::planning_pipeline_interfaces::StoppingCriterionFunction& stopping_criterion_callback,
+    const moveit::planning_pipeline_interfaces::SolutionSelectionFunction& solution_selection_function)
+  : node_(node)
+  , pipeline_id_planner_id_map_(pipeline_id_planner_id_map)
+  , stopping_criterion_callback_(stopping_criterion_callback)
+  , solution_selection_function_(solution_selection_function) {
+	// If the pipeline name - pipeline map is passed as constructor argument, use it. Otherwise, it will be created in
+	// the init(..) function
+	if (!planning_pipelines.empty()) {
+		planning_pipelines_ = planning_pipelines;
 	}
-};
+	// Declare properties of the MotionPlanRequest
+	properties().declare<uint>("num_planning_attempts", 1u, "number of planning attempts");
+	properties().declare<moveit_msgs::msg::WorkspaceParameters>(
+	    "workspace_parameters", moveit_msgs::msg::WorkspaceParameters(), "allowed workspace of mobile base?");
 
-planning_pipeline::PlanningPipelinePtr PipelinePlanner::create(const rclcpp::Node::SharedPtr& node,
-                                                               const PipelinePlanner::Specification& spec) {
-	static PlannerCache cache;
-
-	static constexpr char const* PLUGIN_PARAMETER_NAME = "planning_plugin";
-
-	std::string pipeline_ns = spec.ns;
-	const std::string parameter_name = pipeline_ns + "." + PLUGIN_PARAMETER_NAME;
-	// fallback to old structure for pipeline parameters in MoveIt
-	if (!node->has_parameter(parameter_name)) {
-		node->declare_parameter(parameter_name, rclcpp::ParameterType::PARAMETER_STRING);
-	}
-	if (std::string parameter; !node->get_parameter(parameter_name, parameter)) {
-		RCLCPP_WARN(node->get_logger(), "Failed to find '%s.%s'. %s", pipeline_ns.c_str(), PLUGIN_PARAMETER_NAME,
-		            "Attempting to load pipeline from old parameter structure. Please update your MoveIt config.");
-		pipeline_ns = "move_group";
-	}
-
-	PlannerCache::PlannerID id(pipeline_ns, spec.adapter_param);
-
-	std::weak_ptr<planning_pipeline::PlanningPipeline>& entry = cache.retrieve(spec.model, id);
-	planning_pipeline::PlanningPipelinePtr planner = entry.lock();
-	if (!planner) {
-		// create new entry
-		planner = std::make_shared<planning_pipeline::PlanningPipeline>(spec.model, node, pipeline_ns,
-		                                                                PLUGIN_PARAMETER_NAME, spec.adapter_param);
-		// store in cache
-		entry = planner;
-	}
-	return planner;
+	properties().declare<double>("goal_joint_tolerance", 1e-4, "tolerance for reaching joint goals");
+	properties().declare<double>("goal_position_tolerance", 1e-4, "tolerance for reaching position goals");
+	properties().declare<double>("goal_orientation_tolerance", 1e-4, "tolerance for reaching orientation goals");
+	// Declare properties that configure the planning pipeline
+	properties().declare<bool>("display_motion_plans", false,
+	                           "publish generated solutions on topic " +
+	                               planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC);
+	properties().declare<bool>("publish_planning_requests", false,
+	                           "publish motion planning requests on topic " +
+	                               planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC);
 }
 
-PipelinePlanner::PipelinePlanner(const rclcpp::Node::SharedPtr& node, const std::string& pipeline_name)
-  : pipeline_name_{ pipeline_name }, node_(node) {
-	auto& p = properties();
-	p.declare<std::string>("planner", "", "planner id");
-
-	p.declare<uint>("num_planning_attempts", 1u, "number of planning attempts");
-	p.declare<moveit_msgs::msg::WorkspaceParameters>("workspace_parameters", moveit_msgs::msg::WorkspaceParameters(),
-	                                                 "allowed workspace of mobile base?");
-
-	p.declare<double>("goal_joint_tolerance", 1e-4, "tolerance for reaching joint goals");
-	p.declare<double>("goal_position_tolerance", 1e-4, "tolerance for reaching position goals");
-	p.declare<double>("goal_orientation_tolerance", 1e-4, "tolerance for reaching orientation goals");
-
-	p.declare<bool>("display_motion_plans", false,
-	                "publish generated solutions on topic " + planning_pipeline::PlanningPipeline::DISPLAY_PATH_TOPIC);
-	p.declare<bool>("publish_planning_requests", false,
-	                "publish motion planning requests on topic " +
-	                    planning_pipeline::PlanningPipeline::MOTION_PLAN_REQUEST_TOPIC);
+bool PipelinePlanner::setPlannerId(const std::string& pipeline_name, const std::string& planner_id) {
+	// Only set ID if pipeline exists. It is not possible to create new pipelines with this command.
+	if (pipeline_id_planner_id_map_.count(pipeline_name) > 0) {
+		pipeline_id_planner_id_map_[pipeline_name] = planner_id;
+	}
+	RCLCPP_ERROR(node_->get_logger(),
+	             "PipelinePlanner does not have a pipeline called '%s'. Cannot set pipeline ID '%s'",
+	             pipeline_name.c_str(), planner_id.c_str());
+	return false;
 }
 
-PipelinePlanner::PipelinePlanner(const planning_pipeline::PlanningPipelinePtr& planning_pipeline)
-  : PipelinePlanner(rclcpp::Node::SharedPtr()) {
-	planner_ = planning_pipeline;
+void PipelinePlanner::setStoppingCriterionFunction(
+    const moveit::planning_pipeline_interfaces::StoppingCriterionFunction& stopping_criterion_function) {
+	stopping_criterion_callback_ = stopping_criterion_function;
+}
+void PipelinePlanner::setSolutionSelectionFunction(
+    const moveit::planning_pipeline_interfaces::SolutionSelectionFunction& solution_selection_function) {
+	solution_selection_function_ = solution_selection_function;
 }
 
 void PipelinePlanner::init(const core::RobotModelConstPtr& robot_model) {
-	if (!planner_) {
-		Specification spec;
-		spec.model = robot_model;
-		spec.pipeline = pipeline_name_;
-		spec.ns = pipeline_name_;
-		planner_ = create(node_, spec);
-	} else if (robot_model != planner_->getRobotModel()) {
-		throw std::runtime_error(
-		    "The robot model of the planning pipeline isn't the same as the task's robot model -- "
-		    "use Task::setRobotModel for setting the robot model when using custom planning pipeline");
+	// If no planning pipelines exist, create them based on the pipeline names provided in pipeline_id_planner_id_map_.
+	// The assumption here is that all parameters required by the planning pipeline can be found in a namespace that
+	// equals the pipeline name.
+	if (planning_pipelines_.empty()) {
+		planning_pipelines_ = moveit::planning_pipeline_interfaces::createPlanningPipelineMap(
+		    [&]() {
+			    // Create pipeline name vector from the keys of pipeline_id_planner_id_map_
+			    std::vector<std::string> pipeline_names;
+			    for (const auto& pipeline_name_planner_id_pair : pipeline_id_planner_id_map_) {
+				    pipeline_names.push_back(pipeline_name_planner_id_pair.first);
+			    }
+			    return pipeline_names;
+		    }(),
+		    robot_model, node_);
 	}
-	planner_->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
-	planner_->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
-}
 
-void initMotionPlanRequest(moveit_msgs::msg::MotionPlanRequest& req, const PropertyMap& p,
-                           const moveit::core::JointModelGroup* jmg, double timeout) {
-	req.group_name = jmg->getName();
-	req.planner_id = p.get<std::string>("planner");
-	req.allowed_planning_time = timeout;
-	req.start_state.is_diff = true;  // we don't specify an extra start state
-
-	req.num_planning_attempts = p.get<uint>("num_planning_attempts");
-	req.max_velocity_scaling_factor = p.get<double>("max_velocity_scaling_factor");
-	req.max_acceleration_scaling_factor = p.get<double>("max_acceleration_scaling_factor");
-	req.workspace_parameters = p.get<moveit_msgs::msg::WorkspaceParameters>("workspace_parameters");
+	// Configure all pipelines according to the configuration in properties
+	for (auto const& name_pipeline_pair : planning_pipelines_) {
+		name_pipeline_pair.second->displayComputedMotionPlans(properties().get<bool>("display_motion_plans"));
+		name_pipeline_pair.second->publishReceivedRequests(properties().get<bool>("publish_planning_requests"));
+	}
 }
 
 bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& from,
-                           const planning_scene::PlanningSceneConstPtr& to, const moveit::core::JointModelGroup* jmg,
-                           double timeout, robot_trajectory::RobotTrajectoryPtr& result,
+                           const planning_scene::PlanningSceneConstPtr& to,
+                           const moveit::core::JointModelGroup* joint_model_group, double timeout,
+                           robot_trajectory::RobotTrajectoryPtr& result,
                            const moveit_msgs::msg::Constraints& path_constraints) {
-	const auto& props = properties();
-	moveit_msgs::msg::MotionPlanRequest req;
-	initMotionPlanRequest(req, props, jmg, timeout);
-
-	req.goal_constraints.resize(1);
-	req.goal_constraints[0] = kinematic_constraints::constructGoalConstraints(to->getCurrentState(), jmg,
-	                                                                          props.get<double>("goal_joint_tolerance"));
-	req.path_constraints = path_constraints;
-
-	::planning_interface::MotionPlanResponse res;
-	bool success = planner_->generatePlan(from, req, res);
-	result = res.trajectory;
-	return success;
+	// Construct goal constraints from the goal planning scene
+	const auto goal_constraints = kinematic_constraints::constructGoalConstraints(
+	    to->getCurrentState(), joint_model_group, properties().get<double>("goal_joint_tolerance"));
+	return plan(from, joint_model_group, goal_constraints, timeout, result, path_constraints);
 }
 
 bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& from, const moveit::core::LinkModel& link,
                            const Eigen::Isometry3d& offset, const Eigen::Isometry3d& target_eigen,
-                           const moveit::core::JointModelGroup* jmg, double timeout,
+                           const moveit::core::JointModelGroup* joint_model_group, double timeout,
                            robot_trajectory::RobotTrajectoryPtr& result,
                            const moveit_msgs::msg::Constraints& path_constraints) {
-	const auto& props = properties();
-	moveit_msgs::msg::MotionPlanRequest req;
-	initMotionPlanRequest(req, props, jmg, timeout);
-
+	// Construct a Cartesian target pose from the given target transform and offset
 	geometry_msgs::msg::PoseStamped target;
 	target.header.frame_id = from->getPlanningFrame();
 	target.pose = tf2::toMsg(target_eigen * offset.inverse());
 
-	req.goal_constraints.resize(1);
-	req.goal_constraints[0] = kinematic_constraints::constructGoalConstraints(
-	    link.getName(), target, props.get<double>("goal_position_tolerance"),
-	    props.get<double>("goal_orientation_tolerance"));
-	req.path_constraints = path_constraints;
+	const auto goal_constraints = kinematic_constraints::constructGoalConstraints(
+	    link.getName(), target, properties().get<double>("goal_position_tolerance"),
+	    properties().get<double>("goal_orientation_tolerance"));
 
-	::planning_interface::MotionPlanResponse res;
-	bool success = planner_->generatePlan(from, req, res);
-	result = res.trajectory;
-	return success;
+	return plan(from, joint_model_group, goal_constraints, timeout, result, path_constraints);
+}
+
+bool PipelinePlanner::plan(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                           const moveit::core::JointModelGroup* joint_model_group,
+                           const moveit_msgs::msg::Constraints& goal_constraints, double timeout,
+                           robot_trajectory::RobotTrajectoryPtr& result,
+                           const moveit_msgs::msg::Constraints& path_constraints) {
+	// Create a request for every planning pipeline that should run in parallel
+	std::vector<moveit_msgs::msg::MotionPlanRequest> requests;
+	requests.reserve(pipeline_id_planner_id_map_.size());
+
+	for (auto const& pipeline_id_planner_id_pair : pipeline_id_planner_id_map_) {
+		// Check that requested pipeline exists and skip it if it doesn't exist
+		if (planning_pipelines_.find(pipeline_id_planner_id_pair.first) == planning_pipelines_.end()) {
+			RCLCPP_WARN(
+			    node_->get_logger(),
+			    "Pipeline '%s' is not available of this PipelineSolver instance. Skipping a request for this pipeline.",
+			    pipeline_id_planner_id_pair.first.c_str());
+			continue;
+		}
+		// Create MotionPlanRequest for pipeline
+		moveit_msgs::msg::MotionPlanRequest request;
+		request.pipeline_id = pipeline_id_planner_id_pair.first;
+		request.group_name = joint_model_group->getName();
+		request.planner_id = pipeline_id_planner_id_pair.second;
+		request.allowed_planning_time = timeout;
+		request.start_state.is_diff = true;  // we don't specify an extra start state
+		request.num_planning_attempts = properties().get<uint>("num_planning_attempts");
+		request.max_velocity_scaling_factor = properties().get<double>("max_velocity_scaling_factor");
+		request.max_acceleration_scaling_factor = properties().get<double>("max_acceleration_scaling_factor");
+		request.workspace_parameters = properties().get<moveit_msgs::msg::WorkspaceParameters>("workspace_parameters");
+		request.goal_constraints.resize(1);
+		request.goal_constraints.at(0) = goal_constraints;
+		request.path_constraints = path_constraints;
+		requests.push_back(request);
+	}
+
+	// Run planning pipelines in parallel to create a vector of responses. If a solution selection function is provided,
+	// planWithParallelPipelines will return a vector with the single best solution
+	std::vector<::planning_interface::MotionPlanResponse> responses =
+	    moveit::planning_pipeline_interfaces::planWithParallelPipelines(
+	        requests, planning_scene, planning_pipelines_, stopping_criterion_callback_, solution_selection_function_);
+
+	// If solutions exist and the first one is successful
+	if (!responses.empty()) {
+		auto const solution = responses.at(0);
+		if (solution) {
+			// Choose the first solution trajectory as response
+			result = solution.trajectory;
+			return bool(result);
+		}
+	}
+	return false;
 }
 }  // namespace solvers
 }  // namespace task_constructor

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -308,6 +308,8 @@ Stage::Stage(StagePrivate* impl) : pimpl_(impl) {
 	auto& p = properties();
 	p.declare<double>("timeout", "timeout per run (s)");
 	p.declare<std::string>("marker_ns", name(), "marker namespace");
+	p.declare<TrajectoryExecutionInfo>("trajectory_execution_info", TrajectoryExecutionInfo(),
+	                                   "settings used when executing the trajectory");
 
 	p.declare<std::set<std::string>>("forwarded_properties", std::set<std::string>(),
 	                                 "set of interface properties to forward");

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -636,6 +636,9 @@ void PropagatingEitherWay::computeGeneric(const InterfaceState& start) {
 	else
 		send<dir>(start, InterfaceState(end), std::move(trajectory));
 }
+// Explicitly instantiate templates for both directions
+template void PropagatingEitherWay::computeGeneric<Interface::FORWARD>(const InterfaceState& start);
+template void PropagatingEitherWay::computeGeneric<Interface::BACKWARD>(const InterfaceState& start);
 
 PropagatingForwardPrivate::PropagatingForwardPrivate(PropagatingForward* me, const std::string& name)
   : PropagatingEitherWayPrivate(me, PropagatingEitherWay::FORWARD, name) {

--- a/core/src/stages/CMakeLists.txt
+++ b/core/src/stages/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(${PROJECT_NAME}_stages SHARED
 	${PROJECT_INCLUDE}/stages/fixed_state.h
 	${PROJECT_INCLUDE}/stages/fixed_cartesian_poses.h
 	${PROJECT_INCLUDE}/stages/generate_pose.h
+	${PROJECT_INCLUDE}/stages/generate_random_pose.h
 	${PROJECT_INCLUDE}/stages/generate_grasp_pose.h
 	${PROJECT_INCLUDE}/stages/generate_place_pose.h
 	${PROJECT_INCLUDE}/stages/compute_ik.h
@@ -26,6 +27,7 @@ add_library(${PROJECT_NAME}_stages SHARED
 	fixed_state.cpp
 	fixed_cartesian_poses.cpp
 	generate_pose.cpp
+	generate_random_pose.cpp
 	generate_grasp_pose.cpp
 	generate_place_pose.cpp
 	compute_ik.cpp

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -161,7 +161,15 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 
 		robot_trajectory::RobotTrajectoryPtr trajectory;
 		success = pair.second->plan(start, end, jmg, timeout, trajectory, path_constraints);
-		sub_trajectories.push_back(trajectory);  // include failed trajectory
+
+		// Do not push partial solutions
+		if (success) {
+			sub_trajectories.push_back(trajectory);  
+		}
+		else {
+			// Pushing a nullptr instead of a failed trajectory. 
+			sub_trajectories.push_back(nullptr); 
+		}
 
 		if (!success)
 			break;

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -164,11 +164,10 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 
 		// Do not push partial solutions
 		if (success) {
-			sub_trajectories.push_back(trajectory);  
-		}
-		else {
-			// Pushing a nullptr instead of a failed trajectory. 
-			sub_trajectories.push_back(nullptr); 
+			sub_trajectories.push_back(trajectory);
+		} else {
+			// Pushing a nullptr instead of a failed trajectory.
+			sub_trajectories.push_back(nullptr);
 		}
 
 		if (!success)

--- a/core/src/stages/generate_random_pose.cpp
+++ b/core/src/stages/generate_random_pose.cpp
@@ -1,0 +1,162 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2020, PickNik Inc
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PickNik Inc nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Henning Kayser */
+
+#include <moveit/task_constructor/stages/generate_random_pose.h>
+#include <moveit/task_constructor/storage.h>
+#include <moveit/task_constructor/marker_tools.h>
+#include <moveit/planning_scene/planning_scene.h>
+#include <rviz_marker_tools/marker_creation.h>
+
+#include <Eigen/Geometry>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <chrono>
+
+namespace {
+// TODO(henningkayser): support user-defined random number engines
+std::random_device rd_;
+std::mt19937 gen_(rd_());
+}  // namespace
+
+namespace moveit {
+namespace task_constructor {
+namespace stages {
+
+GenerateRandomPose::GenerateRandomPose(const std::string& name) : GeneratePose(name) {
+	auto& p = properties();
+	p.declare<geometry_msgs::msg::PoseStamped>("pose", "target pose to pass on in spawned states");
+	p.declare<size_t>("max_solutions", 20,
+	                  "limit of the number of spawned solution in case randomized sampling is enabled");
+	p.property("timeout").setDefaultValue(1.0 /* seconds */);
+}
+
+template <>
+GenerateRandomPose::PoseDimensionSampler
+GenerateRandomPose::getPoseDimensionSampler<std::normal_distribution>(double stddev) {
+	return [stddev, &gen = gen_](double mean) {
+		static std::normal_distribution<double> dist(mean, stddev);
+		return dist(gen);
+	};
+}
+
+template <>
+GenerateRandomPose::PoseDimensionSampler
+GenerateRandomPose::getPoseDimensionSampler<std::uniform_real_distribution>(double range) {
+	return [range, &gen = gen_](double mean) {
+		static std::uniform_real_distribution<double> dist(mean - 0.5 * range, mean + 0.5 * range);
+		return dist(gen);
+	};
+}
+
+bool GenerateRandomPose::canCompute() const {
+	return GeneratePose::canCompute() && !pose_dimension_samplers_.empty();
+}
+
+void GenerateRandomPose::compute() {
+	if (upstream_solutions_.empty())
+		return;
+
+	planning_scene::PlanningScenePtr scene = upstream_solutions_.pop()->end()->scene()->diff();
+	geometry_msgs::msg::PoseStamped target_pose = properties().get<geometry_msgs::msg::PoseStamped>("pose");
+	if (target_pose.header.frame_id.empty())
+		target_pose.header.frame_id = scene->getPlanningFrame();
+	else if (!scene->knowsFrameTransform(target_pose.header.frame_id)) {
+		RCLCPP_WARN(rclcpp::get_logger("GenerateRandomPose"), "Unknown frame: '%s'", target_pose.header.frame_id.c_str());
+		return;
+	}
+
+	const auto& spawn_target_pose = [&](const geometry_msgs::msg::PoseStamped& target_pose) {
+		InterfaceState state(scene);
+		state.properties().set("target_pose", target_pose);
+
+		SubTrajectory trajectory;
+		trajectory.setCost(0.0);
+
+		rviz_marker_tools::appendFrame(trajectory.markers(), target_pose, 0.1, "pose frame");
+
+		spawn(std::move(state), std::move(trajectory));
+	};
+
+	// Spawn initial pose
+	spawn_target_pose(target_pose);
+
+	if (pose_dimension_samplers_.empty())
+		return;
+
+	// Use target pose as seed pose
+	const geometry_msgs::msg::PoseStamped seed_pose = target_pose;
+	Eigen::Isometry3d seed, sample;
+	tf2::fromMsg(seed_pose.pose, seed);
+	double elapsed_time = 0.0;
+	const auto start_time = std::chrono::steady_clock::now();
+	size_t spawned_solutions = 0;
+	const size_t max_solutions = properties().get<size_t>("max_solutions");
+	while (elapsed_time < timeout() && ++spawned_solutions < max_solutions) {
+		// Randomize pose using specified dimension samplers applied in the order
+		// in which they have been specified
+		sample = seed;
+		for (const auto& pose_dim_sampler : pose_dimension_samplers_) {
+			switch (pose_dim_sampler.first) {
+				case X:
+					sample.translate(Eigen::Vector3d(pose_dim_sampler.second(0.0), 0, 0));
+					break;
+				case Y:
+					sample.translate(Eigen::Vector3d(0, pose_dim_sampler.second(0.0), 0));
+					break;
+				case Z:
+					sample.translate(Eigen::Vector3d(0, 0, pose_dim_sampler.second(0.0)));
+					break;
+				case ROLL:
+					sample.rotate(Eigen::AngleAxisd(pose_dim_sampler.second(0.0), Eigen::Vector3d::UnitX()));
+					break;
+				case PITCH:
+					sample.rotate(Eigen::AngleAxisd(pose_dim_sampler.second(0.0), Eigen::Vector3d::UnitY()));
+					break;
+				case YAW:
+					sample.rotate(Eigen::AngleAxisd(pose_dim_sampler.second(0.0), Eigen::Vector3d::UnitZ()));
+			}
+		}
+		target_pose.pose = tf2::toMsg(sample);
+
+		// Spawn sampled pose
+		spawn_target_pose(target_pose);
+
+		elapsed_time = std::chrono::duration<double>(std::chrono::steady_clock::now() - start_time).count();
+	}
+}
+}  // namespace stages
+}  // namespace task_constructor
+}  // namespace moveit

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -223,6 +223,10 @@ void SubTrajectory::fillMessage(moveit_task_constructor_msgs::msg::Solution& msg
 	moveit_task_constructor_msgs::msg::SubTrajectory& t = msg.sub_trajectory.back();
 	SolutionBase::fillInfo(t.info, introspection);
 
+	const auto trajectory_execution_info =
+	    creator()->properties().get<TrajectoryExecutionInfo>("trajectory_execution_info");
+	t.execution_info = trajectory_execution_info.toMsg();
+
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ set(msg_files
 	"msg/SubTrajectory.msg"
 	"msg/TaskDescription.msg"
 	"msg/TaskStatistics.msg"
+        "msg/TrajectoryExecutionInfo.msg"
 )
 
 set(srv_files

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -1,6 +1,9 @@
 # generic solution information
 SolutionInfo info
 
+# trajectory execution information, like controller configuration
+TrajectoryExecutionInfo execution_info
+
 # trajectory
 moveit_msgs/RobotTrajectory trajectory
 

--- a/msgs/msg/TrajectoryExecutionInfo.msg
+++ b/msgs/msg/TrajectoryExecutionInfo.msg
@@ -1,0 +1,2 @@
+# List of controllers to use when executing the trajectory
+string[] controller_names


### PR DESCRIPTION
Sometimes, the plan function in the `Connect` stage returns success with an incomplete trajectory. 
This predominantly happens when using OMPL's RRT planner. Here is a band-aid fix to mark such trajectories as failure while I dig deeper to find the source of this error.
