### PR TITLE
Fix assert on multi-init() with Fallback

### DIFF
--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -876,6 +876,8 @@ void Fallbacks::onNewSolution(const SolutionBase& s) {
 
 inline void Fallbacks::replaceImpl() {
 	FallbacksPrivate *impl = pimpl();
+	if (pimpl()->interfaceFlags() == pimpl()->requiredInterface())
+		return;
 	switch (pimpl()->requiredInterface()) {
 		case GENERATE:
 			impl = new FallbacksPrivateGenerator(std::move(*impl));


### PR DESCRIPTION
There should be no harm in running init multiple times
and it actually happens with `Task.init(); ...; Task.plan();`.

However, the logic here overwrites impl with a new type by moving
the old pimpl object a couple of times with operator= through inheritance.
This is eventually caught by StagePrivate::operator=() asserting that the typeid is not identical.
