### PR TITLE
Run goalcallback asynchronously

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -94,8 +94,10 @@ void ExecuteTaskSolutionCapability::initialize() {
 	                                             std::placeholders::_1, std::placeholders::_2)),
 	    ActionServerType::CancelCallback(
 	        std::bind(&ExecuteTaskSolutionCapability::preemptCallback, this, std::placeholders::_1)),
-	    ActionServerType::AcceptedCallback(
-	        std::bind(&ExecuteTaskSolutionCapability::goalCallback, this, std::placeholders::_1)));
+	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>> goal_handle) {
+		    last_goal_future_ =
+		        std::async(std::launch::async, &ExecuteTaskSolutionCapability::goalCallback, this, goal_handle);
+	    });
 }
 
 void ExecuteTaskSolutionCapability::goalCallback(

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -92,6 +92,7 @@ void ExecuteTaskSolutionCapability::initialize() {
 	    context_->moveit_cpp_->getNode(), "execute_task_solution",
 	    [this](const rclcpp_action::GoalUUID& /*uuid*/,
 	           const ExecuteTaskSolutionAction::Goal::ConstSharedPtr& /*goal*/) {
+                    // Reject new goal if another goal is currently processed
 		    if (last_goal_future_.valid() &&
 		        last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready) {
 			    return rclcpp_action::GoalResponse::REJECT;

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -92,7 +92,7 @@ void ExecuteTaskSolutionCapability::initialize() {
 	    context_->moveit_cpp_->getNode(), "execute_task_solution",
 	    [this](const rclcpp_action::GoalUUID& /*uuid*/,
 	           const ExecuteTaskSolutionAction::Goal::ConstSharedPtr& /*goal*/) {
-                    // Reject new goal if another goal is currently processed
+		    // Reject new goal if another goal is currently processed
 		    if (last_goal_future_.valid() &&
 		        last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready) {
 			    return rclcpp_action::GoalResponse::REJECT;

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -90,10 +90,17 @@ void ExecuteTaskSolutionCapability::initialize() {
 	// configure the action server
 	as_ = rclcpp_action::create_server<moveit_task_constructor_msgs::action::ExecuteTaskSolution>(
 	    context_->moveit_cpp_->getNode(), "execute_task_solution",
-	    ActionServerType::GoalCallback(std::bind(&ExecuteTaskSolutionCapability::handleNewGoal, this,
-	                                             std::placeholders::_1, std::placeholders::_2)),
-	    ActionServerType::CancelCallback(
-	        std::bind(&ExecuteTaskSolutionCapability::preemptCallback, this, std::placeholders::_1)),
+	    [this](const rclcpp_action::GoalUUID& /*uuid*/,
+	           const ExecuteTaskSolutionAction::Goal::ConstSharedPtr& /*goal*/) {
+		    if (last_goal_future_.valid() &&
+		        last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready) {
+			    return rclcpp_action::GoalResponse::REJECT;
+		    }
+		    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+	    },
+	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle) {
+		    return preemptCallback(goal_handle);
+	    },
 	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle) {
 		    last_goal_future_ =
 		        std::async(std::launch::async, &ExecuteTaskSolutionCapability::goalCallback, this, goal_handle);

--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -94,7 +94,7 @@ void ExecuteTaskSolutionCapability::initialize() {
 	                                             std::placeholders::_1, std::placeholders::_2)),
 	    ActionServerType::CancelCallback(
 	        std::bind(&ExecuteTaskSolutionCapability::preemptCallback, this, std::placeholders::_1)),
-	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>> goal_handle) {
+	    [this](const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle) {
 		    last_goal_future_ =
 		        std::async(std::launch::async, &ExecuteTaskSolutionCapability::goalCallback, this, goal_handle);
 	    });

--- a/capabilities/src/execute_task_solution_capability.h
+++ b/capabilities/src/execute_task_solution_capability.h
@@ -68,15 +68,6 @@ private:
 	rclcpp_action::CancelResponse
 	preemptCallback(const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle);
 
-	/** Only accept the goal if we aren't executing one */
-	rclcpp_action::GoalResponse handleNewGoal(const rclcpp_action::GoalUUID& /*uuid*/,
-	                                          const ExecuteTaskSolutionAction::Goal::ConstSharedPtr /*goal*/) const {
-		if (last_goal_future_.valid() &&
-		    last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready)
-			return rclcpp_action::GoalResponse::REJECT;
-		return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
-	}
-
 	ActionServerType::SharedPtr as_;
 	std::future<void> last_goal_future_;
 };

--- a/capabilities/src/execute_task_solution_capability.h
+++ b/capabilities/src/execute_task_solution_capability.h
@@ -68,13 +68,17 @@ private:
 	rclcpp_action::CancelResponse
 	preemptCallback(const std::shared_ptr<rclcpp_action::ServerGoalHandle<ExecuteTaskSolutionAction>>& goal_handle);
 
-	/** Always accept the goal */
+	/** Only accept the goal if we aren't executing one */
 	rclcpp_action::GoalResponse handleNewGoal(const rclcpp_action::GoalUUID& /*uuid*/,
-	                                          const ExecuteTaskSolutionAction::Goal::ConstSharedPtr& /*goal*/) const {
+	                                          const ExecuteTaskSolutionAction::Goal::ConstSharedPtr /*goal*/) const {
+		if (last_goal_future_.valid() &&
+		    last_goal_future_.wait_for(std::chrono::seconds::zero()) != std::future_status::ready)
+			return rclcpp_action::GoalResponse::REJECT;
 		return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 	}
 
 	ActionServerType::SharedPtr as_;
+	std::future<void> last_goal_future_;
 };
 
 }  // namespace move_group


### PR DESCRIPTION
Finally address [this comment](https://github.com/ros-planning/moveit_task_constructor/pull/461#issuecomment-1563080267) in #461.

Disclaimer: I am not the original author of these changes. 
This changes the behavior of the execute_task_solution_capability to not accept new execution requests if another request is currently processed. I assume the reason for this is to avoid interruptions because of incorrect execution commands. It is still possible to abort the execution with the CancelCallback.