### PR TITLE
[ros-o] rely on post-noetic pybind11_catkin

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 	roscpp
 	visualization_msgs
 	rviz_marker_tools
+	pybind11_catkin
 	py_binding_tools
 )
 

--- a/core/package.xml
+++ b/core/package.xml
@@ -17,6 +17,7 @@
 
 	<build_depend>roscpp</build_depend>
 	<build_depend>roslint</build_depend>
+	<build_depend>pybind11_catkin</build_depend>
 	<exec_depend>roscpp</exec_depend>
 
 	<depend>fmt</depend>

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -1,7 +1,3 @@
-# pybind11 must use the ROS python version
-set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
-find_package(pybind11 3.0 REQUIRED)
-
 # C++ wrapper code
 add_subdirectory(bindings)
 

--- a/core/python/bindings/CMakeLists.txt
+++ b/core/python/bindings/CMakeLists.txt
@@ -11,7 +11,7 @@ target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC pybind11::opt_size)
 #catkin_lint: ignore undefined_target
 
 # moveit.task_constructor
-pybind11_add_module(pymoveit_mtc
+pybind_add_module(pymoveit_mtc
 	src/solvers.cpp
 	src/core.cpp
 	src/stages.cpp


### PR DESCRIPTION
ros-o's pybind11_catkin bundles a sufficient pybind11 and ensures `python_add_library` is available also with the ros-o transition to `find_package(Python COMPONENTS Interpreter)` in catkin, which does not provide it by default anymore.