### PR TITLE
Revert implicit trajectory info property inheritance

### DIFF
--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -365,10 +365,6 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
-	if (stage->trajectoryExecutionInfo().controller_names.empty()) {
-		stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
-	}
-
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);
 


### PR DESCRIPTION
Addresses https://github.com/ros-planning/moveit_task_constructor/pull/355/files#r1379822616

@rhaschke If I want to inherit every property from the parent except the trajectory info, is this how it would be done:
```
  stage->properties().configureInitFrom(moveit::task_constructor::Stage::PARENT);
  stage->properties().set("trajectory_execution_info", custom_trajectory_info);
```