### PR TITLE
Consider pruning property in Connect stage

### DIFF
--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -1029,6 +1029,11 @@ bool FallbacksPrivatePropagator::nextJob() {
 	}
 
 	// When arriving here, we have a valid job_ and a current_ child to feed it. Let's do that.
+	if (dir_ == Interface::FORWARD)
+		setStatus<Interface::BACKWARD>(nullptr, nullptr, &*job_, InterfaceState::Status::ENABLED);
+	else
+		setStatus<Interface::FORWARD>(nullptr, nullptr, &*job_, InterfaceState::Status::ENABLED);
+
 	copyState(dir_, job_, (*current_)->pimpl()->pullInterface(dir_), Interface::UpdateFlags());
 	return true;
 }

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -327,7 +327,7 @@ void ContainerBasePrivate::liftSolution(const SolutionBasePtr& solution, const I
 
 ContainerBase::ContainerBase(ContainerBasePrivate* impl) : Stage(impl) {
 	auto& p = properties();
-	p.declare<bool>("pruning", std::string("enable pruning?")).configureInitFrom(Stage::PARENT, "pruning");
+	p.declare<bool>("pruning", false, std::string("enable pruning?")).configureInitFrom(Stage::PARENT, "pruning");
 }
 
 size_t ContainerBase::numChildren() const {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -820,7 +820,7 @@ void ConnectingPrivate::newState(Interface::iterator it, Interface::UpdateFlags 
 		for (Interface::iterator oit : oit_to_enable)
 			parent_pimpl->setStatus<opposite<dir>()>(me(), &*it, &*oit, InterfaceState::Status::ENABLED);
 
-		if (!have_enabled_opposites)  // prune new state and associated branch if necessary
+		if (!have_enabled_opposites && parent()->pruning())  // prune new state and associated branch if necessary
 			// pass creator=nullptr to skip hasPendingOpposites() check as we did this here already
 			parent_pimpl->setStatus<dir>(nullptr, nullptr, &*it, InterfaceState::Status::ARMED);
 	}

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -94,7 +94,6 @@ const ContainerBase* TaskPrivate::stages() const {
 
 Task::Task(const std::string& ns, bool introspection, ContainerBase::pointer&& container)
   : WrapperBase(new TaskPrivate(this, ns), std::move(container)) {
-	setPruning(false);
 	setTimeout(std::numeric_limits<double>::max());
 
 	// monitor state on commandline

--- a/core/test/test_fallback.cpp
+++ b/core/test/test_fallback.cpp
@@ -195,3 +195,19 @@ TEST_F(FallbacksFixtureConnect, connectStageInsideFallbacks) {
 	EXPECT_TRUE(t.plan());
 	EXPECT_COSTS(t.solutions(), testing::ElementsAre(11, 12, 22, 121));
 }
+
+TEST_F(FallbacksFixtureConnect, connectInsideSerialInsideFallbacks) {
+	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts({ 0.0 })));
+	auto fallbacks = std::make_unique<Fallbacks>("Fallbacks");
+	auto serial = std::make_unique<SerialContainer>("Serial1");
+	serial->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(0.0)));
+	serial->add(std::make_unique<ConnectMockup>(PredefinedCosts::constant(1.0)));
+	serial->add(std::make_unique<BackwardMockup>(PredefinedCosts::constant(INF)));
+	serial->add(std::make_unique<GeneratorMockup>(PredefinedCosts::single(2.0)));
+	fallbacks->add(std::move(serial));
+	fallbacks->add(std::make_unique<ForwardMockup>(PredefinedCosts::constant(4.0)));
+
+	t.add(std::move(fallbacks));
+	EXPECT_TRUE(t.plan());
+	EXPECT_COSTS(t.solutions(), testing::ElementsAre(4.0));
+}


### PR DESCRIPTION
Even if pruning was disabled, pruning could sneak in via the Connect stage.
For now fixes #737.

For me, the added unit test failed with an assertion failure, because the state copied from the Fallback to the next child was `PRUNED` and not `ENABLED`:
https://github.com/moveit/moveit_task_constructor/blob/82a1156ea4518ec0021432d24b0b39826b322700/core/src/storage.cpp#L125