### PR TITLE
Set non inf default timeout in current state stage

### DIFF
--- a/core/src/stages/current_state.cpp
+++ b/core/src/stages/current_state.cpp
@@ -35,6 +35,8 @@
 
 /* Authors: Michael Goerner, Luca Lach, Robert Haschke */
 
+#include <chrono>
+
 #include <moveit/task_constructor/stages/current_state.h>
 #include <moveit/task_constructor/storage.h>
 #include <moveit_msgs/srv/get_planning_scene.hpp>
@@ -47,13 +49,16 @@ namespace moveit {
 namespace task_constructor {
 namespace stages {
 
+using namespace std::chrono_literals;
+constexpr std::chrono::duration<double> DEFAULT_TIMEOUT = 3s;
+
 static const rclcpp::Logger LOGGER = rclcpp::get_logger("CurrentState");
 
 CurrentState::CurrentState(const std::string& name) : Generator(name) {
 	auto& p = properties();
 	Property& timeout = p.property("timeout");
 	timeout.setDescription("max time to wait for get_planning_scene service");
-	timeout.setValue(-1.0);
+	timeout.setValue(DEFAULT_TIMEOUT.count());
 }
 
 void CurrentState::init(const moveit::core::RobotModelConstPtr& robot_model) {


### PR DESCRIPTION
Port of https://github.com/PickNikRobotics/moveit_task_constructor/pull/7

If no planning scene is received, this stage blocks forever with an inf default