### PR TITLE
Fix `DisplaySolution::fillMessage()` drops `info` and `execution_info` from SubTrajectory messages

### DIFF
--- a/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
@@ -83,8 +83,6 @@ class DisplaySolution
 		std::string comment_;
 		/// id of creating stage
 		uint32_t creator_id_;
-		/// solution info (stage_id, markers, etc.)
-		moveit_task_constructor_msgs::msg::SolutionInfo info_;
 		/// trajectory execution info (controller_names, etc.)
 		moveit_task_constructor_msgs::msg::TrajectoryExecutionInfo execution_info_;
 		/// rviz markers

--- a/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
+++ b/visualization/visualization_tools/include/moveit/visualization_tools/display_solution.h
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <moveit_task_constructor_msgs/msg/solution.hpp>
+#include <moveit_task_constructor_msgs/msg/trajectory_execution_info.hpp>
 #include <moveit/macros/class_forward.hpp>
 
 namespace moveit {
@@ -82,6 +83,10 @@ class DisplaySolution
 		std::string comment_;
 		/// id of creating stage
 		uint32_t creator_id_;
+		/// solution info (stage_id, markers, etc.)
+		moveit_task_constructor_msgs::msg::SolutionInfo info_;
+		/// trajectory execution info (controller_names, etc.)
+		moveit_task_constructor_msgs::msg::TrajectoryExecutionInfo execution_info_;
 		/// rviz markers
 		MarkerVisualizationPtr markers_;
 	};

--- a/visualization/visualization_tools/src/display_solution.cpp
+++ b/visualization/visualization_tools/src/display_solution.cpp
@@ -112,6 +112,8 @@ void DisplaySolution::setFromMessage(const planning_scene::PlanningScenePtr& sta
 		                        sub.trajectory.multi_dof_joint_trajectory.joint_names.end());
 		data_[i].comment_ = sub.info.comment;
 		data_[i].creator_id_ = sub.info.stage_id;
+		data_[i].info_ = sub.info;
+		data_[i].execution_info_ = sub.execution_info;
 		steps_ += data_[i].trajectory_->getWayPointCount();
 
 		ref_scene->setPlanningSceneDiffMsg(sub.scene_diff);
@@ -133,6 +135,8 @@ void DisplaySolution::fillMessage(moveit_task_constructor_msgs::msg::Solution& m
 	msg.sub_trajectory.resize(data_.size());
 	auto traj_it = msg.sub_trajectory.begin();
 	for (const auto& sub : data_) {
+		traj_it->info = sub.info_;
+		traj_it->execution_info = sub.execution_info_;
 		sub.scene_->getPlanningSceneDiffMsg(traj_it->scene_diff);
 		sub.trajectory_->getRobotTrajectoryMsg(traj_it->trajectory, sub.joints_);
 		++traj_it;

--- a/visualization/visualization_tools/src/display_solution.cpp
+++ b/visualization/visualization_tools/src/display_solution.cpp
@@ -112,7 +112,6 @@ void DisplaySolution::setFromMessage(const planning_scene::PlanningScenePtr& sta
 		                        sub.trajectory.multi_dof_joint_trajectory.joint_names.end());
 		data_[i].comment_ = sub.info.comment;
 		data_[i].creator_id_ = sub.info.stage_id;
-		data_[i].info_ = sub.info;
 		data_[i].execution_info_ = sub.execution_info;
 		steps_ += data_[i].trajectory_->getWayPointCount();
 
@@ -135,7 +134,6 @@ void DisplaySolution::fillMessage(moveit_task_constructor_msgs::msg::Solution& m
 	msg.sub_trajectory.resize(data_.size());
 	auto traj_it = msg.sub_trajectory.begin();
 	for (const auto& sub : data_) {
-		traj_it->info = sub.info_;
 		traj_it->execution_info = sub.execution_info_;
 		sub.scene_->getPlanningSceneDiffMsg(traj_it->scene_diff);
 		sub.trajectory_->getRobotTrajectoryMsg(traj_it->trajectory, sub.joints_);


### PR DESCRIPTION
When clicking the "Execute solution" button on the Motion Planning Tasks panel, the action goal sent to the `execute_task_solution` action server was missing the `SolutionInfo` and `TrajectoryExecutionInfo` fields in every `SubTrajectory`.

The internal `DisplaySolution::Data` struct had no info_ or execution_info_ fields. Consequently, `DisplaySolutionfillMessage()` had nothing to write back for `SubTrajectory::info` and `SubTrajectory::execution_info`, so they were always sent as empty values.

Any action server that relies on `execution_info.controller_names` or other `SolutionInfo` fields like `markers`, `planner_id`, `cost`, `id` would receive empty data. I happened to hit this because my action server uses `execution_info`, and I triggered it through the panel button.