### PR TITLE
Support for optimising IK solvers. Use minimum of the remaining stage timeout and configured IK solver timeout

### DIFF
--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -413,7 +413,8 @@ void ComputeIK::compute() {
 		tried_current_state_as_seed = true;
 
 		size_t previous = ik_solutions.size();
-		bool succeeded = sandbox_state.setFromIK(jmg, target_pose, link->getName(), remaining_time, is_valid);
+		auto iteration_timeout = std::min(remaining_time, jmg->getDefaultIKTimeout());
+		bool succeeded = sandbox_state.setFromIK(jmg, target_pose, link->getName(), iteration_timeout, is_valid);
 
 		auto now = std::chrono::steady_clock::now();
 		remaining_time -= std::chrono::duration<double>(now - start_time).count();


### PR DESCRIPTION
This change is to support using optimising IK solvers such as TRAC-IK distance solver in compute_ik stages.

The previous behaviour was to use the remaining stage timeout as the timeout for the individual call to the IK solver. In the case of optimising IK solvers, which use the entire provided timeout to find the best solution, this would mean that only one IK solution would be generated. 

For example with TRAC-IK distance solver configured to use a 5ms timeout and the stage timeout set to 1s, the full 1s was actually used for a single solution generation.

This change uses the minimum of the configured timeout on the IK solver, or the remaining stage time left. Thus meaning that the above scenario will make multiple 5ms calls to the TRAC-IK solver until the total 1s stage timeout is reached.