### PR TITLE
Add function to Introspection class to retrieve all solutions

### DIFF
--- a/core/include/moveit/task_constructor/introspection.h
+++ b/core/include/moveit/task_constructor/introspection.h
@@ -80,6 +80,10 @@ public:
 	/// fill task state message for publishing the current task state
 	moveit_task_constructor_msgs::msg::TaskStatistics&
 	fillTaskStatistics(moveit_task_constructor_msgs::msg::TaskStatistics& msg);
+
+	/// Function to get a map between solution id and solutions.
+	std::map<uint32_t, moveit_task_constructor_msgs::msg::Solution> getAllSolutions();
+
 	/// publish the current state of task
 	void publishTaskState();
 


### PR DESCRIPTION
Currently, the way to retrieve solutions is to use the `get_solution` service, where you can send one solution ID as a request and get the corresponding solution.

In this PR, I have added a function to get the entire solution ID and solution map.
This would be useful for another introspection tool we are building at PickNik.