### PR TITLE
Set independant start and end states in a Generator stage

### DIFF
--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -365,6 +365,7 @@ public:
 
 	virtual bool canCompute() const = 0;
 	virtual void compute() = 0;
+	void spawn(InterfaceState&& from, InterfaceState&& to, SubTrajectory&& trajectory);
 	void spawn(InterfaceState&& state, SubTrajectory&& trajectory);
 	void spawn(InterfaceState&& state, double cost) {
 		SubTrajectory trajectory;

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -136,6 +136,7 @@ public:
 	void sendBackward(InterfaceState&& from, const InterfaceState& to, const SolutionBasePtr& solution);
 	template <Interface::Direction>
 	inline void send(const InterfaceState& start, InterfaceState&& end, const SolutionBasePtr& solution);
+	void spawn(InterfaceState&& from, InterfaceState&& to, const SolutionBasePtr& solution);
 	void spawn(InterfaceState&& state, const SolutionBasePtr& solution);
 	void connect(const InterfaceState& from, const InterfaceState& to, const SolutionBasePtr& solution);
 


### PR DESCRIPTION
Releated to https://github.com/ros-planning/moveit_task_constructor/issues/543. This PR enables the possibility to set independent start and end states when calling the `spawn` method of a Generator stage, while maintaining the previous functionality that uses the same state.

I didn't implement [this overload](https://github.com/ros-planning/moveit_task_constructor/blob/e1b891ba5a346eae14454b3c23f74052d9ada23e/core/include/moveit/task_constructor/stage.h#L369C2-L373C3) as it implies that the trajectory will be empty and it makes no sense to set different start and end states when the robot is not actually moving, right? Or am I missing any specific use case where this could be handy?

I noticed that [`connect`](https://github.com/ros-planning/moveit_task_constructor/blob/e1b891ba5a346eae14454b3c23f74052d9ada23e/core/include/moveit/task_constructor/stage.h#L418) uses const lvalue reference (`const InterfaceState&`) instead of rvalue (`InterfaceState&&`). Are there any design preferences?

Is there an easy way to backport this to humble branch or I should cherry-pick another PR?