### PR TITLE
LimitSolutions: prevent child compute calls after max_solutions is reached

### DIFF
--- a/core/src/stages/limit_solutions.cpp
+++ b/core/src/stages/limit_solutions.cpp
@@ -73,10 +73,10 @@ void LimitSolutions::compute() {
 	if (forwarded_solutions >= max_solutions)
 		return;
 
-	if (forwarded_solutions < max_solutions && WrapperBase::canCompute())
+	if (WrapperBase::canCompute())
 		WrapperBase::compute();
 
-	if (!upstream_solutions_.empty() && forwarded_solutions < max_solutions) {
+	if (!upstream_solutions_.empty()) {
 		++forwarded_solutions;
 		liftSolution(*upstream_solutions_.pop());
 	}

--- a/core/src/stages/limit_solutions.cpp
+++ b/core/src/stages/limit_solutions.cpp
@@ -54,24 +54,32 @@ void LimitSolutions::reset() {
 }
 
 void LimitSolutions::onNewSolution(const SolutionBase& s) {
-	uint32_t max_solutions = properties().get<uint32_t>("max_solutions");
+	const uint32_t max_solutions = properties().get<uint32_t>("max_solutions");
+
 	if (forwarded_solutions + upstream_solutions_.size() < max_solutions)
 		upstream_solutions_.push(&s);
 }
 
 bool LimitSolutions::canCompute() const {
-	return !upstream_solutions_.empty() || WrapperBase::canCompute();
+	const uint32_t max_solutions = properties().get<uint32_t>("max_solutions");
+
+	return !upstream_solutions_.empty() || (forwarded_solutions < max_solutions && WrapperBase::canCompute());
 }
 
 void LimitSolutions::compute() {
-	if (WrapperBase::canCompute())
-		WrapperBase::compute();
+	const uint32_t max_solutions = properties().get<uint32_t>("max_solutions");
 
-	if (upstream_solutions_.empty())
+	// once the limit is reached do not call compute on the child anymore
+	if (forwarded_solutions >= max_solutions)
 		return;
 
-	++forwarded_solutions;
-	liftSolution(*upstream_solutions_.pop());
+	if (forwarded_solutions < max_solutions && WrapperBase::canCompute())
+		WrapperBase::compute();
+
+	if (!upstream_solutions_.empty() && forwarded_solutions < max_solutions) {
+		++forwarded_solutions;
+		liftSolution(*upstream_solutions_.pop());
+	}
 }
 }  // namespace stages
 }  // namespace task_constructor

--- a/core/test/test_limit_solutions.cpp
+++ b/core/test/test_limit_solutions.cpp
@@ -37,3 +37,19 @@ TEST_F(LimitSolutionsTest, returnsBestSolutions) {
 	EXPECT_EQ(t.solutions().size(), 3u);  // only 3 solutions should have been generated
 	EXPECT_EQ(t.solutions().front()->cost(), 2.0);  // solution with cost 1.0 was not considered anymore
 }
+
+// ensure that the child stage is not called again after max_solutions has been reached
+TEST_F(LimitSolutionsTest, childNotCalledAfterLimitReached) {
+	auto g = std::make_unique<GeneratorMockup>(PredefinedCosts({ 4.0, 2.0, 3.0, 1.0 }), 1);
+	auto* g_ptr = g.get();
+
+	auto ls = std::make_unique<stages::LimitSolutions>("LimitSolutions", std::move(g));
+	ls->setMaxSolutions(1);
+
+	auto delayed = std::make_unique<DelayingWrapper>(std::list<unsigned int>{ 0, 0, 1, 1, 1 }, std::move(ls));
+	t.add(std::move(delayed));
+
+	EXPECT_TRUE(t.plan());
+	EXPECT_EQ(t.solutions().size(), 1u);
+	EXPECT_EQ(g_ptr->runs_, 1u);  // generator (child) should run only once
+}


### PR DESCRIPTION
Currently, when `max_solutions` is reached, the child may still continue computing additional solutions. This was not an issue with a simple `Generator` stage, but with a large `SerialContainer` with multiple nested stages, the computational cost becomes significant.

Moreover, these additional solutions are not propagated, since the limit for forwarding solutions has already been reached. Thus, this extra computation is wasted.

With the change proposed in this PR, once the limit of forwarded solutions (`max_solutions`) is reached, the child container will stop generating further solutions.

For future reference, as discussed [here](https://github.com/moveit/moveit_task_constructor/issues/728#issuecomment-3612165496), a better approach might be to relax the `max_solutions` restriction and allow incremental forwarding of solutions, before the task fails. While limiting solutions helps reduce combinatorial explosion in long tasks, it also risks missing valid alternatives. @rhaschke Do you see a simple way—without major refactoring—to achieve this using the current wrapper implementation?