### PR TITLE
disable hooks for unused rviz-based task construction

### DIFF
--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -107,7 +107,7 @@ TaskPanel::TaskPanel(QWidget* parent) : rviz::Panel(parent), d_ptr(new TaskPanel
 	// settings widget should come last
 	addSubPanel(new GlobalSettingsWidget(this, d->property_root), "Global Settings", QIcon(":/icons/settings.png"));
 
-	connect(d->button_show_stage_dock_widget, SIGNAL(clicked()), this, SLOT(showStageDockWidget()));
+	// connect(d->button_show_stage_dock_widget, SIGNAL(clicked()), this, SLOT(showStageDockWidget()));
 
 	// if still undefined, this becomes the global instance
 	if (SINGLETON.isNull())
@@ -176,8 +176,8 @@ TaskPanelPrivate::TaskPanelPrivate(TaskPanel* panel) : q_ptr(panel) {
 	setupUi(panel);
 	tool_buttons_group = new QButtonGroup(panel);
 	tool_buttons_group->setExclusive(true);
-	button_show_stage_dock_widget->setEnabled(bool(getStageFactory()));
-	button_show_stage_dock_widget->setToolTip("Show available stages");
+	// button_show_stage_dock_widget->setEnabled(bool(getStageFactory()));
+	// button_show_stage_dock_widget->setToolTip("Show available stages");
 	property_root = new rviz::Property("Global Settings");
 }
 

--- a/visualization/motion_planning_tasks/src/task_panel.cpp
+++ b/visualization/motion_planning_tasks/src/task_panel.cpp
@@ -107,7 +107,7 @@ TaskPanel::TaskPanel(QWidget* parent) : rviz::Panel(parent), d_ptr(new TaskPanel
 	// settings widget should come last
 	addSubPanel(new GlobalSettingsWidget(this, d->property_root), "Global Settings", QIcon(":/icons/settings.png"));
 
-	// connect(d->button_show_stage_dock_widget, SIGNAL(clicked()), this, SLOT(showStageDockWidget()));
+	connect(d->button_show_stage_dock_widget, SIGNAL(clicked()), this, SLOT(showStageDockWidget()));
 
 	// if still undefined, this becomes the global instance
 	if (SINGLETON.isNull())
@@ -176,8 +176,8 @@ TaskPanelPrivate::TaskPanelPrivate(TaskPanel* panel) : q_ptr(panel) {
 	setupUi(panel);
 	tool_buttons_group = new QButtonGroup(panel);
 	tool_buttons_group->setExclusive(true);
-	// button_show_stage_dock_widget->setEnabled(bool(getStageFactory()));
-	// button_show_stage_dock_widget->setToolTip("Show available stages");
+	button_show_stage_dock_widget->setEnabled(bool(getStageFactory()));
+	button_show_stage_dock_widget->setVisible(false);  // hide for now
 	property_root = new rviz::Property("Global Settings");
 }
 

--- a/visualization/motion_planning_tasks/src/task_panel.ui
+++ b/visualization/motion_planning_tasks/src/task_panel.ui
@@ -57,6 +57,20 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QToolButton" name="button_show_stage_dock_widget">
+       <property name="toolTip">
+        <string>Show available stages</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="resources.qrc">
+         <normaloff>:/icons/new-stage.png</normaloff>:/icons/new-stage.png</iconset>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/visualization/motion_planning_tasks/src/task_panel.ui
+++ b/visualization/motion_planning_tasks/src/task_panel.ui
@@ -57,20 +57,6 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QToolButton" name="button_show_stage_dock_widget">
-       <property name="toolTip">
-        <string>Show available stages</string>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="resources.qrc">
-         <normaloff>:/icons/new-stage.png</normaloff>:/icons/new-stage.png</iconset>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
This implementation is far from functional right now and the button confuses users.

@rhaschke I don't know whether you want to keep the whole underlying framework (which is quite sophisticated) around, so I just disabled the UI hook.
I believe you also moved on to specifying tasks in python instead of trying to set them up visually.
