### PR TITLE
End-state deviates from goal state

### DIFF
--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -65,6 +65,9 @@ class Connect : public Connecting
 {
 protected:
 	bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const override;
+	bool validateEndTrajectoryDeviation(const moveit::core::JointModelGroup* jmg,
+	                                    const robot_trajectory::RobotTrajectoryPtr trajectory,
+	                                    const moveit::core::RobotState& goal_state, std::string& comment);
 
 public:
 	enum MergeMode

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -67,7 +67,8 @@ protected:
 	bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const override;
 	bool validateEndTrajectoryDeviation(const moveit::core::JointModelGroup* jmg,
 	                                    const robot_trajectory::RobotTrajectoryPtr trajectory,
-	                                    const moveit::core::RobotState& goal_state, std::string& comment);
+	                                    const moveit::core::RobotState& goal_state, double max_joint_deviation,
+	                                    std::string& comment);
 
 public:
 	enum MergeMode
@@ -79,6 +80,7 @@ public:
 	using GroupPlannerVector = std::vector<std::pair<std::string, solvers::PlannerInterfacePtr> >;
 	Connect(const std::string& name = "connect", const GroupPlannerVector& planners = {});
 
+	void setMaxJointDeviation(double max_joint_deviation) { setProperty("max_joint_deviation", max_joint_deviation); }
 	void setPathConstraints(moveit_msgs::Constraints path_constraints) {
 		setProperty("path_constraints", std::move(path_constraints));
 	}

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -65,10 +65,6 @@ class Connect : public Connecting
 {
 protected:
 	bool compatible(const InterfaceState& from_state, const InterfaceState& to_state) const override;
-	bool validateEndTrajectoryDeviation(const moveit::core::JointModelGroup* jmg,
-	                                    const robot_trajectory::RobotTrajectoryPtr trajectory,
-	                                    const moveit::core::RobotState& goal_state, double max_joint_deviation,
-	                                    std::string& comment);
 
 public:
 	enum MergeMode
@@ -80,7 +76,7 @@ public:
 	using GroupPlannerVector = std::vector<std::pair<std::string, solvers::PlannerInterfacePtr> >;
 	Connect(const std::string& name = "connect", const GroupPlannerVector& planners = {});
 
-	void setMaxJointDeviation(double max_joint_deviation) { setProperty("max_joint_deviation", max_joint_deviation); }
+	void setMaxDistance(double max_distance) { setProperty("max_distance", max_distance); }
 	void setPathConstraints(moveit_msgs::Constraints path_constraints) {
 		setProperty("path_constraints", std::move(path_constraints));
 	}

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -182,8 +182,13 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 				Eigen::Map<const Eigen::VectorXd> positions_last_waypoint(
 				    trajectory->getWayPoint(waypoint_count - 1).getJointPositions(jm), num);
 
+				double min_distance;
 				for (std::size_t i = 0; i < num; ++i) {
-					double min_distance = angles::shortest_angular_distance(positions_last_waypoint[i], positions_goal[i]);
+					if (jm->getType() == robot_state::JointModel::REVOLUTE)
+						min_distance = angles::shortest_angular_distance(positions_last_waypoint[i], positions_goal[i]);
+					else
+						min_distance = positions_last_waypoint[i], positions_goal[i];
+
 					ROS_DEBUG_STREAM_NAMED(
 					    "Connect", "angular deviation: " << min_distance << " between trajectory last waypoint and goal.");
 

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -134,6 +134,51 @@ bool Connect::compatible(const InterfaceState& from_state, const InterfaceState&
 	return true;
 }
 
+bool Connect::validateEndTrajectoryDeviation(const moveit::core::JointModelGroup* jmg,
+                                             const robot_trajectory::RobotTrajectoryPtr trajectory,
+                                             const moveit::core::RobotState& goal_state, std::string& comment) {
+	const std::size_t waypoint_count = trajectory->getWayPointCount();
+
+	if (!waypoint_count) {
+		comment = "Cannot validate end trajectory deviation with an empty trajectory";
+		return false;
+	}
+
+	for (const moveit::core::JointModel* jm : jmg->getJointModels()) {
+		const unsigned int num = jm->getVariableCount();
+
+		if (!num)
+			continue;
+
+		Eigen::Map<const Eigen::VectorXd> positions_goal(goal_state.getJointPositions(jm), num);
+		Eigen::Map<const Eigen::VectorXd> positions_last_waypoint(
+		    trajectory->getWayPoint(waypoint_count - 1).getJointPositions(jm), num);
+
+		double min_distance;
+		for (std::size_t i = 0; i < num; ++i) {
+			if (jm->getType() == robot_state::JointModel::REVOLUTE)
+				min_distance = angles::shortest_angular_distance(positions_last_waypoint[i], positions_goal[i]);
+			else
+				min_distance = positions_last_waypoint[i], positions_goal[i];
+
+			ROS_DEBUG_STREAM_NAMED("Connect",
+			                       "angular deviation: " << min_distance << " between trajectory last waypoint and goal.");
+
+			if (std::abs(min_distance) > 1e-4) {
+				std::stringstream ss;
+				ss << "Deviation in joint " << jm->getName() << ": [" << positions_last_waypoint.transpose() << "] != ["
+				   << positions_goal.transpose() << "]";
+				comment = ss.str();
+				ROS_ERROR_STREAM_NAMED("Connect", comment);
+
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 	const auto& props = properties();
 	double timeout = this->timeout();
@@ -148,8 +193,7 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 	intermediate_scenes.push_back(start);
 
 	bool success = false;
-	bool deviation = false;
-	std::stringstream deviation_comment;
+	std::string deviation_comment;
 	std::vector<double> positions;
 	for (const GroupPlannerVector::value_type& pair : planner_) {
 		// set intermediate goal state
@@ -168,48 +212,10 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 		if (!success)
 			break;
 
-		// validate position deviation from trajectory last waypoint to goal
-		const std::size_t waypoint_count = trajectory->getWayPointCount();
+		// validate position deviation: trajectory last waypoint to goal
+		success = validateEndTrajectoryDeviation(jmg, trajectory, goal_state, deviation_comment);
 
-		if (waypoint_count) {
-			for (const moveit::core::JointModel* jm : jmg->getJointModels()) {
-				const unsigned int num = jm->getVariableCount();
-
-				if (!num)
-					continue;
-
-				Eigen::Map<const Eigen::VectorXd> positions_goal(goal_state.getJointPositions(jm), num);
-				Eigen::Map<const Eigen::VectorXd> positions_last_waypoint(
-				    trajectory->getWayPoint(waypoint_count - 1).getJointPositions(jm), num);
-
-				double min_distance;
-				for (std::size_t i = 0; i < num; ++i) {
-					if (jm->getType() == robot_state::JointModel::REVOLUTE)
-						min_distance = angles::shortest_angular_distance(positions_last_waypoint[i], positions_goal[i]);
-					else
-						min_distance = positions_last_waypoint[i], positions_goal[i];
-
-					ROS_DEBUG_STREAM_NAMED(
-					    "Connect", "angular deviation: " << min_distance << " between trajectory last waypoint and goal.");
-
-					if (std::abs(min_distance) > 1e-4) {
-						deviation_comment << "Deviation in joint " << jm->getName() << ": ["
-						                  << positions_last_waypoint.transpose() << "] != [" << positions_goal.transpose()
-						                  << "]";
-						ROS_ERROR_STREAM_NAMED("Connect", deviation_comment.str());
-
-						deviation = true;
-						success = false;
-						break;
-					}
-				}
-
-				if (deviation)
-					break;
-			}
-		}
-
-		if (deviation)
+		if (!success)
 			break;
 
 		// continue from reached state
@@ -223,8 +229,8 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 		solution = makeSequential(sub_trajectories, intermediate_scenes, from, to);
 	if (!success)  // error during sequential planning
 		solution->markAsFailure();
-	if (deviation)  // deviation error
-		solution->setComment(deviation_comment.str());
+	if (!deviation_comment.empty())  // deviation error
+		solution->setComment(deviation_comment);
 	connect(from, to, solution);
 }
 

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -159,7 +159,7 @@ bool Connect::validateEndTrajectoryDeviation(const moveit::core::JointModelGroup
 			if (jm->getType() == robot_state::JointModel::REVOLUTE)
 				min_distance = angles::shortest_angular_distance(positions_last_waypoint[i], positions_goal[i]);
 			else
-				min_distance = positions_last_waypoint[i], positions_goal[i];
+				min_distance = positions_last_waypoint[i] - positions_goal[i];
 
 			ROS_DEBUG_STREAM_NAMED("Connect",
 			                       "angular deviation: " << min_distance << " between trajectory last waypoint and goal.");


### PR DESCRIPTION
This fixes #531 but may not fix the actual problem, e.g. it may be the planner that silently fails or something else in the framework.

I just validate the last trajectory waypoint with the goal in the `ConnectStage`. If there is a deviation, the solution is marked as failed and a comment is set. I'm pretty sure you can optimize some of the code ;)

---

On a side note, I had to make sure that the joints where compared correctly (-pi = pi). Currently, when comparing joint position in the [Connect::compatible](https://github.com/ros-planning/moveit_task_constructor/blob/master/core/src/stages/connect.cpp#L124-L125) method, this is not checked. You might reject some valid solutions, e.g the IK solver gives some joint positions in a negative defined angle versus the RobotState who may have a positive defined angle.

Solution 1 et 3 are valid but not 2 and 4.

![image](https://github.com/ros-planning/moveit_task_constructor/assets/32679594/2104c5df-add5-4c1e-88db-43b62f44f14c)
