### PR TITLE
Add ability to preempt the task when a stage fails (preempt_on_failure)

### DIFF
--- a/core/include/moveit/task_constructor/stage.h
+++ b/core/include/moveit/task_constructor/stage.h
@@ -211,6 +211,11 @@ public:
 		return properties().get<TrajectoryExecutionInfo>("trajectory_execution_info");
 	}
 
+	/// If true, a failure of this stage will cause immediate preemption of the task
+	void setPreemptOnFailure(bool preempt_on_failure) { setProperty("preempt_on_failure", preempt_on_failure); }
+	/// Get whether this stage is configured to preempt the task on failure
+	bool preemptOnFailure() const { return properties().get<bool>("preempt_on_failure"); }
+
 	/// forwarding of properties between interface states
 	void forwardProperties(const InterfaceState& source, InterfaceState& dest);
 	std::set<std::string> forwardedProperties() const {
@@ -256,6 +261,9 @@ public:
 	[[noreturn]] void reportPropertyError(const Property::error& e);
 
 	double getTotalComputeTime() const;
+
+	/// Request preemption of task execution
+	void requestPreemption();
 
 protected:
 	/// Stage can only be instantiated through derived classes

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -313,7 +313,8 @@ Stage::Stage(StagePrivate* impl) : pimpl_(impl) {
 	p.declare<std::string>("marker_ns", name(), "marker namespace");
 	p.declare<TrajectoryExecutionInfo>("trajectory_execution_info", TrajectoryExecutionInfo(),
 	                                   "settings used when executing the trajectory");
-
+	p.declare<bool>("preempt_on_failure", false,
+	                "if true, a failure of this stage will cause immediate preemption of the task");
 	p.declare<std::set<std::string>>("forwarded_properties", std::set<std::string>(),
 	                                 "set of interface properties to forward");
 }
@@ -446,6 +447,12 @@ void Stage::setProperty(const std::string& name, const boost::any& value) {
 
 double Stage::getTotalComputeTime() const {
 	return pimpl()->total_compute_time_.count();
+}
+
+void Stage::requestPreemption() {
+	if (pimpl()->preempt_requested_ != nullptr) {
+		const_cast<std::atomic<bool>*>(pimpl()->preempt_requested_)->store(true);
+	}
 }
 
 void StagePrivate::composePropertyErrorMsg(const std::string& property_name, std::ostream& os) {


### PR DESCRIPTION
In our tasks, we make extensive use of the `PredicateFilter` stage to perform certain checks in the scene before other stages are executed. This stage is expected to always succeed for the task to proceed. However, the task currently continues planning and looks for alternative solutions in earlier stages, which unnecessarily prolongs planning time—even though we already know that if this stage fails, the task is not feasible and there is no reason to continue.

With this in mind, we propose adding a `preempt_on_failure` property. If set to true, the stage must always succeed; if the stage fails even once, the task is immediately preempted and planning aborts.

We can currently do something similar using `addSolutionCallback` and throwing an exception when any solution fails, but this does not update introspection correctly.

Thoughts, @rhaschke?