### PR TITLE
ignore Debian-specific error around urdfdom_headers

### DIFF
--- a/rviz_marker_tools/CMakeLists.txt
+++ b/rviz_marker_tools/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(Eigen3 REQUIRED)
 
+# lint ignore is needed to support ROS distributions which also define urdfdom_headers in rosdep (e.g., Debian ROS packages)
+#catkin_lint: ignore missing_depend[pkg=urdfdom_headers]
 find_package(urdfdom_headers REQUIRED)
 
 catkin_package(


### PR DESCRIPTION
Without the patch I see this building with the Debian ROS packages:

    $ catkin_lint rviz_marker_tools/
    rviz_marker_tools: package.xml: error: missing build_depend on 'urdfdom_headers'

Backstory for the error in catkin_lint: [The python3-rosdep package defines this key](https://salsa.debian.org/science-team/ros-rosdep/-/blob/master/debian/debian.yaml?ref_type=heads#L914-916) although ROS does not do that from indigo to noetic anymore. However, [ROS2 has a package - and thus a rosdep key - with that name again](https://github.com/ros/rosdistro/blob/a650aa03ce1a431f047c71dc105504961663abcd/ardent/distribution.yaml#L864-L874). So dropping the key entry from the Debian package is no real option assuming eventual support for ros2, but I also do not see another nice way for `catkin_lint` to support this check better. Thus, I discussed with @jspricke and we decided it might be best to nolint the error here.

Note that this prevents simple commits as catkin_lint without errors is a hard prerequisite for [our `pre-commit rules`](https://github.com/moveit/moveit_task_constructor/blob/99ccc115e041c5e80b8e653815a62936c3d392ec/.pre-commit-config.yaml#L46-L52) and I would like to keep it that way.

@roehling It seems `catkin_lint` does not support `ignore_once missing_depend`, which is why I had to disable the warning for the whole package. I seem to recall some issue about just this years ago, but I cannot find anything related. If relevant, I can also create an upstream issue of course.