### PR TITLE
avoid mapping memory and comparing joints with zero variables

### DIFF
--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -123,6 +123,9 @@ bool Connect::compatible(const InterfaceState& from_state, const InterfaceState&
 			continue;  // ignore joints we plan for
 
 		const unsigned int num = jm->getVariableCount();
+		if (num == 0)
+			continue;  // The joint model doesn't have any variables (e.g. fixed).
+
 		Eigen::Map<const Eigen::VectorXd> positions_from(from.getJointPositions(jm), num);
 		Eigen::Map<const Eigen::VectorXd> positions_to(to.getJointPositions(jm), num);
 		if (!(positions_from - positions_to).isZero(1e-4)) {


### PR DESCRIPTION
Calling `getJointPositions()` on a joint model with zero variables is buggy on the MoveIt side. It will return a meaningless value most of the time, but can access out of bounds memory in some edge cases (fixed joints at the end of a robot model).
This had been okay until now because `RobotState` had big chunk of memory accessed via raw pointers, so out of bounds memory access was silently happening. `RobotState` now uses `std::vector` internally for data allocation, which means that any out-of-bounds access will now trigger an exception.
We should fix the `getJointPositions()` (and others) behavior in MoveIt (follow up PR), but this change won't hurt anyway because there is no need to Eigen::Map and compare zero-sized memory.
