### PR TITLE
Fix the typo in the execute_task_solution_capability.cpp file in ros2 branch

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -152,16 +152,16 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 		state = scene->getCurrentState();
 	}
 
-	plan.plan_components.reserve(solution.sub_trajectory.size());
+	plan.plan_components_.reserve(solution.sub_trajectory.size());
 	for (size_t i = 0; i < solution.sub_trajectory.size(); ++i) {
 		const moveit_task_constructor_msgs::msg::SubTrajectory& sub_traj = solution.sub_trajectory[i];
 
-		plan.plan_components.emplace_back();
-		plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components.back();
+		plan.plan_components_.emplace_back();
+		plan_execution::ExecutableTrajectory& exec_traj = plan.plan_components_.back();
 
 		// define individual variable for use in closure below
 		const std::string description = std::to_string(i + 1) + "/" + std::to_string(solution.sub_trajectory.size());
-		exec_traj.description = description;
+		exec_traj.description_ = description;
 
 		const moveit::core::JointModelGroup* group = nullptr;
 		{
@@ -178,12 +178,12 @@ bool ExecuteTaskSolutionCapability::constructMotionPlan(const moveit_task_constr
 				RCLCPP_DEBUG(LOGGER, "Using JointModelGroup '%s' for execution", group->getName().c_str());
 			}
 		}
-		exec_traj.trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
-		exec_traj.trajectory->setRobotTrajectoryMsg(state, sub_traj.trajectory);
-		exec_traj.controller_name = sub_traj.execution_info.controller_names;
+		exec_traj.trajectory_ = std::make_shared<robot_trajectory::RobotTrajectory>(model, group);
+		exec_traj.trajectory_->setRobotTrajectoryMsg(state, sub_traj.trajectory);
+		exec_traj.controller_names_ = sub_traj.execution_info.controller_names;
 
 		/* TODO add action feedback and markers */
-		exec_traj.effect_on_success = [this, sub_traj,
+		exec_traj.effect_on_success_ = [this, sub_traj,
 		                               description](const plan_execution::ExecutableMotionPlan* /*plan*/) {
 			if (!moveit::core::isEmpty(sub_traj.scene_diff)) {
 				RCLCPP_DEBUG_STREAM(LOGGER, "apply effect of " << description);


### PR DESCRIPTION
## Description

This fix addresses a typo in the `execute_task_solution_capability.cpp` file in the ros2 branch. The source code in this branch is utilized during the [Getting Started](https://moveit.picknik.ai/main/doc/tutorials/getting_started/getting_started.html) tutorial of MoveIt2 documentation.

## Changes Made

- Replaced `plan_components` with `plan_components_`
- Replaced `description` with `description_`
- Replaced `trajectory` with `trajectory_`
- Replaced `controller_name` with `controller_names_`
