### PR TITLE
ci: cover kilted and lyrical, and add a real Resolute rolling job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,22 +34,35 @@ jobs:
               -e LSAN_OPTIONS="suppressions=$PWD/.github/workflows/lsan.suppressions,fast_unwind_on_malloc=0"
               -e ASAN_OPTIONS="new_delete_type_mismatch=0,alloc_dealloc_mismatch=0"
             TARGET_CMAKE_ARGS: -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1 -g"
+          - ROS_DISTRO: kilted
+            ROS_REPO: main
+          # moveit_core has no Resolute deb yet, so these two cannot pass until
+          # moveit2 is released for Resolute. Keep them non-blocking until then;
+          # they are the only jobs here that exercise Resolute at all.
+          - ROS_DISTRO: lyrical
+            ROS_REPO: main
+            OS_CODE_NAME: resolute
+            NONBLOCKING: true
+          - ROS_DISTRO: rolling
+            ROS_REPO: testing
+            OS_CODE_NAME: resolute
+            NONBLOCKING: true
 
     env:
       CLANG_TIDY_ARGS: -quiet -export-fixes ${{ github.workspace }}/.work/clang-tidy-fixes.yaml
-      DOCKER_IMAGE: moveit/moveit2:${{ matrix.env.IMAGE }}
       UNDERLAY: ${{ endsWith(matrix.env.IMAGE, '-source') && '/root/ws_moveit/install' || ''}}
       TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work
-      CACHE_PREFIX: "${{ matrix.env.IMAGE }}${{ contains(matrix.env.TARGET_CMAKE_ARGS, '--coverage') && '-ccov' || '' }}"
+      CACHE_PREFIX: "${{ matrix.env.IMAGE || format('{0}-{1}', matrix.env.ROS_DISTRO, matrix.env.ROS_REPO) }}${{ contains(matrix.env.TARGET_CMAKE_ARGS, '--coverage') && '-ccov' || '' }}"
       # perform full clang-tidy check only on manual trigger (workflow_dispatch), PRs do check changed files, otherwise nothing
       CLANG_TIDY_BASE_REF: ${{ github.event_name != 'workflow_dispatch' && (github.base_ref || github.ref) || '' }}
       CC: ${{ matrix.env.CLANG_TIDY && 'clang' }}
       CXX: ${{ matrix.env.CLANG_TIDY && 'clang++ -std=c++17' }}
 
-    name: "${{ matrix.env.IMAGE }}${{ matrix.env.NAME && ' • ' || ''}}${{ matrix.env.NAME }}${{ matrix.env.CLANG_TIDY && ' • clang-tidy' || '' }}"
+    name: "${{ matrix.env.IMAGE || format('{0}-{1}', matrix.env.ROS_DISTRO, matrix.env.ROS_REPO) }}${{ matrix.env.NAME && ' • ' || ''}}${{ matrix.env.NAME }}${{ matrix.env.CLANG_TIDY && ' • clang-tidy' || '' }}"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.env.NONBLOCKING || false }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -65,6 +78,12 @@ jobs:
             ccache-${{ env.CACHE_PREFIX }}
         env:
           GHA_CACHE_SAVE: always
+
+      # Jobs building on a bare OS image (OS_CODE_NAME set) must leave
+      # DOCKER_IMAGE unset so industrial_ci builds the base itself.
+      - name: Set prebuilt DOCKER_IMAGE
+        if: ${{ ! matrix.env.OS_CODE_NAME }}
+        run: echo "DOCKER_IMAGE=moveit/moveit2:${{ matrix.env.IMAGE }}" >> "$GITHUB_ENV"
 
       - id: ici
         name: Run industrial_ci


### PR DESCRIPTION
## Why

The `ros2` branch is released to **four** distros but the matrix tests two:

| distro | released | tested |
|---|---|---|
| jazzy | 0.1.5-1 | ✅ `jazzy-source` |
| kilted | 0.1.5-1 | ❌ |
| lyrical | 0.1.5-3 | ❌ |
| rolling | 0.1.5-2 | ⚠️ `rolling-source` — see below |

(humble is released from its own branch, unaffected.)

### The rolling jobs don't test Resolute

With a **prebuilt image**, `ROS_DISTRO: rolling` doesn't imply Resolute — the OS comes from the image. `moveit/moveit2:rolling-source` is **Ubuntu noble, built 2026-01-24**, with MoveIt compiled inside it. Rolling moved to Resolute, so those jobs have been green while testing a distro/OS pairing that no longer ships.

They won't refresh either: moveit2's `docker.yaml` has **12 successes to 85 failures**, last success 2026-06-24 (currently a hardcoded `clang-format-14` that Resolute doesn't package).

## How

Rather than converting them, **add bare-OS jobs alongside** — the shape [moveit2's own `ci.yaml`](https://github.com/moveit/moveit2/blob/main/.github/workflows/ci.yaml) uses, where a non-blocking `rolling-resolute` job sits next to the prebuilt `rolling-ci` ones. That keeps `ccov`, `clang-tidy` and `asan` running against MoveIt `main` while giving the branch a Resolute signal it has never had.

| job | base OS | blocking |
|---|---|---|
| `jazzy-source • ccov` | noble | ✅ *(unchanged)* |
| `rolling-source • clang-tidy` | noble | ✅ *(unchanged)* |
| `rolling-source • asan` | noble | ✅ *(unchanged)* |
| `kilted-main` | noble | ✅ **new** |
| `lyrical-main` | **resolute** | ⚠️ **new**, non-blocking |
| `rolling-testing` | **resolute** | ⚠️ **new**, non-blocking |

`DOCKER_IMAGE` moves out of the static job `env:` into a step gated on `! matrix.env.OS_CODE_NAME`, since bare-OS jobs must leave it unset. `CACHE_PREFIX` and the job name fall back to `<distro>-<repo>` where `IMAGE` is absent. `UNDERLAY` already handled this correctly — it's conditional on `endsWith(matrix.env.IMAGE, '-source')`.

## ⚠️ Expect the two Resolute jobs to fail initially

```
E: Unable to locate package ros-lyrical-moveit-core
```

Only `moveit_common`, `moveit_configs_utils`, `moveit_msgs` and `moveit_resources` are published for Resolute; **`moveit_core` is not**. That blocks every downstream package there — on lyrical as well as rolling. Both jobs are non-blocking and will start passing on their own once moveit2 is released for Resolute.

This mirrors [moveit_visual_tools#157](https://github.com/moveit/moveit_visual_tools/pull/157) and [rviz_visual_tools#301](https://github.com/PickNikRobotics/rviz_visual_tools/pull/301), both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)